### PR TITLE
Add support for a subcommand

### DIFF
--- a/src/SeqCli/Cli/CommandAttribute.cs
+++ b/src/SeqCli/Cli/CommandAttribute.cs
@@ -20,6 +20,7 @@ namespace SeqCli.Cli
     public class CommandAttribute : Attribute, ICommandMetadata
     {
         public string Name { get; }
+        public string SubCommand { get; }
         public string HelpText { get; }
 
         public string Example { get; set; }
@@ -28,6 +29,11 @@ namespace SeqCli.Cli
         {
             Name = name;
             HelpText = helpText;
+        }
+
+        public CommandAttribute(string name, string subCommand, string helpText) : this(name, helpText)
+        {
+            SubCommand = subCommand;
         }
     }
 }

--- a/src/SeqCli/Cli/CommandLineHost.cs
+++ b/src/SeqCli/Cli/CommandLineHost.cs
@@ -47,7 +47,7 @@ namespace SeqCli.Cli
                 }
                 else
                 {
-                    cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == norm);
+                    cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == norm && c.Metadata.SubCommand == default);
                 }
                 if (cmd != null)
                 {

--- a/src/SeqCli/Cli/CommandLineHost.cs
+++ b/src/SeqCli/Cli/CommandLineHost.cs
@@ -37,11 +37,21 @@ namespace SeqCli.Cli
 
             if (args.Length > 0)
             {
+                var amountToSkip = 1;
                 var norm = args[0].ToLowerInvariant();
-                var cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == norm);
+                Meta<Lazy<Command>, CommandMetadata> cmd; 
+                if (!args[1].Contains("-"))
+                {
+                    amountToSkip = 2;
+                    cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == norm && c.Metadata.SubCommand == args[1].ToLowerInvariant());
+                }
+                else
+                {
+                    cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == norm);
+                }
                 if (cmd != null)
                 {
-                    return await cmd.Value.Value.Invoke(args.Skip(1).ToArray());
+                    return await cmd.Value.Value.Invoke(args.Skip(amountToSkip).ToArray());
                 }
             }
 

--- a/src/SeqCli/Cli/CommandLineHost.cs
+++ b/src/SeqCli/Cli/CommandLineHost.cs
@@ -37,20 +37,12 @@ namespace SeqCli.Cli
 
             if (args.Length > 0)
             {
-                var amountToSkip = 1;
                 var norm = args[0].ToLowerInvariant();
-                Meta<Lazy<Command>, CommandMetadata> cmd; 
-                if (!args[1].Contains("-"))
-                {
-                    amountToSkip = 2;
-                    cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == norm && c.Metadata.SubCommand == args[1].ToLowerInvariant());
-                }
-                else
-                {
-                    cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == norm && c.Metadata.SubCommand == default);
-                }
+                var subCommandNorm = args.Length > 1 && !args[1].Contains("-") ? args[1].ToLowerInvariant() : default;
+                var cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == norm && c.Metadata.SubCommand == subCommandNorm);
                 if (cmd != null)
                 {
+                    var amountToSkip = subCommandNorm == default ? 1 : 2;
                     return await cmd.Value.Value.Invoke(args.Skip(amountToSkip).ToArray());
                 }
             }

--- a/src/SeqCli/Cli/CommandMetadata.cs
+++ b/src/SeqCli/Cli/CommandMetadata.cs
@@ -17,6 +17,7 @@ namespace SeqCli.Cli
     public class CommandMetadata : ICommandMetadata
     {
         public string Name { get; set; }
+        public string SubCommand { get; set; }
         public string HelpText { get; set; }
         public string Example { get; set; }
     }

--- a/src/SeqCli/Cli/ICommandMetadata.cs
+++ b/src/SeqCli/Cli/ICommandMetadata.cs
@@ -17,6 +17,7 @@ namespace SeqCli.Cli
     interface ICommandMetadata
     {
         string Name { get; }
+        string SubCommand { get; }
         string HelpText { get; }
     }
 }

