### PR TITLE
Generic entity formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Stream log events matching a filter.
 
 Print the current executable version.
 
-## Extraction Patterns
+## Extraction patterns
 
 The `seqcli ingest` command can be used for parsing plain text logs into structured log events.
 
@@ -201,7 +201,7 @@ Different matchers are needed so that a piece of text like `200OK` can be separa
 
 There are three kinds of matchers:
 
- * Matchers like `alpha` and `nat` are built-in _named_ matchers. These are built-in.
+ * Matchers like `alpha` and `nat` are built-in _named_ matchers.
  * The special matchers `*`, `**` and so-on, are _non-greedy content_ matchers; these will match any text up until the next pattern element matches (`*`), the next two elements match, and so-on. We saw this in action with the `{@m:*}{:n}` elements in the example - the message is all of the text up until the next newline.
  * More complex _compound_ matchers are described using a sub-expression. These are prefixed with an equals sign `=`, like `{Phone:={:nat}-{:nat}-{:nat}}`. This will extract chunks of text like `123-456-7890` into the `Phone` property.
 

--- a/src/SeqCli/Cli/CommandLineHost.cs
+++ b/src/SeqCli/Cli/CommandLineHost.cs
@@ -38,11 +38,14 @@ namespace SeqCli.Cli
             if (args.Length > 0)
             {
                 var norm = args[0].ToLowerInvariant();
-                var subCommandNorm = args.Length > 1 && !args[1].Contains("-") ? args[1].ToLowerInvariant() : default;
-                var cmd = _availableCommands.SingleOrDefault(c => c.Metadata.Name == norm && c.Metadata.SubCommand == subCommandNorm);
+                var subCommandNorm = args.Length > 1 && !args[1].Contains("-") ? args[1].ToLowerInvariant() : null;
+                
+                var cmd = _availableCommands.SingleOrDefault(c =>
+                    c.Metadata.Name == norm && (c.Metadata.SubCommand == subCommandNorm || c.Metadata.SubCommand == null));
+                
                 if (cmd != null)
                 {
-                    var amountToSkip = subCommandNorm == default ? 1 : 2;
+                    var amountToSkip = cmd.Metadata.SubCommand == null ? 1 : 2;
                     return await cmd.Value.Value.Invoke(args.Skip(amountToSkip).ToArray());
                 }
             }

--- a/src/SeqCli/Cli/Commands/ApiKey/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/ApiKey/RemoveCommand.cs
@@ -9,14 +9,14 @@ using SeqCli.Connection;
 
 namespace SeqCli.Cli.Commands.ApiKey
 {
-    [Command("apikey", "remove", "Remove API Key from the server", Example =
-        "seqcli apikey remove -t TestApiKey")]
+    [Command("apikey", "remove", "Remove an API key from the server",
+        Example="seqcli apikey remove -t TestApiKey")]
     class RemoveCommand : Command
     {
-        private readonly SeqConnectionFactory _connectionFactory;
-        private readonly ConnectionFeature _connection;
-        private string _title;
-        private string _id;
+        readonly SeqConnectionFactory _connectionFactory;
+        readonly ConnectionFeature _connection;
+        string _title;
+        string _id;
 
         public RemoveCommand(SeqConnectionFactory connectionFactory)
         {

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -89,24 +89,17 @@ namespace SeqCli.Cli.Features
             if (_json)
             {
                 jo.Remove("Links");
-                if (_noColor)
-                {
-                    Console.WriteLine(JsonConvert.SerializeObject(jo, Formatting.None));
-                }
-                else
-                {
-                    // Proof-of-concept; this is a very inefficient
-                    // way to write colorized JSON ;)
-                    
-                    var writer = new LoggerConfiguration()
-                        .Destructure.JsonNetTypes()
-                        .Enrich.With<StripStructureTypeEnricher>()
-                        .WriteTo.Console(
-                            outputTemplate: "{@Message:j}{NewLine}",
-                            theme: Theme)
-                        .CreateLogger();
-                    writer.Information("{@Entity}", jo);
-                }
+                // Proof-of-concept; this is a very inefficient
+                // way to write colorized JSON ;)
+                
+                var writer = new LoggerConfiguration()
+                    .Destructure.JsonNetTypes()
+                    .Enrich.With<StripStructureTypeEnricher>()
+                    .WriteTo.Console(
+                        outputTemplate: "{@Message:j}{NewLine}",
+                        theme: Theme)
+                    .CreateLogger();
+                writer.Information("{@Entity}", jo);
             }
             else
             {

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 using System;
+using Destructurama;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Seq.Api.Model;
 using SeqCli.Config;
 using SeqCli.Csv;
 using SeqCli.Output;
@@ -73,6 +77,41 @@ namespace SeqCli.Cli.Features
             {
                 var tokens = new CsvTokenizer().Tokenize(csv);
                 CsvWriter.WriteCsv(tokens, Theme, Console.Out, true);
+            }
+        }
+
+        public void WriteEntity(Entity entity)
+        {
+            if (entity == null) throw new ArgumentNullException(nameof(entity));
+
+            var jo = JObject.FromObject(entity);
+            
+            if (_json)
+            {
+                jo.Remove("Links");
+                if (_noColor)
+                {
+                    Console.WriteLine(JsonConvert.SerializeObject(jo, Formatting.None));
+                }
+                else
+                {
+                    // Proof-of-concept; this is a very inefficient
+                    // way to write colorized JSON ;)
+                    
+                    var writer = new LoggerConfiguration()
+                        .Destructure.JsonNetTypes()
+                        .Enrich.With<StripStructureTypeEnricher>()
+                        .WriteTo.Console(
+                            outputTemplate: "{@Message:j}{NewLine}",
+                            theme: Theme)
+                        .CreateLogger();
+                    writer.Information("{@Entity}", jo);
+                }
+            }
+            else
+            {
+                var dyn = (dynamic) jo;
+                Console.WriteLine($"{entity.Id} {dyn.Title ?? dyn.Name}");
             }
         }
     }

--- a/src/SeqCli/Output/StripStructureTypeEnricher.cs
+++ b/src/SeqCli/Output/StripStructureTypeEnricher.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+using Serilog.Core;
+using Serilog.Data;
+using Serilog.Events;
+
+namespace SeqCli.Output
+{
+    public class StripStructureTypeEnricher : LogEventPropertyValueRewriter<object>, ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            foreach (var property in logEvent.Properties)
+            {
+                var updated = new LogEventProperty(property.Key, Visit(null, property.Value));
+                logEvent.AddOrUpdateProperty(updated);
+            }
+        }
+
+        protected override LogEventPropertyValue VisitStructureValue(object state, StructureValue structure)
+        {
+            return new StructureValue(structure.Properties.Select(p =>
+                new LogEventProperty(p.Name, Visit(null, p.Value))));
+        }
+    }
+}

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -18,6 +18,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Destructurama.JsonNet" Version="1.2.0" />
     <PackageReference Include="newtonsoft.json" Version="10.0.3" />
     <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="serilog.filters.expressions" Version="1.1.0" />

