### PR TITLE
End-to-end test harness

### DIFF
--- a/seqcli.sln
+++ b/seqcli.sln
@@ -51,10 +51,10 @@ Global
 		{5E28D963-3523-49DE-B03B-E76684258415}.Debug|x64.ActiveCfg = Debug|x64
 		{5E28D963-3523-49DE-B03B-E76684258415}.Release|x64.ActiveCfg = Release|x64
 		{5E28D963-3523-49DE-B03B-E76684258415}.Release|x64.Build.0 = Release|x64
-		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|x64.Build.0 = Debug|Any CPU
-		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|x64.ActiveCfg = Release|Any CPU
-		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|x64.Build.0 = Release|Any CPU
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|x64.ActiveCfg = Debug|x64
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|x64.Build.0 = Debug|x64
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|x64.ActiveCfg = Release|x64
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/seqcli.sln
+++ b/seqcli.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FC0A256C-CC1F-4ECE-AF09-707248D10DC1}"
 EndProject
@@ -32,7 +32,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SeqCli.Tests", "test\SeqCli
 EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "SeqCli.Setup", "setup\SeqCli.Setup\SeqCli.Setup.wixproj", "{5E28D963-3523-49DE-B03B-E76684258415}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeqCli.EndToEnd", "test\SeqCli.EndToEnd\SeqCli.EndToEnd.csproj", "{B86DEF3C-C461-4126-AD49-986EBB19B487}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SeqCli.EndToEnd", "test\SeqCli.EndToEnd\SeqCli.EndToEnd.csproj", "{B86DEF3C-C461-4126-AD49-986EBB19B487}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/seqcli.sln
+++ b/seqcli.sln
@@ -32,6 +32,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SeqCli.Tests", "test\SeqCli
 EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "SeqCli.Setup", "setup\SeqCli.Setup\SeqCli.Setup.wixproj", "{5E28D963-3523-49DE-B03B-E76684258415}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeqCli.EndToEnd", "test\SeqCli.EndToEnd\SeqCli.EndToEnd.csproj", "{B86DEF3C-C461-4126-AD49-986EBB19B487}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -49,6 +51,10 @@ Global
 		{5E28D963-3523-49DE-B03B-E76684258415}.Debug|x64.ActiveCfg = Debug|x64
 		{5E28D963-3523-49DE-B03B-E76684258415}.Release|x64.ActiveCfg = Release|x64
 		{5E28D963-3523-49DE-B03B-E76684258415}.Release|x64.Build.0 = Release|x64
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|x64.Build.0 = Debug|Any CPU
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|x64.ActiveCfg = Release|Any CPU
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,6 +63,7 @@ Global
 		{EBDBEED2-A1BC-4269-B6B0-EA908CE4D687} = {FC0A256C-CC1F-4ECE-AF09-707248D10DC1}
 		{DBC69360-519B-4A9B-829B-2AE1B5412521} = {3587B633-0C03-4235-8903-6226900328F1}
 		{5E28D963-3523-49DE-B03B-E76684258415} = {203E8AE7-ADF0-44FA-A341-90723C8595F7}
+		{B86DEF3C-C461-4126-AD49-986EBB19B487} = {3587B633-0C03-4235-8903-6226900328F1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6D299713-28D4-4078-9DA7-9033679CD200}

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -58,11 +58,11 @@ namespace SeqCli.PlainText.Extraction
             Span.Regex("\\w{3} ( )?\\d{1,2} \\d{2}:\\d{2}:\\d{2}")
                 .Select(span =>
                 {
-                    var dt = DateTime.ParseExact(span.ToStringValue(), "MMM d HH:mm:ss", CultureInfo.InvariantCulture,
+                    var dt = DateTimeOffset.ParseExact(span.ToStringValue(), "MMM d HH:mm:ss", CultureInfo.InvariantCulture,
                         DateTimeStyles.AllowInnerWhite | DateTimeStyles.AssumeLocal);
                     if (dt > DateTime.Now.AddDays(7)) // Tailing a late December log in early January :-)
                         dt = dt.AddYears(-1);
-                    return (object) new DateTimeOffset(dt, TimeZoneInfo.Local.GetUtcOffset(dt));
+                    return (object) dt;
                 });            
 
         public static TextParser<object> SerilogFileTimestamp { get; } =

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -62,7 +62,7 @@ namespace SeqCli.PlainText.Extraction
                         DateTimeStyles.AllowInnerWhite | DateTimeStyles.AssumeLocal);
                     if (dt > DateTime.Now.AddDays(7)) // Tailing a late December log in early January :-)
                         dt = dt.AddYears(-1);
