### PR TITLE
Option to ignore connection issues during ingestion

### DIFF
--- a/src/SeqCli/Cli/Commands/IngestCommand.cs
+++ b/src/SeqCli/Cli/Commands/IngestCommand.cs
@@ -38,6 +38,7 @@ namespace SeqCli.Cli.Commands
         readonly InvalidDataHandlingFeature _invalidDataHandlingFeature;
         readonly FileInputFeature _fileInputFeature;
         readonly PropertiesFeature _properties;
+        readonly SendFailureHandlingFeature _sendFailureHandlingFeature;
         readonly ConnectionFeature _connection;
         string _filter, _pattern = DefaultPattern;
         bool _json;
@@ -60,7 +61,8 @@ namespace SeqCli.Cli.Commands
             Options.Add("f=|filter=",
                 "Filter expression to select a subset of events",
                 v => _filter = string.IsNullOrWhiteSpace(v) ? null : v.Trim());
-            
+
+            _sendFailureHandlingFeature = Enable<SendFailureHandlingFeature>();            
             _connection = Enable<ConnectionFeature>();
         }
 
@@ -95,6 +97,7 @@ namespace SeqCli.Cli.Commands
                         reader,
                         enrichers,
                         _invalidDataHandlingFeature.InvalidDataHandling,
+                        _sendFailureHandlingFeature.SendFailureHandling,
                         filter);
                 }
             }

--- a/src/SeqCli/Cli/Features/SendFailureHandlingFeature.cs
+++ b/src/SeqCli/Cli/Features/SendFailureHandlingFeature.cs
@@ -17,15 +17,15 @@ using SeqCli.Ingestion;
 
 namespace SeqCli.Cli.Features
 {
-    class InvalidDataHandlingFeature : CommandFeature
+    class SendFailureHandlingFeature : CommandFeature
     {
-        public InvalidDataHandling InvalidDataHandling { get; private set; }
+        public SendFailureHandling SendFailureHandling { get; private set; }
 
         public override void Enable(OptionSet options)
         {
-            options.Add("invalid-data=",
-                "Specify how invalid data is handled: `fail` (default) or `ignore`",
-                v => InvalidDataHandling = (InvalidDataHandling)Enum.Parse(typeof(InvalidDataHandling), v, ignoreCase: true));
+            options.Add("send-failure=",
+                "Specify how connection failures are handled: `fail` (default), `continue`, or `ignore`",
+                v => SendFailureHandling = (SendFailureHandling)Enum.Parse(typeof(SendFailureHandling), v, ignoreCase: true));
         }
     }
 

--- a/src/SeqCli/Ingestion/SendFailureHandling.cs
+++ b/src/SeqCli/Ingestion/SendFailureHandling.cs
@@ -12,21 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using SeqCli.Ingestion;
-
-namespace SeqCli.Cli.Features
+namespace SeqCli.Ingestion
 {
-    class InvalidDataHandlingFeature : CommandFeature
+    /// <summary>
+    /// Controls how connection failures during ingestion are handled.
+    /// </summary>
+    /// <remarks>A 'retry' option will appear here at some future point.</remarks>
+    enum SendFailureHandling
     {
-        public InvalidDataHandling InvalidDataHandling { get; private set; }
-
-        public override void Enable(OptionSet options)
-        {
-            options.Add("invalid-data=",
-                "Specify how invalid data is handled: `fail` (default) or `ignore`",
-                v => InvalidDataHandling = (InvalidDataHandling)Enum.Parse(typeof(InvalidDataHandling), v, ignoreCase: true));
-        }
+        /// <summary>
+        /// Log error information and exit.
+        /// </summary>
+        Fail,
+        
+        /// <summary>
+        /// Log error information, drop the failed batch, and continue.
+        /// </summary>
+        Continue,
+        
+        /// <summary>
+        /// Silently ignore failures.
+        /// </summary>
+        Ignore
     }
-
 }


### PR DESCRIPTION
Three options are added; `--send-failure=fail` - the default, `continue` or (silently) `ignore`.

Usage:

```shell
tail -c 0 -F /var/log/syslog |
  seqcli ingest \
    -x "{@t:syslogdt} {host} {ident:*}: {@m:*}{:n}" \
    -p source=syslog \
    --send-failure=continue
```

(For #37 to be complete, a `retry` option is needed, but this will mean rethinking the way backpressure is currently handled, and probably require some buffering.)