--- a/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
+++ b/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Autofac.Features.Metadata;
 using SeqCli.Cli;
-using SeqCli.Cli.Commands;
 using Xunit;
 
 namespace SeqCli.Tests.Cli
@@ -21,55 +18,15 @@ namespace SeqCli.Tests.Cli
             {
                 new Meta<Lazy<Command>, CommandMetadata>(
                     new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test"))),
-                    new CommandMetadata() {Name = "test"}),
+                    new CommandMetadata {Name = "test"}),
                 new Meta<Lazy<Command>, CommandMetadata>(
                     new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test2"))),
-                    new CommandMetadata() {Name = "test2"})
+                    new CommandMetadata {Name = "test2"})
             };
             var commandLineHost = new CommandLineHost(availableCommands);
             await commandLineHost.Run(new []{ "test"});
 
             Assert.Equal(commandsRan.First(), "test");
-        }
-
-        [Fact]
-        public async Task WhenCommandAndSubcommandAndTheUserRunsWithoutSubcommandEnsurePickedCorrect()
-        {
-            var commandsRan = new List<string>();
-            var availableCommands =
-                new List<Meta<Lazy<Command>, CommandMetadata>>
-                {
-                    new Meta<Lazy<Command>, CommandMetadata>(
-                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test"))),
-                        new CommandMetadata() {Name = "test"}),
-                    new Meta<Lazy<Command>, CommandMetadata>(
-                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand"))),
-                        new CommandMetadata() {Name = "test", SubCommand = "subcommand"})
-                };
-            var commandLineHost = new CommandLineHost(availableCommands);
-            await commandLineHost.Run(new[] { "test" });
-
-            Assert.Equal(commandsRan.First(), "test");
-        }
-
-        [Fact]
-        public async Task WhenCommandAndSubcommandAndTheUserRunsWithSubcommandEnsurePickedCorrect()
-        {
-            var commandsRan = new List<string>();
-            var availableCommands =
-                new List<Meta<Lazy<Command>, CommandMetadata>>
-                {
-                    new Meta<Lazy<Command>, CommandMetadata>(
-                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test"))),
-                        new CommandMetadata() {Name = "test"}),
-                    new Meta<Lazy<Command>, CommandMetadata>(
-                        new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand"))),
-                        new CommandMetadata() {Name = "test", SubCommand = "subcommand"})
-                };
-            var commandLineHost = new CommandLineHost(availableCommands);
-            await commandLineHost.Run(new[] { "test", "subcommand" });
-
-            Assert.Equal(commandsRan.First(), "test-subcommand");
         }
 
         [Fact]
@@ -81,10 +38,10 @@ namespace SeqCli.Tests.Cli
                 {
                     new Meta<Lazy<Command>, CommandMetadata>(
                         new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand1"))),
-                        new CommandMetadata() {Name = "test", SubCommand = "subcommand1"}),
+                        new CommandMetadata {Name = "test", SubCommand = "subcommand1"}),
                     new Meta<Lazy<Command>, CommandMetadata>(
                         new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand2"))),
-                        new CommandMetadata() {Name = "test", SubCommand = "subcommand2"})
+                        new CommandMetadata {Name = "test", SubCommand = "subcommand2"})
                 };
             var commandLineHost = new CommandLineHost(availableCommands);
             await commandLineHost.Run(new[] { "test", "subcommand2" });


### PR DESCRIPTION
Had a shot at generic output formatting for entities, i.e. what we'll get from `apikey list` type commands:

![screenshot from 2018-03-01 20-52-05](https://user-images.githubusercontent.com/342712/36840958-7d83318e-1d92-11e8-8dfe-120e56f1fa60.png)

The results are okay - there are three modes, text (Id/Title pair), JSON (colorized via Serilog...) and plain JSON. It's a hideously inefficient way to output JSON, but not _too_ bad to read. An `--indented` option might be desirable someday.

~~Hacked in~~Sorted out the `seqcli help <command> <subcommand>` functionality en route.