### PR TITLE
Remove ILLink

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <!--<clear />-->
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/seqcli.sln
+++ b/seqcli.sln
@@ -11,7 +11,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sln", "sln", "{2EA56595-519
 		appveyor.yml = appveyor.yml
 		Build.ps1 = Build.ps1
 		LICENSE = LICENSE
-		nuget.config = nuget.config
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="1.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.0.1" />
     <PackageReference Include="Autofac" Version="4.0.0" />
-    <PackageReference Include="ILLink.Tasks" Version="0.1.4-preview-981901" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="Seq.Api" Version="4.2.2" />


### PR DESCRIPTION
Seeing the following in published binaries only:

```
System.Net.WebSockets.WebSocketException (0x80004005): Unable to connect to the remote server ---> System.IO.IOException: Unable to write data to the transport connection: The lazily-initialized type does not have a public, parameterless constructor.. ---> System.MissingMemberException: The lazily-initialized type does not have a public, parameterless constructor.
   at System.Threading.LazyHelpers`1.ActivatorFactorySelector()
   at System.Threading.LazyInitializer.EnsureInitializedCore[T](T& target, Func`1 valueFactory)
   at System.Net.Sockets.Socket.RentSocketAsyncEventArgs(Boolean isReceive)
   at System.Net.Sockets.Socket.SendAsync(ArraySegment`1 buffer, SocketFlags socketFlags, Boolean fromNetworkStream)
   at System.Net.Sockets.NetworkStream.WriteAsync(Byte[] buffer, Int32 offset, Int32 size, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Sockets.NetworkStream.WriteAsync(Byte[] buffer, Int32 offset, Int32 size, CancellationToken cancellationToken)
   at System.Net.WebSockets.WebSocketHandle.<ConnectAsyncCore>d__24.MoveNext()
   at System.Net.WebSockets.WebSocketHandle.<ConnectAsyncCore>d__24.MoveNext()
...
```