### PR TITLE
Fail correctly on non-object JSON values when ingesting JSON

### DIFF
--- a/src/SeqCli/Ingestion/JsonLogEventReader.cs
+++ b/src/SeqCli/Ingestion/JsonLogEventReader.cs
@@ -53,7 +53,9 @@ namespace SeqCli.Ingestion
             if (frame.IsOrphan)
                 throw new InvalidDataException($"A line arrived late or could not be parsed: `{frame.Value.Trim()}`.");
 
-            var jobject = _serializer.Deserialize<JObject>(new JsonTextReader(new StringReader(frame.Value)));
+            var frameValue = new JsonTextReader(new StringReader(frame.Value));
+            if (!(_serializer.Deserialize<JToken>(frameValue) is JObject jobject))
+                throw new InvalidDataException($"The line is not a JSON object: `{frame.Value.Trim()}`.");
 
             if (!jobject.TryGetValue("@t", out _))
                 jobject.Add("@t", new JValue(DateTime.UtcNow.ToString("O")));


### PR DESCRIPTION
When an invalid line in a JSON file takes the form of a JSON value that is not an object, e.g. `42`, `["foo"]`, JSON.NET will deserialize it as `JObject` but then trigger `InvalidCastException` internally in `Deserialize()`.

This change ensures that the exception type is one of the expected "invalid data format" exception types that `LogShipper` can deal with.