### PR TITLE
JSON ingestion, more test coverage

### DIFF
--- a/src/SeqCli/Cli/Commands/IngestCommand.cs
+++ b/src/SeqCli/Cli/Commands/IngestCommand.cs
@@ -24,7 +24,6 @@ using Serilog;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Filters.Expressions;
-using Serilog.Formatting.Compact.Reader;
 
 namespace SeqCli.Cli.Commands
 {
@@ -89,7 +88,7 @@ namespace SeqCli.Cli.Commands
                     var input = inputFile ?? Console.In;
                     
                     var reader = _json ?
-                        (ILogEventReader)new ClefLogEventReader(input) :
+                        (ILogEventReader)new JsonLogEventReader(input) :
                         new PlainTextLogEventReader(input, _pattern);
                     
                     return await LogShipper.ShipEvents(

--- a/src/SeqCli/PlainText/Framing/FrameReader.cs
+++ b/src/SeqCli/PlainText/Framing/FrameReader.cs
@@ -123,7 +123,7 @@ namespace SeqCli.PlainText.Framing
             {
                 if (line == null) throw new ArgumentNullException(nameof(line));
                 var result = _frameStart(new TextSpan(line));
-                return result.HasValue && result.Value.Length > 0;
+                return result.HasValue;
             }
         }
     }

--- a/test/SeqCli.EndToEnd/Data/events.clef
+++ b/test/SeqCli.EndToEnd/Data/events.clef
@@ -1,0 +1,15 @@
+﻿{"@t":"2017-04-20T04:24:47.0251719Z","@mt":"Loop {Counter}","Counter":0}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":1}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":2}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":3}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":4}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":5}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":6}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":7}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":8}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":9}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":10}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":11}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":12}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":13}
+{"@t":"2017-04-20T04:24:47.0371689Z","@mt":"Loop {Counter}","Counter":14}

--- a/test/SeqCli.EndToEnd/Data/events.ndjson
+++ b/test/SeqCli.EndToEnd/Data/events.ndjson
@@ -1,0 +1,15 @@
+﻿{"Counter":0}
+{"Counter":1}
+{"Counter":2}
+{"Counter":3}
+{"Counter":4}
+{"Counter":5}
+{"Counter":6}
+{"Counter":7}
+{"Counter":8}
+{"Counter":9}
+{"Counter":10}
+{"Counter":11}
+{"Counter":12}
+{"Counter":13}
+{"Counter":14}

--- a/test/SeqCli.EndToEnd/Data/events.txt
+++ b/test/SeqCli.EndToEnd/Data/events.txt
@@ -1,0 +1,4 @@
+﻿Loop 1
+Loop 2
+
+Loop 3

--- a/test/SeqCli.EndToEnd/IngestCommand/NDJsonIngestionTestCase.cs
+++ b/test/SeqCli.EndToEnd/IngestCommand/NDJsonIngestionTestCase.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.IngestCommand
+{
+    // ReSharper disable once InconsistentNaming
+    public class NDJsonIngestionTestCase : ICliTestCase
+    {
+        public async Task ExecuteAsync(
+            SeqConnection connection,
+            ILogger logger,
+            CliCommandRunner runner)
+        {
+            var inputFile = Path.Combine("Data", "events.ndjson");
+            Assert.True(File.Exists(inputFile));
+
+            var exit = runner.Exec("ingest", $"--json -i {inputFile}");
+            Assert.Equal(0, exit);
+
+            var events = await connection.Events.ListAsync();
+            Assert.Equal(15, events.Count);
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/IngestCommand/SimpleTextIngestionTestCase.cs
+++ b/test/SeqCli.EndToEnd/IngestCommand/SimpleTextIngestionTestCase.cs
@@ -1,0 +1,27 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.IngestCommand
+{
+    public class SimpleTextIngestionTestCase : ICliTestCase
+    {
+        public async Task ExecuteAsync(
+            SeqConnection connection,
+            ILogger logger,
+            CliCommandRunner runner)
+        {
+            var inputFile = Path.Combine("Data", "events.txt");
+            Assert.True(File.Exists(inputFile));
+
+            var exit = runner.Exec("ingest", $"-i {inputFile}");
+            Assert.Equal(0, exit);
+
+            var events = await connection.Events.ListAsync();
+            Assert.Equal(3, events.Count);
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/IngestCommand/StrictClefIngestionTestCase.cs
+++ b/test/SeqCli.EndToEnd/IngestCommand/StrictClefIngestionTestCase.cs
@@ -1,0 +1,27 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.IngestCommand
+{
+    public class StrictClefIngestionTestCase : ICliTestCase
+    {
+        public async Task ExecuteAsync(
+            SeqConnection connection,
+            ILogger logger,
+            CliCommandRunner runner)
+        {
+            var inputFile = Path.Combine("Data", "events.clef");
+            Assert.True(File.Exists(inputFile));
+
+            var exit = runner.Exec("ingest", $"--json -i {inputFile}");
+            Assert.Equal(0, exit);
+
+            var events = await connection.Events.ListAsync();
+            Assert.Equal(15, events.Count);
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
+++ b/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
@@ -12,4 +12,15 @@
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
     <PackageReference Include="Seq.Api" Version="4.2.0" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="Data\events.clef">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\events.ndjson">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\events.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/test/SeqCli.EndToEnd/Support/IsolatedTestCase.cs
+++ b/test/SeqCli.EndToEnd/Support/IsolatedTestCase.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 using System.Threading.Tasks;
 using Seq.Api;
 using Serilog;

--- a/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
+++ b/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
@@ -6,7 +6,7 @@ namespace SeqCli.EndToEnd.Support
 {
     public class TestConfiguration
     {
-        public string ServerListenUrl { get; } = "http://127.0.0.1:9989";
+        public string ServerListenUrl { get; } = "http://localhost:9989";
 
         string EquivalentBaseDirectory { get; } = AppDomain.CurrentDomain.BaseDirectory
             .Replace(Path.Combine("test", "SeqCli.EndToEnd"), Path.Combine("src", "SeqCli"));

--- a/test/SeqCli.EndToEnd/Support/TestDriver.cs
+++ b/test/SeqCli.EndToEnd/Support/TestDriver.cs
@@ -46,7 +46,6 @@ namespace SeqCli.EndToEnd.Support
                         Console.ForegroundColor = ConsoleColor.Green;
                         Console.WriteLine("PASS");
                         Console.ResetColor();
-                        break; // tries
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Fixes #46. Any JSON document is now accepted as an event by `ingest --json`.