--- a/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
+++ b/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autofac.Features.Metadata;
+using SeqCli.Cli;
+using SeqCli.Cli.Commands;
+using Xunit;
+
+namespace SeqCli.Tests.Cli
+{
+    public class CommandLineHostTests
+    {
+        [Fact]
+        public async Task CheckCommandLineHostPicksCorrectCommand()
+        {
+            var commandsRan = new List<string>();
+            var availableCommands = new List<Meta<Lazy<Command>, CommandMetadata>>
+            {
+                new Meta<Lazy<Command>, CommandMetadata>(
+                    new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test"))),
+                    new CommandMetadata() {Name = "test"}),
+                new Meta<Lazy<Command>, CommandMetadata>(
+                    new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test2"))),
+                    new CommandMetadata() {Name = "test2"})
+            };
+            var commandLineHost = new CommandLineHost(availableCommands);
+            await commandLineHost.Run(new []{ "test"});
+
+            Assert.Equal(commandsRan.First(), "test");
+        }
+
+        [Fact]
+        public async Task WhenCommandAndSubcommandAndTheUserRunsWithoutSubcommandEnsurePickedCorrect()
+        {
+            var commandsRan = new List<string>();
+            var availableCommands =
+                new List<Meta<Lazy<Command>, CommandMetadata>>
+                {
+                    new Meta<Lazy<Command>, CommandMetadata>(
+                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test"))),
+                        new CommandMetadata() {Name = "test"}),
+                    new Meta<Lazy<Command>, CommandMetadata>(
+                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand"))),
+                        new CommandMetadata() {Name = "test", SubCommand = "subcommand"})
+                };
+            var commandLineHost = new CommandLineHost(availableCommands);
+            await commandLineHost.Run(new[] { "test" });
+
+            Assert.Equal(commandsRan.First(), "test");
+        }
+
+        [Fact]
+        public async Task WhenCommandAndSubcommandAndTheUserRunsWithSubcommandEnsurePickedCorrect()
+        {
+            var commandsRan = new List<string>();
+            var availableCommands =
+                new List<Meta<Lazy<Command>, CommandMetadata>>
+                {
+                    new Meta<Lazy<Command>, CommandMetadata>(
+                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test"))),
+                        new CommandMetadata() {Name = "test"}),
+                    new Meta<Lazy<Command>, CommandMetadata>(
+                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand"))),
+                        new CommandMetadata() {Name = "test", SubCommand = "subcommand"})
+                };
+            var commandLineHost = new CommandLineHost(availableCommands);
+            await commandLineHost.Run(new[] { "test", "subcommand" });
+
+            Assert.Equal(commandsRan.First(), "test-subcommand");
+        }
+
+        [Fact]
+        public async Task WhenMoreThanOneSubcommandAndTheUserRunsWithSubcommandEnsurePickedCorrect()
+        {
+            var commandsRan = new List<string>();
+            var availableCommands =
+                new List<Meta<Lazy<Command>, CommandMetadata>>
+                {
+                    new Meta<Lazy<Command>, CommandMetadata>(
+                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand1"))),
+                        new CommandMetadata() {Name = "test", SubCommand = "subcommand1"}),
+                    new Meta<Lazy<Command>, CommandMetadata>(
+                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand2"))),
+                        new CommandMetadata() {Name = "test", SubCommand = "subcommand2"})
+                };
+            var commandLineHost = new CommandLineHost(availableCommands);
+            await commandLineHost.Run(new[] { "test", "subcommand2" });
+
+            Assert.Equal(commandsRan.First(), "test-subcommand2");
+        }
+
+        class ActionCommand : Command
+        {
+            public ActionCommand(Action action)
+            {
+                action.Invoke();
+            }
+        }
+    }
+}

--- a/test/SeqCli.Tests/Cli/NoDuplicateCommands.cs
+++ b/test/SeqCli.Tests/Cli/NoDuplicateCommands.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using SeqCli.Cli;
+using Xunit;
+
+namespace SeqCli.Tests.Cli
+{
+
+    public class NoDuplicateCommands
+    {
+        [Fact]
+        public void EnsureNoDuplicateCommands()
+        {
+            var anyDuplicates = typeof(Command).GetTypeInfo().Assembly.GetExportedTypes()
+                .Where(t => t.IsAssignableFrom(typeof(Command)))
+                .Select(t => new {CommandType = t, Attribute = t.GetCustomAttribute<CommandAttribute>()})
+                .GroupBy(t => new {t.Attribute.Name, t.Attribute.SubCommand})
+                .Any(t => t.Count() > 1);
+
+            Assert.Equal(anyDuplicates, false);
+        }
+    }
+}


### PR DESCRIPTION
This is designed to allow for the first proposal in https://github.com/datalust/seqcli/issues/2.

I am building a proposal for API Key management which is where this came from.

```
seqcli apikey list
seqcli apikey get -n="ApplicationName"
```