### PR TITLE
Tidy up tail output; output verbose error information 

### DIFF
--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using SeqCli.Config;
+using SeqCli.Output;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -43,7 +44,8 @@ namespace SeqCli.Cli.Features
         public Logger CreateOutputLogger()
         {
             var outputConfiguration = new LoggerConfiguration()
-                .MinimumLevel.Is(LevelAlias.Minimum);
+                .MinimumLevel.Is(LevelAlias.Minimum)
+                .Enrich.With<RedundantEventTypeRemovalEnricher>();
 
             if (_json)
                 outputConfiguration.WriteTo.Console(new CompactJsonFormatter());

--- a/src/SeqCli/Output/RedundantEventTypeRemovalEnricher.cs
+++ b/src/SeqCli/Output/RedundantEventTypeRemovalEnricher.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2018 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SeqCli.Output
+{
+    public class RedundantEventTypeRemovalEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            logEvent.RemovePropertyIfPresent("@i");
+        }
+    }
+}

--- a/src/SeqCli/Program.cs
+++ b/src/SeqCli/Program.cs
@@ -28,7 +28,7 @@ namespace SeqCli
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Error()
                 .WriteTo.Console(
-                    outputTemplate: "{Message:lj}{NewLine}",
+                    outputTemplate: "{Message:lj}{NewLine}{Exception}",
                     standardErrorFromLevel: LevelAlias.Minimum)
                 .CreateLogger();
             


### PR DESCRIPTION
(At least while the bugs are being shaken out; this will probably turn into a --verbose flag.)