### PR TITLE
Basic systemd/syslog ingestion

### DIFF
--- a/src/SeqCli/Ingestion/BatchResult.cs
+++ b/src/SeqCli/Ingestion/BatchResult.cs
@@ -1,0 +1,16 @@
+﻿using Serilog.Events;
+
+namespace SeqCli.Ingestion
+{
+    struct BatchResult
+    {
+        public LogEvent[] LogEvents { get; }
+        public bool IsLast { get; }
+
+        public BatchResult(LogEvent[] logEvents, bool isLast)
+        {
+            LogEvents = logEvents;
+            IsLast = isLast;
+        }
+    }
+}

--- a/src/SeqCli/Ingestion/ILogEventReader.cs
+++ b/src/SeqCli/Ingestion/ILogEventReader.cs
@@ -5,6 +5,6 @@ namespace SeqCli.Ingestion
 {
     interface ILogEventReader
     {
-        Task<LogEvent> TryReadAsync();
+        Task<ReadResult> TryReadAsync();
     }
 }

--- a/src/SeqCli/Ingestion/LogShipper.cs
+++ b/src/SeqCli/Ingestion/LogShipper.cs
@@ -31,7 +31,7 @@ namespace SeqCli.Ingestion
     static class LogShipper
     {
         // Keep things simple with a fixed batch size.
-        const int BatchSize = 500;
+        const int BatchSize = 100;
 
         static readonly CompactJsonFormatter Formatter = new CompactJsonFormatter();
 

--- a/src/SeqCli/Ingestion/ReadResult.cs
+++ b/src/SeqCli/Ingestion/ReadResult.cs
@@ -1,0 +1,16 @@
+﻿using Serilog.Events;
+
+namespace SeqCli.Ingestion
+{
+    struct ReadResult
+    {
+        public LogEvent LogEvent { get; }
+        public bool IsAtEnd { get; }
+
+        public ReadResult(LogEvent logEvent, bool isAtEnd)
+        {
+            LogEvent = logEvent;
+            IsAtEnd = isAtEnd;
+        }
+    }
+}

--- a/src/SeqCli/PlainText/Extraction/ExtractionPatternInterpreter.cs
+++ b/src/SeqCli/PlainText/Extraction/ExtractionPatternInterpreter.cs
@@ -7,11 +7,6 @@ namespace SeqCli.PlainText.Extraction
 {
     static class ExtractionPatternInterpreter
     {
-        public static NameValueExtractor MultilineMessageExtractor { get; } = new NameValueExtractor(new[]
-        {
-            new SimplePatternElement(Matchers.MultiLineMessage, ReifiedProperties.Message)
-        });
-
         static PatternElement[] CreatePatternElements(ExtractionPattern pattern)
         {
             if (pattern == null) throw new ArgumentNullException(nameof(pattern));

--- a/src/SeqCli/PlainText/Extraction/ExtractionPatternInterpreter.cs
+++ b/src/SeqCli/PlainText/Extraction/ExtractionPatternInterpreter.cs
@@ -29,13 +29,19 @@ namespace SeqCli.PlainText.Extraction
                     case CapturePatternExpression capture
                     when capture.Content is MatchTypeContentExpression mtc:
                         patternElements[i] = new SimplePatternElement(
-                            mtc.Type == null ? Matchers.Token : Matchers.GetByType(mtc.Type),
+                            Matchers.GetByType(mtc.Type),
                             capture.Name);
                         break;
                     case CapturePatternExpression capture
                     when capture.Content is GroupedContentExpression gc:
                         patternElements[i] = new GroupedPatternElement(
                             CreatePatternElements(gc.ExtractionPattern),
+                            capture.Name);
+                        break;
+                    case CapturePatternExpression capture
+                    when capture.Content == null:
+                        patternElements[i] = new SimplePatternElement(
+                            Matchers.Token,
                             capture.Name);
                         break;
                     default:

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -61,7 +61,7 @@ namespace SeqCli.PlainText.Extraction
         public static TextParser<object> Timestamp { get; } =
             Iso8601DateTime.Try().Or(SerilogFileTimestamp);
 
-        // Unclear whether we need to name this
+        [Matcher("trailingindent")]
         public static TextParser<object> MultiLineMessage { get; } =
             SpanEx.MatchedBy(
                     Character.Matching(ch => !char.IsWhiteSpace(ch), "non whitespace character")

--- a/src/SeqCli/PlainText/Framing/Frame.cs
+++ b/src/SeqCli/PlainText/Framing/Frame.cs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace SeqCli.PlainText
+namespace SeqCli.PlainText.Framing
 {
     struct Frame
     {
         public bool HasValue { get; set; }
         public bool IsOrphan { get; set; }
         public string Value { get; set; }
+        public bool IsAtEnd { get; set; }
     }
 }

--- a/src/SeqCli/PlainText/Framing/FrameReader.cs
+++ b/src/SeqCli/PlainText/Framing/FrameReader.cs
@@ -19,9 +19,9 @@ using System.Threading.Tasks;
 using Superpower;
 using Superpower.Model;
 
-namespace SeqCli.PlainText
+namespace SeqCli.PlainText.Framing
 {
-    class FrameReader : IDisposable
+    class FrameReader
     {
         readonly TextReader _source;
         readonly TimeSpan _trailingLineArrivalDeadline;
@@ -50,10 +50,14 @@ namespace SeqCli.PlainText
             }
             else if (_unawaitedNextLine != null)
             {
+                var index = Task.WaitAny(new Task[] {_unawaitedNextLine}, _trailingLineArrivalDeadline);
+                if (index == -1)
+                    return new Frame();
+                
                 var line = await _unawaitedNextLine;
                 _unawaitedNextLine = null;
                 if (line == null)
-                    return new Frame();
+                    return new Frame {IsAtEnd = true};
 
                 valueBuilder.AppendLine(line);
                 hasValue = true;
@@ -67,7 +71,7 @@ namespace SeqCli.PlainText
             {
                 readLine = readLine ?? Task.Run(_source.ReadLineAsync);                
                 var index = Task.WaitAny(new Task[] {readLine}, _trailingLineArrivalDeadline);
-                if (index == -1) // Timeout
+                if (index == -1)
                 {
                     if (hasValue)
                     {
@@ -85,7 +89,7 @@ namespace SeqCli.PlainText
                     {
                         if (hasValue)
                         {
-                            return new Frame {HasValue = true, Value = valueBuilder.ToString()};
+                            return new Frame {HasValue = true, Value = valueBuilder.ToString(), IsAtEnd = true};
                         }
 
                         return new Frame();
@@ -121,11 +125,6 @@ namespace SeqCli.PlainText
                 var result = _frameStart(new TextSpan(line));
                 return result.HasValue && result.Value.Length > 0;
             }
-        }
-
-        public void Dispose()
-        {
-            _unawaitedNextLine?.Dispose();
         }
     }
 }

--- a/src/SeqCli/PlainText/Patterns/MatchTypeContentExpression.cs
+++ b/src/SeqCli/PlainText/Patterns/MatchTypeContentExpression.cs
@@ -1,4 +1,6 @@
-﻿namespace SeqCli.PlainText.Patterns
+﻿using System;
+
+namespace SeqCli.PlainText.Patterns
 {
     class MatchTypeContentExpression : CaptureContentExpression
     {
@@ -6,7 +8,7 @@
 
         public MatchTypeContentExpression(string type)
         {
-            Type = type;
+            Type = type ?? throw new ArgumentNullException(nameof(type));
         }
     }
 }

--- a/test/SeqCli.Tests/PlainText/FrameReaderTests.cs
+++ b/test/SeqCli.Tests/PlainText/FrameReaderTests.cs
@@ -73,7 +73,7 @@ namespace SeqCli.Tests.PlainText
             var reader = new FrameReader(
                 new StringReader(source),
                 frameStart,
-                TimeSpan.FromMilliseconds(1));
+                TimeSpan.FromMilliseconds(10));
 
             var result = new List<Frame>();
             

--- a/test/SeqCli.Tests/PlainText/FrameReaderTests.cs
+++ b/test/SeqCli.Tests/PlainText/FrameReaderTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using SeqCli.PlainText;
+using SeqCli.PlainText.Framing;
 using SeqCli.PlainText.Parsers;
 using Superpower;
 using Superpower.Model;

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using SeqCli.PlainText.Extraction;
+using Superpower;
+using Xunit;
+
+namespace SeqCli.Tests.PlainText
+{
+    public class MatchersTests
+    {
+        [Theory]
+        [InlineData("Mar  6 13:22:29", 3, 6, 13, 22, 29)]
+        [InlineData("Dec 31 23:59:59", 12, 31, 23, 59, 59)]
+        [InlineData("Jan  1 00:00:00", 1, 1, 0, 0, 0)]
+        public void DefaultSyslogDateTimeIsMatched(string timestamp, int month, int day, int hour, int minute, int second)
+        {
+            var result = Matchers.SyslogDefaultTimestamp.AtEnd().Parse(timestamp);
+            var dto = Assert.IsType<DateTimeOffset>(result);
+            Assert.Equal(month, dto.Month);
+            Assert.Equal(day, dto.Day);
+            Assert.Equal(hour, dto.Hour);
+            Assert.Equal(minute, dto.Minute);
+            Assert.Equal(second, dto.Second);
+            Assert.Equal(DateTimeOffset.Now.Offset, dto.Offset);
+        }
+    }
+}

--- a/test/SeqCli.Tests/PlainText/NameValueExtractorTests.cs
+++ b/test/SeqCli.Tests/PlainText/NameValueExtractorTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using SeqCli.PlainText;
 using SeqCli.PlainText.Extraction;
+using SeqCli.PlainText.Patterns;
 using Superpower.Model;
 using Xunit;
 
@@ -10,20 +11,26 @@ namespace SeqCli.Tests.PlainText
     public class NameValueExtractorTests
     {
         [Fact]
-        public void TheDefaultPatternMatchesMultilineMessages()
+        public void TheTrailingIndentPatternMatchesMultilineMessages()
         {
+            var multilineMessageExtractor =
+                ExtractionPatternInterpreter.CreateNameValueExtractor(
+                    ExtractionPatternParser.Parse("{@m:trailingindent}"));
             var frame = $"Hello,{Environment.NewLine} world!";
-            var (properties, remainder) = ExtractionPatternInterpreter.MultilineMessageExtractor.ExtractValues(frame);
+            var (properties, remainder) = multilineMessageExtractor.ExtractValues(frame);
             Assert.Null(remainder);
             Assert.Single(properties, p => p.Key == ReifiedProperties.Message &&
                                            ((TextSpan)p.Value).ToStringValue() == frame);
         }
 
         [Fact]
-        public void TheDefaultPatternDoesNotMatchLinesStartingWithWhitespace()
+        public void TheTrailingIndentPatternDoesNotMatchLinesStartingWithWhitespace()
         {
+            var multilineMessageExtractor =
+                ExtractionPatternInterpreter.CreateNameValueExtractor(
+                    ExtractionPatternParser.Parse("{@m:trailingindent}"));
             var frame = " world";
-            var (properties, remainder) = ExtractionPatternInterpreter.MultilineMessageExtractor.ExtractValues(frame);
+            var (properties, remainder) = multilineMessageExtractor.ExtractValues(frame);
             Assert.Empty(properties);
             Assert.Equal(frame, remainder);
         }


### PR DESCRIPTION
The following now work on my default/Australian English Ubuntu 17.10 box:

```shell
# Tail systemd logs
journalctl -f -n 0 |
  seqcli ingest -x "{@t:syslogdt} {host} {ident:*}: {@m:*}{:n}" --invalid-data=ignore

# Tail /var/log/syslog
 tail -c 0 -F /var/log/syslog |
  seqcli ingest -x "{@t:syslogdt} {host} {ident:*}: {@m:*}{:n}"
```
The output is not _pretty_, but it's a start!

![screenshot from 2018-03-06 14-39-56](https://user-images.githubusercontent.com/342712/37014471-9d74dfb6-214c-11e8-83f5-e82fb0eb8ea2.png)

Fixes #34 Depends on #35 