### PR TITLE
Ensure API key is passed via the command

### DIFF
--- a/src/SeqCli/Cli/Commands/LogCommand.cs
+++ b/src/SeqCli/Cli/Commands/LogCommand.cs
@@ -102,7 +102,13 @@ namespace SeqCli.Cli.Commands
             }
 
             var connection = _connectionFactory.Connect(_connection);
-            var result = await connection.Client.HttpClient.PostAsync(ApiConstants.IngestionEndpoint, content);
+
+            var request = new HttpRequestMessage(HttpMethod.Post, ApiConstants.IngestionEndpoint) {Content = content};
+
+            if (_connection.IsApiKeySpecified)
+                request.Headers.Add("X-Seq-ApiKey", _connection.ApiKey);
+            
+            var result = await connection.Client.HttpClient.SendAsync(request);
 
             if (result.IsSuccessStatusCode)
                 return 0;


### PR DESCRIPTION
This is normally handled by `SeqConnection`, but we're bypassing it here so we need to add the header manually.