### PR TITLE
Only encrypt api key variable on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To set a default server URL, run:
 seqcli config -k connection.serverUrl -v https://your-seq-server
 ```
 
-This will create `SeqConfig.json` in your home directory. A default API key can also be set by providing the `connection.apiKey` setting name.
+The API key will be stored in your `SeqCli.json` configuration file; on Windows, this is encrypted using DPAPI; on Mac/Linux the key is currently stored in plain text.
 
 ## Commands
 

--- a/src/SeqCli/Config/SeqCliConnectionConfig.cs
+++ b/src/SeqCli/Config/SeqCliConnectionConfig.cs
@@ -39,7 +39,7 @@ namespace SeqCli.Config
                 if (!EncodedApiKey.StartsWith(ProtectedDataPrefix))
                     return EncodedApiKey;
 
-                return MachineScopeDataProtection.Unprotect(EncodedApiKey.Substring(ProtectedDataPrefix.Length));
+                return UserScopeDataProtection.Unprotect(EncodedApiKey.Substring(ProtectedDataPrefix.Length));
             }
             set
             {
@@ -49,7 +49,7 @@ namespace SeqCli.Config
                     return;
                 }
 
-                EncodedApiKey = $"{ProtectedDataPrefix}{MachineScopeDataProtection.Protect(value)}";
+                EncodedApiKey = $"{ProtectedDataPrefix}{UserScopeDataProtection.Protect(value)}";
             }
 #else
             get { return EncodedApiKey; }

--- a/src/SeqCli/Config/SeqCliConnectionConfig.cs
+++ b/src/SeqCli/Config/SeqCliConnectionConfig.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Newtonsoft.Json;
 using SeqCli.Util;
 
@@ -29,6 +30,7 @@ namespace SeqCli.Config
         [JsonIgnore]
         public string ApiKey
         {
+#if WINDOWS
             get
             {
                 if (string.IsNullOrWhiteSpace(EncodedApiKey))
@@ -49,7 +51,10 @@ namespace SeqCli.Config
 
                 EncodedApiKey = $"{ProtectedDataPrefix}{MachineScopeDataProtection.Protect(value)}";
             }
+#else
+            get { return EncodedApiKey; }
+            set { EncodedApiKey = value; }
+#endif
         }
-
     }
 }

--- a/src/SeqCli/Util/UserScopeDataProtection.cs
+++ b/src/SeqCli/Util/UserScopeDataProtection.cs
@@ -32,7 +32,7 @@ using System.Text;
 
 namespace SeqCli.Util
 {
-    static class MachineScopeDataProtection
+    static class UserScopeDataProtection
     {
         public static string Unprotect(string @protected)
         {
@@ -42,7 +42,7 @@ namespace SeqCli.Util
 
             var bytes = Convert.FromBase64String(parts[0]);
             var salt = Convert.FromBase64String(parts[1]);
-            var decoded = ProtectedData.Unprotect(bytes, salt, DataProtectionScope.LocalMachine);
+            var decoded = ProtectedData.Unprotect(bytes, salt, DataProtectionScope.CurrentUser);
             return Encoding.UTF8.GetString(decoded);
         }
 
@@ -52,7 +52,7 @@ namespace SeqCli.Util
             using (var cp = new RNGCryptoServiceProvider())
                 cp.GetBytes(salt);
 
-            var bytes = ProtectedData.Protect(Encoding.UTF8.GetBytes(value), salt, DataProtectionScope.LocalMachine);
+            var bytes = ProtectedData.Protect(Encoding.UTF8.GetBytes(value), salt, DataProtectionScope.CurrentUser);
             return $"{Convert.ToBase64String(bytes)}${Convert.ToBase64String(salt)}";
         }
     }


### PR DESCRIPTION
Fixes #40 

Avoids attempting to call Windows APIs when using API keys by not encrypting them on non-Windows platforms. Where should we call out that non-Windows platforms won't have their API keys encrypted in the configuration?