### PR TITLE
Don't block while partial batches are read from STDIN

### DIFF
--- a/src/SeqCli/Ingestion/BatchResult.cs
+++ b/src/SeqCli/Ingestion/BatchResult.cs
@@ -1,0 +1,16 @@
+﻿using Serilog.Events;
+
+namespace SeqCli.Ingestion
+{
+    struct BatchResult
+    {
+        public LogEvent[] LogEvents { get; }
+        public bool IsLast { get; }
+
+        public BatchResult(LogEvent[] logEvents, bool isLast)
+        {
+            LogEvents = logEvents;
+            IsLast = isLast;
+        }
+    }
+}

--- a/src/SeqCli/Ingestion/ILogEventReader.cs
+++ b/src/SeqCli/Ingestion/ILogEventReader.cs
@@ -5,6 +5,6 @@ namespace SeqCli.Ingestion
 {
     interface ILogEventReader
     {
-        Task<LogEvent> TryReadAsync();
+        Task<ReadResult> TryReadAsync();
     }
 }

--- a/src/SeqCli/Ingestion/LogShipper.cs
+++ b/src/SeqCli/Ingestion/LogShipper.cs
@@ -31,7 +31,7 @@ namespace SeqCli.Ingestion
     static class LogShipper
     {
         // Keep things simple with a fixed batch size.
-        const int BatchSize = 500;
+        const int BatchSize = 100;
 
         static readonly CompactJsonFormatter Formatter = new CompactJsonFormatter();
 

--- a/src/SeqCli/Ingestion/ReadResult.cs
+++ b/src/SeqCli/Ingestion/ReadResult.cs
@@ -1,0 +1,16 @@
+﻿using Serilog.Events;
+
+namespace SeqCli.Ingestion
+{
+    struct ReadResult
+    {
+        public LogEvent LogEvent { get; }
+        public bool IsAtEnd { get; }
+
+        public ReadResult(LogEvent logEvent, bool isAtEnd)
+        {
+            LogEvent = logEvent;
+            IsAtEnd = isAtEnd;
+        }
+    }
+}

--- a/src/SeqCli/PlainText/Extraction/ExtractionPatternInterpreter.cs
+++ b/src/SeqCli/PlainText/Extraction/ExtractionPatternInterpreter.cs
@@ -7,11 +7,6 @@ namespace SeqCli.PlainText.Extraction
 {
     static class ExtractionPatternInterpreter
     {
-        public static NameValueExtractor MultilineMessageExtractor { get; } = new NameValueExtractor(new[]
-        {
-            new SimplePatternElement(Matchers.MultiLineMessage, ReifiedProperties.Message)
-        });
-
         static PatternElement[] CreatePatternElements(ExtractionPattern pattern)
         {
             if (pattern == null) throw new ArgumentNullException(nameof(pattern));

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -61,7 +61,7 @@ namespace SeqCli.PlainText.Extraction
         public static TextParser<object> Timestamp { get; } =
             Iso8601DateTime.Try().Or(SerilogFileTimestamp);
 
-        // Unclear whether we need to name this
+        [Matcher("trailingindent")]
         public static TextParser<object> MultiLineMessage { get; } =
             SpanEx.MatchedBy(
                     Character.Matching(ch => !char.IsWhiteSpace(ch), "non whitespace character")

--- a/src/SeqCli/PlainText/Framing/Frame.cs
+++ b/src/SeqCli/PlainText/Framing/Frame.cs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace SeqCli.PlainText
+namespace SeqCli.PlainText.Framing
 {
     struct Frame
     {
         public bool HasValue { get; set; }
         public bool IsOrphan { get; set; }
         public string Value { get; set; }
+        public bool IsAtEnd { get; set; }
     }
 }

--- a/src/SeqCli/PlainText/Framing/FrameReader.cs
+++ b/src/SeqCli/PlainText/Framing/FrameReader.cs
@@ -92,7 +92,7 @@ namespace SeqCli.PlainText.Framing
                             return new Frame {HasValue = true, Value = valueBuilder.ToString(), IsAtEnd = true};
                         }
 
-                        return new Frame();
+                        return new Frame {IsAtEnd = true};
                     }
 
                     if (IsFrameStart(line))

--- a/src/SeqCli/PlainText/Framing/FrameReader.cs
+++ b/src/SeqCli/PlainText/Framing/FrameReader.cs
@@ -19,9 +19,9 @@ using System.Threading.Tasks;
 using Superpower;
 using Superpower.Model;
 
-namespace SeqCli.PlainText
+namespace SeqCli.PlainText.Framing
 {
-    class FrameReader : IDisposable
+    class FrameReader
     {
         readonly TextReader _source;
         readonly TimeSpan _trailingLineArrivalDeadline;
@@ -50,10 +50,14 @@ namespace SeqCli.PlainText
             }
             else if (_unawaitedNextLine != null)
             {
+                var index = Task.WaitAny(new Task[] {_unawaitedNextLine}, _trailingLineArrivalDeadline);
+                if (index == -1)
+                    return new Frame();
+                
                 var line = await _unawaitedNextLine;
                 _unawaitedNextLine = null;
                 if (line == null)
-                    return new Frame();
+                    return new Frame {IsAtEnd = true};
 
                 valueBuilder.AppendLine(line);
                 hasValue = true;
@@ -67,7 +71,7 @@ namespace SeqCli.PlainText
             {
                 readLine = readLine ?? Task.Run(_source.ReadLineAsync);                
                 var index = Task.WaitAny(new Task[] {readLine}, _trailingLineArrivalDeadline);
-                if (index == -1) // Timeout
+                if (index == -1)
                 {
                     if (hasValue)
                     {
@@ -85,7 +89,7 @@ namespace SeqCli.PlainText
                     {
                         if (hasValue)
                         {
-                            return new Frame {HasValue = true, Value = valueBuilder.ToString()};
+                            return new Frame {HasValue = true, Value = valueBuilder.ToString(), IsAtEnd = true};
                         }
 
                         return new Frame();
@@ -121,11 +125,6 @@ namespace SeqCli.PlainText
                 var result = _frameStart(new TextSpan(line));
                 return result.HasValue && result.Value.Length > 0;
             }
-        }
-
-        public void Dispose()
-        {
-            _unawaitedNextLine?.Dispose();
         }
     }
 }

--- a/test/SeqCli.Tests/PlainText/FrameReaderTests.cs
+++ b/test/SeqCli.Tests/PlainText/FrameReaderTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using SeqCli.PlainText;
+using SeqCli.PlainText.Framing;
 using SeqCli.PlainText.Parsers;
 using Superpower;
 using Superpower.Model;

--- a/test/SeqCli.Tests/PlainText/NameValueExtractorTests.cs
+++ b/test/SeqCli.Tests/PlainText/NameValueExtractorTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using SeqCli.PlainText;
 using SeqCli.PlainText.Extraction;
+using SeqCli.PlainText.Patterns;
 using Superpower.Model;
 using Xunit;
 
@@ -10,20 +11,26 @@ namespace SeqCli.Tests.PlainText
     public class NameValueExtractorTests
     {
         [Fact]
-        public void TheDefaultPatternMatchesMultilineMessages()
+        public void TheTrailingIndentPatternMatchesMultilineMessages()
         {
+            var multilineMessageExtractor =
+                ExtractionPatternInterpreter.CreateNameValueExtractor(
+                    ExtractionPatternParser.Parse("{@m:trailingindent}"));
             var frame = $"Hello,{Environment.NewLine} world!";
-            var (properties, remainder) = ExtractionPatternInterpreter.MultilineMessageExtractor.ExtractValues(frame);
+            var (properties, remainder) = multilineMessageExtractor.ExtractValues(frame);
             Assert.Null(remainder);
             Assert.Single(properties, p => p.Key == ReifiedProperties.Message &&
                                            ((TextSpan)p.Value).ToStringValue() == frame);
         }
 
         [Fact]
-        public void TheDefaultPatternDoesNotMatchLinesStartingWithWhitespace()
+        public void TheTrailingIndentPatternDoesNotMatchLinesStartingWithWhitespace()
         {
+            var multilineMessageExtractor =
+                ExtractionPatternInterpreter.CreateNameValueExtractor(
+                    ExtractionPatternParser.Parse("{@m:trailingindent}"));
             var frame = " world";
-            var (properties, remainder) = ExtractionPatternInterpreter.MultilineMessageExtractor.ExtractValues(frame);
+            var (properties, remainder) = multilineMessageExtractor.ExtractValues(frame);
             Assert.Empty(properties);
             Assert.Equal(frame, remainder);
         }


### PR DESCRIPTION
Fixes #33 

When logs are streamed to `seqcli ingest`, partial batches need to be sent rather than waiting for a complete batch from STDIN.

This is achieved using `FrameReader`, which sets a new property `IsAtEnd` on `Frame` - each attempt to read a new line will now time out in 10ms and the batching logic send any accumulated events that have been queued.

There's still room for refactoring and improvement here, but we should be closer to working respectably, now :-)

Switches JSON ingestion to this mode also.