-                    return (object) new DateTimeOffset(dt);
+                    return (object) new DateTimeOffset(dt, TimeZoneInfo.Local.GetUtcOffset(dt));
                 });            
 
         public static TextParser<object> SerilogFileTimestamp { get; } =

--- a/src/SeqCli/Program.cs
+++ b/src/SeqCli/Program.cs
@@ -40,7 +40,7 @@ namespace SeqCli
                         new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
                 TaskScheduler.UnobservedTaskException += 
-                    (s,e) => Log.Error(e.Exception, "Unobserved task exception: {UnobservedExceptionMessage}");
+                    (s,e) => Log.Error(e.Exception, "Unobserved task exception");
                 
                 var builder = new ContainerBuilder();
                 builder.RegisterModule<SeqCliModule>();

--- a/test/SeqCli.EndToEnd/Args.cs
+++ b/test/SeqCli.EndToEnd/Args.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace SeqCli.EndToEnd
+{
+    class Args
+    {
+        readonly string[] _args;
+
+        public Args(params string[] args)
+        {
+            _args = args;
+        }
+        
+        public Regex[] TestCases() => _args
+            .Where(arg => !arg.StartsWith("--"))
+            .Select(ToArgRegex)
+            .ToArray();
+
+        // Simple replacement so `Events.*` becomes `Events\..*`
+        static Regex ToArgRegex(string arg) => new Regex(arg.Replace(".", "\\.").Replace("*", ".*"));
+    }
+}

