### PR TITLE
Update Seq.Api.dll; fixes #60

### DIFF
--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -23,12 +23,12 @@
     <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="serilog.filters.expressions" Version="1.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.0.0" />
-    <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="1.0.3-*" />
+    <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="1.0.3-dev-00034" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.0.1" />
     <PackageReference Include="Autofac" Version="4.0.0" />
     <PackageReference Include="Superpower" Version="2.0.0-*" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
-    <PackageReference Include="Seq.Api" Version="5.0.0-dev-00079" />
+    <PackageReference Include="Seq.Api" Version="5.0.0-dev-00084" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The pre-release v5 _Seq.Api_ package that this app depends upon caused problems when sending `SignalEntity` payloads due to an invalid `null` value for the renamed `IsRestricted` property. Updating the package fixes this.