--- a/test/SeqCli.EndToEnd/LogCommand/LogCommandBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/LogCommand/LogCommandBasicsTestCase.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.LogCommand
+{
+    public class LogCommandBasicsTestCase : ICliTestCase
+    {
+        public async Task ExecuteAsync(
+            SeqConnection connection,
+            ILogger logger,
+            CliCommandRunner runner)
+        {
+            var exit = runner.Exec("log", "-m 'Hello, {Name}!' -p Name=world");
+            Assert.Equal(0, exit);
+
+            var events = await connection.Events.ListAsync(render: true, filter: "Name = 'world'");
+            Assert.Single(events);
+
+            var hello = events.Single();
+            Assert.Equal("Hello, world!", hello.RenderedMessage);
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/LogCommand/LogCommandBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/LogCommand/LogCommandBasicsTestCase.cs
@@ -14,7 +14,7 @@ namespace SeqCli.EndToEnd.LogCommand
             ILogger logger,
             CliCommandRunner runner)
         {
-            var exit = runner.Exec("log", "-m 'Hello, {Name}!' -p Name=world");
+            var exit = runner.Exec("log", "-m \"Hello, {Name}!\" -p Name=world");
             Assert.Equal(0, exit);
 
             var events = await connection.Events.ListAsync(render: true, filter: "Name = 'world'");

--- a/test/SeqCli.EndToEnd/Program.cs
+++ b/test/SeqCli.EndToEnd/Program.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using Autofac;
+using SeqCli.EndToEnd.Support;
+
+namespace SeqCli.EndToEnd
+{
+    static class Program
+    {
+        static async Task<int> Main(string[] rawArgs)
+        {
+            var args = new Args(rawArgs);
+
+            var builder = new ContainerBuilder();
+            builder.RegisterModule(new TestDriverModule(args));
+            using (var container = builder.Build())
+            {
+                return await container.Resolve<TestDriver>().Run();
+            }
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
+++ b/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
+++ b/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.5.0" />
+    <PackageReference Include="xunit" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+    <PackageReference Include="Seq.Api" Version="4.2.0" />
+  </ItemGroup>
+</Project>

--- a/test/SeqCli.EndToEnd/Support/CaptiveProcess.cs
+++ b/test/SeqCli.EndToEnd/Support/CaptiveProcess.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+namespace SeqCli.EndToEnd.Support
+{
+    public sealed class CaptiveProcess : ITestProcess, IDisposable
+    {
+        readonly bool _captureOutput;
+        readonly Process _process;
+        readonly ManualResetEvent _outputComplete = new ManualResetEvent(false);
+        readonly ManualResetEvent _errorComplete = new ManualResetEvent(false);
+
+        readonly object _sync = new object();
+        readonly StringWriter _output = new StringWriter();
+
+        public CaptiveProcess(
+            string fullExePath,
+            string args = null,
+            IDictionary<string, string> environment = null,
+            bool captureOutput = true)
+        {
+            if (fullExePath == null) throw new ArgumentNullException(nameof(fullExePath));
+            _captureOutput = captureOutput;
+
+            var startInfo = new ProcessStartInfo
+                      {
+                          UseShellExecute = false,
+                          RedirectStandardError = captureOutput,
+                          RedirectStandardOutput = captureOutput,
+                          WindowStyle = ProcessWindowStyle.Hidden,
+                          CreateNoWindow = true,
+                          ErrorDialog = false,
+                          FileName = fullExePath,
+                          Arguments = args ?? ""
+                      };
+            
+            if (environment != null)
+            {
+                foreach (var kvp in environment)
+                {
+                    startInfo.Environment.Add(kvp.Key, kvp.Value);
+                }
+            }
+
+            _process = Process.Start(startInfo);
+            if (_process == null)
+                throw new InvalidOperationException("The process did not start.");
+
+            if (captureOutput)
+            {
+                _process.OutputDataReceived += (o, e) =>
+                {
+                    if (e.Data == null)
+                        _outputComplete.Set(); 
+                    else
+                        WriteOutput(e.Data);
+                };
+                _process.BeginOutputReadLine();
+
+                _process.ErrorDataReceived += (o, e) =>
+                {
+                    if (e.Data == null)
+                        _errorComplete.Set();
+                    else
+                        WriteOutput(e.Data);
+                };
+                _process.BeginErrorReadLine();
+            }
+        }
+
+        void WriteOutput(string o)
+        {
+            lock (_sync)
+                _output.WriteLine(o);
+        }
+
+        public string Output
+        {
+            get
+            {
+                lock (_sync)
+                    return _output.ToString();
+            }
+        }
+
+        public int WaitForExit(TimeSpan? timeout = null)
+        {
+            var processExitTimeout = timeout ?? Timeout.InfiniteTimeSpan;     
+            _process.WaitForExit((int)processExitTimeout.TotalMilliseconds);
+
+            if (_captureOutput)
+            {
+                if (!_outputComplete.WaitOne(TimeSpan.FromSeconds(1)))
+                    throw new IOException("STDOUT did not complete in the fixed 1 second window.");
+                
+                if (!_errorComplete.WaitOne(TimeSpan.FromSeconds(1)))
+                    throw new IOException("STDERR did not complete in the fixed 1 second window.");
+            }
+
+            return _process.ExitCode;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _process.Kill();
+                WaitForExit();
+            }
+            catch
+            {
+                // Ignored
+            }
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/CliCommandRunner.cs
+++ b/test/SeqCli.EndToEnd/Support/CliCommandRunner.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace SeqCli.EndToEnd.Support
+{
+    public class CliCommandRunner
+    {
+        readonly TestConfiguration _configuration;
+        static readonly TimeSpan DefaultExecTimeout = TimeSpan.FromSeconds(10);
+        
+        public ITestProcess LastRunProcess { get; private set; }
+
+        public CliCommandRunner(TestConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public int Exec(string command, string args = null)
+        {
+            using (var process = _configuration.SpawnCliProcess(command, args))
+            {
+                LastRunProcess = process;
+                return process.WaitForExit(DefaultExecTimeout);
+            }
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/ICliTestCase.cs
+++ b/test/SeqCli.EndToEnd/Support/ICliTestCase.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using Seq.Api;
+using Serilog;
+
+namespace SeqCli.EndToEnd.Support
+{
+    interface ICliTestCase
+    {
+        Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner);
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/ITestProcess.cs
+++ b/test/SeqCli.EndToEnd/Support/ITestProcess.cs
@@ -1,0 +1,7 @@
+﻿namespace SeqCli.EndToEnd.Support
+{
+    public interface ITestProcess
+    {
+        string Output { get; }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/IsolatedTestCase.cs
+++ b/test/SeqCli.EndToEnd/Support/IsolatedTestCase.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Seq.Api;
+using Serilog;
+
+namespace SeqCli.EndToEnd.Support
+{
+    class IsolatedTestCase
+    {
+        readonly Lazy<ITestProcess> _serverProcess;
+        readonly Lazy<SeqConnection> _connection;
+        readonly Lazy<ILogger> _logger;
+        readonly CliCommandRunner _commandRunner;
+        readonly ICliTestCase _testCase;
+
+        ITestProcess _lastRunProcess;
+
+        public IsolatedTestCase(
+            Lazy<ITestProcess> serverProcess, 
+            Lazy<SeqConnection> connection,
+            Lazy<ILogger> logger,
+            CliCommandRunner commandRunner,
+            ICliTestCase testCase)
+        {
+            _serverProcess = serverProcess;
+            _connection = connection;
+            _logger = logger;
+            _commandRunner = commandRunner;
+            _testCase = testCase ?? throw new ArgumentNullException(nameof(testCase));
+        }
+
+        public string Description => _testCase.GetType().Name;
+        public string Output => _commandRunner.LastRunProcess?.Output ??_lastRunProcess?.Output ?? "<no process was run>";
+
+        public async Task ExecuteTestCaseAsync()
+        {
+            _lastRunProcess = _serverProcess.Value;
+            await _connection.Value.EnsureConnected();            
+            await _testCase.ExecuteAsync(_connection.Value, _logger.Value, _commandRunner);
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/SeqConnectionExtensions.cs
+++ b/test/SeqCli.EndToEnd/Support/SeqConnectionExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Seq.Api;
+
+namespace SeqCli.EndToEnd.Support
+{
+    static class SeqConnectionExtensions
+    {
+        public static async Task EnsureConnected(this SeqConnection connection)
+        {
+            if (connection == null) throw new ArgumentNullException(nameof(connection));
+
+            var started = DateTime.UtcNow;
+            var wait = TimeSpan.FromMilliseconds(100);
+            var waitLimit = TimeSpan.FromSeconds(100);
+            var deadline = started.Add(waitLimit);
+            while (!await ConnectAsync(connection, DateTime.UtcNow > deadline))
+            {
+                await Task.Delay(wait);
+            }
+        }
+
+        static async Task<bool> ConnectAsync(SeqConnection connection, bool throwOnFailure)
+        {
+            try
+            {
+                return (await connection.Client.HttpClient.GetAsync("/api")).StatusCode == HttpStatusCode.OK;
+            }
+            catch
+            {
+                if (throwOnFailure)
+                    throw;
+                
+                return false;
+            }
+        }
+
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
+++ b/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace SeqCli.EndToEnd.Support
+{
+    public class TestConfiguration
+    {
+        public string ServerListenUrl { get; } = "http://127.0.0.1:9989";
+
+        string EquivalentBaseDirectory { get; } = AppDomain.CurrentDomain.BaseDirectory
+            .Replace(Path.Combine("test", "SeqCli.EndToEnd"), Path.Combine("src", "SeqCli"));
+
+        public string TestedBinary => Path.Combine(EquivalentBaseDirectory, "seqcli.dll");
+
+        public CaptiveProcess SpawnCliProcess(string command, string additionalArgs = null, Dictionary<string, string> environment = null, bool skipServerArg = false)
+        {
+            if (command == null) throw new ArgumentNullException(nameof(command));
+
+            var commandWithArgs = $"{command} {additionalArgs}";
+            if (!skipServerArg)
+                commandWithArgs += $" --server=\"{ServerListenUrl}\"";
+            
+            var args = $"{TestedBinary} {commandWithArgs}";
+            return new CaptiveProcess("dotnet", args, environment);
+        }
+        
+        public CaptiveProcess SpawnServerProcess(string storagePath)
+        {
+            if (storagePath == null) throw new ArgumentNullException(nameof(storagePath));
+
+            var commandWithArgs = $"run --listen=\"{ServerListenUrl}\"--storage=\"{storagePath}\"";
+            
+            return new CaptiveProcess("seq", commandWithArgs);
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
+++ b/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
@@ -29,7 +29,7 @@ namespace SeqCli.EndToEnd.Support
         {
             if (storagePath == null) throw new ArgumentNullException(nameof(storagePath));
 
-            var commandWithArgs = $"run --listen=\"{ServerListenUrl}\"--storage=\"{storagePath}\"";
+            var commandWithArgs = $"run --listen=\"{ServerListenUrl}\" --storage=\"{storagePath}\"";
             
             return new CaptiveProcess("seq", commandWithArgs);
         }

--- a/test/SeqCli.EndToEnd/Support/TestDataFolder.cs
+++ b/test/SeqCli.EndToEnd/Support/TestDataFolder.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.IO;
+using Serilog;
+using Serilog.Core;
+
+namespace SeqCli.EndToEnd.Support
+{
+    sealed class TestDataFolder : IDisposable
+    {
+        readonly string _basePath;
+
+        public TestDataFolder()
+        {
+            _basePath = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "Seq Test",
+                Guid.NewGuid().ToString("n"));
+
+            Directory.CreateDirectory(_basePath);
+        }
+
+        public string Path => _basePath;
+
+        public string Folder(string relativePath)
+        {
+            return System.IO.Path.Combine(_basePath, relativePath);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_basePath, true);
+            }
+            catch (Exception)
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine("Failed to delete temporary path `{0}`.", Path);
+                Console.ResetColor();
+            }
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/TestDriver.cs
+++ b/test/SeqCli.EndToEnd/Support/TestDriver.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac.Features.OwnedInstances;
+
+namespace SeqCli.EndToEnd.Support
+{
+    class TestDriver
+    {
+        readonly TestConfiguration _configuration;
+        readonly IEnumerable<Func<Owned<IsolatedTestCase>>> _cases;
+
+        public TestDriver(
+            TestConfiguration configuration,
+            IEnumerable<Func<Owned<IsolatedTestCase>>> cases)
+        {
+            _configuration = configuration;
+            _cases = cases;
+        }
+
+        public async Task<int> Run()
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine($"TESTING {_configuration.TestedBinary}");
+            Console.ResetColor();
+
+            var count = 0;
+            var passed = new List<string>();
+            var failed = new List<string>();
+
+            foreach (var testCaseFactory in _cases.OrderBy(c => Guid.NewGuid()))
+            {
+                count++;
+                using (var testCase = testCaseFactory())
+                {
+                    Console.ForegroundColor = ConsoleColor.Cyan;
+                    Console.WriteLine($"RUNNING {testCase.Value.Description.PadRight(50)}");
+                    Console.ResetColor();
+
+                    try
+                    {
+                        await testCase.Value.ExecuteTestCaseAsync();
+
+                        passed.Add(testCase.Value.Description);
+                        Console.ForegroundColor = ConsoleColor.Green;
+                        Console.WriteLine("PASS");
+                        Console.ResetColor();
+                        break; // tries
+                    }
+                    catch (Exception ex)
+                    {
+                        failed.Add(testCase.Value.Description);
+
+                        Console.Write(testCase.Value.Output);
+
+                        Console.ForegroundColor = ConsoleColor.Red;
+                        Console.WriteLine("FAIL");
+                        Console.WriteLine(ex);
+                        Console.ResetColor();
+                    }
+                }
+            }
+
+            (var color, var failMsg) = failed.Count != 0 ? (ConsoleColor.Red, "Failures:") : (ConsoleColor.Green, "");
+            Console.ForegroundColor = color;
+            Console.WriteLine($"Done; {count} total, {passed.Count} pass, {failed.Count} fail. {failMsg}");
+
+            foreach (var fail in failed)
+            {
+                Console.WriteLine($"   {fail}");
+            }
+
+            Console.ResetColor();
+            return failed.Count;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/TestDriverModule.cs
+++ b/test/SeqCli.EndToEnd/TestDriverModule.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using Autofac;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+
+namespace SeqCli.EndToEnd
+{
+    class TestDriverModule : Module
+    {
+        readonly Args _args;
+
+        public TestDriverModule(Args args)
+        {
+            _args = args;
+        }
+        
+        protected override void Load(ContainerBuilder builder)
+        {
+            // This enables running the program with an argument like `*Ingest*` to match all test cases
+            // with `Ingest` in their names.
+            var testCases = _args.TestCases();
+            builder.RegisterAssemblyTypes(ThisAssembly)
+                .Where(t => testCases == null || testCases.Length == 0 || testCases.Any(c => c.IsMatch(t.FullName)))
+                .As<ICliTestCase>();
+
+            builder.RegisterType<TestConfiguration>().SingleInstance();
+            builder.RegisterType<TestDataFolder>().InstancePerOwned<IsolatedTestCase>();
+            builder.RegisterType<TestDriver>();
+            builder.RegisterType<CliCommandRunner>();
+
+            builder.Register(c =>
+                {
+                    var configuration = c.Resolve<TestConfiguration>();
+                    return configuration.SpawnServerProcess(c.Resolve<TestDataFolder>().Path);
+                })
+                .As<ITestProcess>()
+                .InstancePerOwned<IsolatedTestCase>();
+
+            builder.Register(c => new SeqConnection(c.Resolve<TestConfiguration>().ServerListenUrl))
+                .InstancePerOwned<IsolatedTestCase>();
+
+            builder.Register(c => new LoggerConfiguration()
+                    .AuditTo.Seq(c.Resolve<SeqConnection>().Client.ServerUrl)
+                    .CreateLogger())
+                .As<ILogger>()
+                .InstancePerOwned<IsolatedTestCase>();
+
+            builder.RegisterAdapter<ICliTestCase, IsolatedTestCase>((ctx, tc) =>
+                new IsolatedTestCase(
+                    ctx.Resolve<Lazy<ITestProcess>>(),
+                    ctx.Resolve<Lazy<SeqConnection>>(),
+                    ctx.Resolve<Lazy<ILogger>>(),
+                    ctx.Resolve<CliCommandRunner>(),
+                    tc));
+        }
+    }
+}

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -20,7 +20,7 @@ namespace SeqCli.Tests.PlainText
             Assert.Equal(hour, dto.Hour);
             Assert.Equal(minute, dto.Minute);
             Assert.Equal(second, dto.Second);
-            Assert.Equal(DateTimeOffset.Now.Offset, dto.Offset);
+            Assert.Equal(TimeZoneInfo.Local.GetUtcOffset(dto), dto.Offset);
         }
     }
 }


### PR DESCRIPTION
Fixes #30 

This allows us to write tests like:

```csharp
    public class LogCommandBasicsTestCase : ICliTestCase
    {
        public async Task ExecuteAsync(
            SeqConnection connection,
            ILogger logger,
            CliCommandRunner runner)
        {
            var exit = runner.Exec("log", "-m 'Hello, {Name}!' -p Name=world");
            Assert.Equal(0, exit);

            var events = await connection.Events.ListAsync(render: true, filter: "Name = 'world'");
            Assert.Single(events);

            var hello = events.Single();
            Assert.Equal("Hello, world!", hello.RenderedMessage);
        }
    }
```

Current caveats:

 * Assumes there's a `seq` binary on the `PATH`
 * Really only viable to run on Windows
 * Not yet invoked from CI
