### PR TITLE
New `user` and `dashboard` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,42 @@ Usage:
 seqcli <command> [<args>]
 ```
 
+### `apikey remove`
+
+Remove an API key from the server.
+
+Example:
+
+```
+seqcli apikey remove -t 'Test API Key'
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-t`, `--title=VALUE` | The title of the API key(s) to remove |
+| `-i`, `--id=VALUE` | The id of a single API key to remove |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
+
+### `apikey list`
+
+List available API keys.
+
+Example:
+
+```
+seqcli apikey list
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-t`, `--title=VALUE` | The title of the API key(s) to list |
+| `-i`, `--id=VALUE` | The id of a single API key to list |
+|       `--json` | Print events in newline-delimited JSON (the default is plain text) |
+|       `--no-color` | Don't colorize text output |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
+
 ### `config`
 
 View and set fields in the `SeqCli.json` file; run with no arguments to list all fields.
@@ -33,6 +69,67 @@ View and set fields in the `SeqCli.json` file; run with no arguments to list all
 | `-k`, `--key=VALUE` | The field, for example `connection.serverUrl` |
 | `-v`, `--value=VALUE` | The field value; if not specified, the command will print the current value |
 | `-c`, `--clear` | Clear the field |
+
+### `dashboard render`
+
+Produce a CSV or JSON result set from a dashboard chart.
+
+Example:
+
+```
+seqcli dashboard render -i dashboard-159 -c 'Response Time (ms)' --last 7d --by 1h
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-i`, `--id=VALUE` | The id of a single dashboard to render |
+| `-c`, `--chart=VALUE` | The title of a chart on the dashboard to render |
+|       `--last=VALUE` | A duration over which the chart should be rendered, e.g. `7d`; this will be aligned to an interval boundary; either `--last` or `--start` and `--end` must be specified |
+|       `--by=VALUE` | The time-slice interval for the chart data, as a duration, e.g. `1h` |
+|       `--start=VALUE` | ISO 8601 date/time to query from |
+|       `--end=VALUE` | Date/time to query to |
+|       `--signal=VALUE` | A signal expression or list of intersected signal ids to apply, for example `signal-1,signal-2` |
+|       `--timeout=VALUE` | The query execution timeout in milliseconds |
+|       `--json` | Print events in newline-delimited JSON (the default is plain text) |
+|       `--no-color` | Don't colorize text output |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
+
+### `dashboard remove`
+
+Remove a dashboard from the server.
+
+Example:
+
+```
+seqcli dashboard remove -i dashboard-159
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-i`, `--id=VALUE` | The id of a single dashboard to remove |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
+
+### `dashboard list`
+
+List dashboards.
+
+Example:
+
+```
+seqcli dashboard list
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-t`, `--title=VALUE` | The title of the dashboard(s) to list |
+| `-i`, `--id=VALUE` | The id of a single dashboard to list |
+| `-o`, `--owner=VALUE` | The id of the user to list dashboards for; by default, shared dashboards are listed |
+|       `--json` | Print events in newline-delimited JSON (the default is plain text) |
+|       `--no-color` | Don't colorize text output |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
 
 ### `help`
 
@@ -61,13 +158,14 @@ seqcli ingest -i events.txt --json --filter="@Level <> 'Debug'" -p Environment=T
 | Option | Description |
 | ------ | ----------- |
 | `-i`, `--input=VALUE` | File to ingest; if not specified, `STDIN` will be used |
-|       `--invalid-data=VALUE` | Specify how invalid data is handled: fail (default) or ignore |
+|       `--invalid-data=VALUE` | Specify how invalid data is handled: `fail` (default) or `ignore` |
 | `-p`, `--property=VALUE1=VALUE2` | Specify event properties, e.g. `-p Customer=C123 -p Environment=Production` |
 | `-x`, `--extract=VALUE` | An extraction pattern to apply to plain-text logs (ignored when `--json` is specified) |
 |       `--json` | Read the events as JSON (the default assumes plain text) |
 | `-f`, `--filter=VALUE` | Filter expression to select a subset of events |
+|       `--send-failure=VALUE` | Specify how connection failures are handled: `fail` (default), `continue`, or `ignore` |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
-| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `config.apiKey` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
 
 ### `log`
 
@@ -87,7 +185,7 @@ seqcli log -m 'Hello, {Name}!' -p Name=World -p App=Test
 | `-x`, `--exception=VALUE` | Additional exception or error information to send, if any |
 | `-p`, `--property=VALUE1=VALUE2` | Specify event properties, e.g. `-p Customer=C123 -p Environment=Production` |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
-| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `config.apiKey` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
 
 ### `query`
 
@@ -109,7 +207,7 @@ seqcli query -q "select count(*) from stream group by @Level" --start="2018-02-2
 |       `--json` | Print events in newline-delimited JSON (the default is plain text) |
 |       `--no-color` | Don't colorize text output |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
-| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `config.apiKey` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
 
 ### `search`
 
@@ -131,7 +229,59 @@ seqcli search -f "@Exception like '%TimeoutException%'" -c 30
 |       `--no-color` | Don't colorize text output |
 |       `--signal=VALUE` | A signal expression or list of intersected signal ids to apply, for example `signal-1,signal-2` |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
-| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `config.apiKey` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
+
+### `signal remove`
+
+Remove a signal from the server.
+
+Example:
+
+```
+seqcli signal remove -t 'Test Signal'
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-t`, `--title=VALUE` | The title of the signal(s) to remove |
+| `-i`, `--id=VALUE` | The id of a single signal to remove |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
+
+### `signal list`
+
+List available signals.
+
+Example:
+
+```
+seqcli signal list
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-t`, `--title=VALUE` | The title of the signal(s) to list |
+| `-i`, `--id=VALUE` | The id of a single signal to list |
+|       `--json` | Print events in newline-delimited JSON (the default is plain text) |
+|       `--no-color` | Don't colorize text output |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
+
+### `signal import`
+
+Import signals in newline-delimited JSON format.
+
+Example:
+
+```
+seqcli signal import -i ./Exceptions.json
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-i`, `--input=VALUE` | File to import; if not specified, `STDIN` will be used |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
 
 ### `tail`
 
@@ -144,7 +294,43 @@ Stream log events matching a filter.
 |       `--no-color` | Don't colorize text output |
 |       `--signal=VALUE` | A signal expression or list of intersected signal ids to apply, for example `signal-1,signal-2` |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
-| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `config.apiKey` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
+
+### `user remove`
+
+Remove a user from the server.
+
+Example:
+
+```
+seqcli user remove -n alice
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-n`, `--name=VALUE` | The username of the user(s) to remove |
+| `-i`, `--id=VALUE` | The id of a single user to remove |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
+
+### `user list`
+
+List users.
+
+Example:
+
+```
+seqcli user list
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-n`, `--name=VALUE` | The username of the user(s) to list |
+| `-i`, `--id=VALUE` | The id of a single user to list |
+|       `--json` | Print events in newline-delimited JSON (the default is plain text) |
+|       `--no-color` | Don't colorize text output |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default `connection.apiKey` value will be used |
 
 ### `version`
 

--- a/src/SeqCli/Cli/Command.cs
+++ b/src/SeqCli/Cli/Command.cs
@@ -67,7 +67,7 @@ namespace SeqCli.Cli
             if (errs.Any())
             {
                 ShowUsageErrors(errs);
-                return -1;
+                return 1;
             }
 
             return await Run(unrecognised);
@@ -78,7 +78,7 @@ namespace SeqCli.Cli
             if (unrecognised.Any())
             {
                 ShowUsageErrors(new [] { "Unrecognized options: " + string.Join(", ", unrecognised) });
-                return -1;
+                return 1;
             }
 
             return await Run();
@@ -94,16 +94,6 @@ namespace SeqCli.Cli
                 Log.Error(error);
 #pragma warning restore Serilog004 // Constant MessageTemplate verifier
             }
-        }
-
-        protected bool Require(string value, string name)
-        {
-            if (!Requirement.IsNonEmpty(value))
-            {
-                ShowUsageErrors(new [] { Requirement.NonEmptyDescription(name) });
-                return false;
-            }
-            return true;
         }
     }
 }

--- a/src/SeqCli/Cli/Commands/ApiKey/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/ApiKey/ListCommand.cs
@@ -18,7 +18,6 @@ using System.Threading.Tasks;
 using SeqCli.Cli.Features;
 using SeqCli.Config;
 using SeqCli.Connection;
-using Serilog;
 
 namespace SeqCli.Cli.Commands.ApiKey
 {
@@ -43,18 +42,12 @@ namespace SeqCli.Cli.Commands.ApiKey
 
         protected override async Task<int> Run()
         {
-            if (_entityIdentity.Title != null && _entityIdentity.Id != null)
-            {
-                Log.Error("Only one of either `title` or `id` can be specified");
-                return -1;
-            }
-
             var connection = _connectionFactory.Connect(_connection);
 
             var list = _entityIdentity.Id != null ?
                 new[] { await connection.ApiKeys.FindAsync(_entityIdentity.Id) } :
                 (await connection.ApiKeys.ListAsync())
-                    .Where(ak => _entityIdentity.Title != null || _entityIdentity.Title == ak.Title)
+                    .Where(ak => _entityIdentity.Title == null || _entityIdentity.Title == ak.Title)
                     .ToArray();
 
             foreach (var apiKey in list)

--- a/src/SeqCli/Cli/Commands/ApiKey/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/ApiKey/RemoveCommand.cs
@@ -43,7 +43,7 @@ namespace SeqCli.Cli.Commands.ApiKey
             if (_entityIdentity.Title == null && _entityIdentity.Id == null)
             {
                 Log.Error("A `title` or `id` must be specified");
-                return -1;
+                return 1;
             }
 
             var connection = _connectionFactory.Connect(_connection);
@@ -57,7 +57,7 @@ namespace SeqCli.Cli.Commands.ApiKey
             if (!toRemove.Any())
             {
                 Log.Error("No matching API key was found");
-                return -1;
+                return 1;
             }
 
             foreach (var apiKeyEntity in toRemove)

--- a/src/SeqCli/Cli/Commands/Dashboard/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Dashboard/RemoveCommand.cs
@@ -19,49 +19,42 @@ using SeqCli.Cli.Features;
 using SeqCli.Connection;
 using Serilog;
 
-namespace SeqCli.Cli.Commands.Signal
+namespace SeqCli.Cli.Commands.Dashboard
 {
-    [Command("signal", "remove", "Remove a signal from the server",
-        Example = "seqcli signal remove -t 'Test Signal'")]
+    [Command("dashboard", "remove", "Remove a dashboard from the server",
+        Example="seqcli dashboard remove -i dashboard-159")]
     class RemoveCommand : Command
     {
         readonly SeqConnectionFactory _connectionFactory;
 
-        readonly EntityIdentityFeature _entityIdentity;
         readonly ConnectionFeature _connection;
+
+        string _id;
 
         public RemoveCommand(SeqConnectionFactory connectionFactory)
         {
             _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
-            _entityIdentity = Enable(new EntityIdentityFeature("signal", "remove"));
+            Options.Add(
+                "i=|id=",
+                "The id of a single dashboard to remove",
+                t => _id = t);
+
             _connection = Enable<ConnectionFeature>();
         }
 
         protected override async Task<int> Run()
         {
-            if (_entityIdentity.Title == null && _entityIdentity.Id == null)
+            if (_id == null)
             {
-                Log.Error("A `title` or `id` must be specified");
+                Log.Error("An `id` must be specified");
                 return 1;
             }
 
             var connection = _connectionFactory.Connect(_connection);
 
-            var toRemove = _entityIdentity.Id != null ?
-                new[] { await connection.Signals.FindAsync(_entityIdentity.Id) } :
-                (await connection.Signals.ListAsync())
-                    .Where(signal => _entityIdentity.Title == signal.Title)
-                    .ToArray();
-
-            if (!toRemove.Any())
-            {
-                Log.Error("No matching signal was found");
-                return 1;
-            }
-
-            foreach (var signal in toRemove)
-                await connection.Signals.RemoveAsync(signal);
+            var toRemove = await connection.Dashboards.FindAsync(_id);
+            await connection.Dashboards.RemoveAsync(toRemove);
 
             return 0;
         }

--- a/src/SeqCli/Cli/Commands/Dashboard/RenderCommand.cs
+++ b/src/SeqCli/Cli/Commands/Dashboard/RenderCommand.cs
@@ -1,0 +1,219 @@
+﻿// Copyright 2018 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Seq.Api.Model.Monitoring;
+using Seq.Api.Model.Signals;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+using SeqCli.Syntax;
+using SeqCli.Util;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.Dashboard
+{
+    [Command("dashboard", "render", "Produce a CSV or JSON result set from a dashboard chart", 
+        Example="seqcli dashboard render -i dashboard-159 -c 'Response Time (ms)' --last 7d --by 1h")]
+    class RenderCommand : Command
+    {
+        const int MaximumReturnedHitRows = 10000;
+
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly DateRangeFeature _range;
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+        readonly SignalExpressionFeature _signal;
+
+        string _id, _lastDuration, _intervalDuration, _chartTitle;
+        int? _timeoutMS;
+
+        public RenderCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add(
+                "i=|id=",
+                "The id of a single dashboard to render",
+                t => _id = ArgumentString.Normalize(t));
+            Options.Add("c=|chart=", "The title of a chart on the dashboard to render",
+                c => _chartTitle = ArgumentString.Normalize(c));
+            Options.Add("last=",
+                "A duration over which the chart should be rendered, e.g. `7d`; this will be aligned to an interval boundary; either `--last` or `--start` and `--end` must be specified",
+                v => _lastDuration = ArgumentString.Normalize(v));
+            Options.Add("by=",
+                "The time-slice interval for the chart data, as a duration, e.g. `1h`",
+                v => _intervalDuration = ArgumentString.Normalize(v));
+            _range = Enable<DateRangeFeature>();
+            _signal = Enable<SignalExpressionFeature>();
+            Options.Add("timeout=", "The query execution timeout in milliseconds", v => _timeoutMS = int.Parse(v?.Trim() ?? "0"));
+            _output = Enable(new OutputFormatFeature(config.Output));
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            if (_id == null)
+            {
+                Log.Error("A dashboard id is required");
+                return 1;
+            }
+
+            if (_chartTitle == null)
+            {
+                Log.Error("A chart name is required");
+                return 1;
+            }
+
+            if (_range.Start == null && _range.End != null ||
+                _range.End == null && _range.Start != null)
+            {
+                Log.Error("If `--start` or `--end` is specified, both must be specified");
+                return 1;
+            }
+
+            if (_lastDuration == null && _range.Start == null)
+            {
+                Log.Error("A `--last` duration, or range `--start` and `--end`, is required");
+                return 1;
+            }
+
+            if (_lastDuration != null && _range.Start != null)
+            {
+                Log.Error("Only one of either `--last` or a `--start`/`--end` range can be specified");
+                return 1;
+            }
+
+            var dashboard = await connection.Dashboards.FindAsync(_id);
+            var charts = dashboard.Charts.Where(c => c.Title == _chartTitle).ToArray();
+
+            if (charts.Length == 0)
+            {
+                Log.Error("No matching chart was found");
+                return 1;
+            }
+
+            if (charts.Length > 1)
+            {
+                Log.Error("More than one matching chart was found");
+                return 1;
+            }
+
+            var chart = charts.Single();
+            var query = chart.Queries.Single();
+
+            var signal = Intersect(
+                _signal.Signal, 
+                dashboard.SignalExpression,
+                chart.SignalExpression,
+                query.SignalExpression);
+
+            TimeSpan? timeGrouping = null;
+            if (_intervalDuration != null)
+                timeGrouping = DurationMoniker.ToTimeSpan(_intervalDuration);
+
+            DateTime rangeStart, rangeEnd;
+            if (_range.Start.HasValue)
+            {
+                rangeStart = _range.Start.Value;
+                // ReSharper disable once PossibleInvalidOperationException
+                rangeEnd = _range.End.Value;
+            }
+            else
+            {
+                // Note, this is local time.
+                rangeEnd = DateTime.Now;
+                var last = DurationMoniker.ToTimeSpan(_lastDuration);
+                rangeStart = rangeEnd - last;
+                if (timeGrouping.HasValue)
+                {
+                    if (timeGrouping.Value >= TimeSpan.FromDays(1))
+                        rangeStart = new DateTime(rangeStart.Year, rangeStart.Month, rangeStart.Day, 0, 0, 0, DateTimeKind.Local);
+                    else if (timeGrouping.Value >= TimeSpan.FromHours(1))
+                        rangeStart = new DateTime(rangeStart.Year, rangeStart.Month, rangeStart.Day, rangeStart.Hour, 0, 0, DateTimeKind.Local);
+                    else if (timeGrouping.Value >= TimeSpan.FromMinutes(1))
+                        rangeStart = new DateTime(rangeStart.Year, rangeStart.Month, rangeStart.Day, rangeStart.Hour, rangeStart.Minute, 0, DateTimeKind.Local);
+                    else
+                        rangeStart = new DateTime(rangeStart.Year, rangeStart.Month, rangeStart.Day, rangeStart.Hour, rangeStart.Minute, rangeStart.Second, DateTimeKind.Local);
+                }
+            }
+
+            var q = BuildSqlQuery(query, rangeStart, rangeEnd, timeGrouping);
+
+            var timeout = _timeoutMS.HasValue ? TimeSpan.FromMilliseconds(_timeoutMS.Value) : (TimeSpan?)null;
+            if (_output.Json)
+            {
+                var result = await connection.Data.QueryAsync(q, signal: signal, timeout: timeout);
+
+                // Some friendlier JSON output is definitely possible here
+                Console.WriteLine(JsonConvert.SerializeObject(result));
+            }
+            else
+            {
+                var result = await connection.Data.QueryCsvAsync(q, signal: signal, timeout: timeout);
+                _output.WriteCsv(result);
+            }
+
+            return 0;
+        }
+
+        static string BuildSqlQuery(ChartQueryPart query, DateTime rangeStart, DateTime rangeEnd, TimeSpan? timeGrouping)
+        {
+            var sql = new QueryBuilder();
+
+            foreach (var measurement in query.Measurements)
+                sql.Select(measurement.Value, measurement.Label);
+
+            sql.FromStream = true;
+
+            sql.Where($"@Timestamp >= DateTime('{rangeStart:O}')");
+            sql.Where($"@Timestamp < DateTime('{rangeEnd:O}')");
+
+            if (!string.IsNullOrEmpty(query.Where))
+                sql.Where(query.Where);
+
+            if (timeGrouping.HasValue)
+                sql.GroupBy(timeGrouping.Value);
+
+            foreach (var grouping in query.GroupBy)
+                sql.GroupBy(grouping);            
+
+            sql.Limit = MaximumReturnedHitRows;
+
+            return sql.Build();
+        }
+
+        static SignalExpressionPart Intersect(params SignalExpressionPart[] expressions)
+        {
+            var result = (SignalExpressionPart) null;
+
+            foreach (var s in expressions)
+            {
+                if (result == null)
+                    result = s;
+                else if (s != null)
+                    result = SignalExpressionPart.Intersection(result, s);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/HelpCommand.cs
+++ b/src/SeqCli/Cli/Commands/HelpCommand.cs
@@ -91,7 +91,10 @@ namespace SeqCli.Cli.Commands
 
             foreach (var cmd in _availableCommands)
             {
-                Console.WriteLine($"### `{cmd.Metadata.Name}`");
+                if (cmd.Metadata.SubCommand != null)
+                    Console.WriteLine($"### `{cmd.Metadata.Name} {cmd.Metadata.SubCommand}`");
+                else
+                    Console.WriteLine($"### `{cmd.Metadata.Name}`");
                 Console.WriteLine();
                 Console.WriteLine(cmd.Metadata.HelpText + ".");
                 Console.WriteLine();

--- a/src/SeqCli/Cli/Commands/QueryCommand.cs
+++ b/src/SeqCli/Cli/Commands/QueryCommand.cs
@@ -41,7 +41,7 @@ namespace SeqCli.Cli.Commands
             Options.Add("q=|query=", "The query to execute", v => _query = v);
             _range = Enable<DateRangeFeature>();
             _signal = Enable<SignalExpressionFeature>();
-            Options.Add("timeout=", "The query execution timeout in milliseconds", v => _timeoutMS = int.Parse(v));
+            Options.Add("timeout=", "The query execution timeout in milliseconds", v => _timeoutMS = int.Parse(v?.Trim() ?? "0"));
             _output = Enable(new OutputFormatFeature(config.Output));
             _connection = Enable<ConnectionFeature>();
         }

--- a/src/SeqCli/Cli/Commands/User/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/User/RemoveCommand.cs
@@ -19,49 +19,49 @@ using SeqCli.Cli.Features;
 using SeqCli.Connection;
 using Serilog;
 
-namespace SeqCli.Cli.Commands.Signal
+namespace SeqCli.Cli.Commands.User
 {
-    [Command("signal", "remove", "Remove a signal from the server",
-        Example = "seqcli signal remove -t 'Test Signal'")]
+    [Command("user", "remove", "Remove a user from the server",
+        Example="seqcli user remove -n alice")]
     class RemoveCommand : Command
     {
         readonly SeqConnectionFactory _connectionFactory;
 
-        readonly EntityIdentityFeature _entityIdentity;
+        readonly UserIdentityFeature _userIdentity;
         readonly ConnectionFeature _connection;
 
         public RemoveCommand(SeqConnectionFactory connectionFactory)
         {
             _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
-            _entityIdentity = Enable(new EntityIdentityFeature("signal", "remove"));
+            _userIdentity = Enable(new UserIdentityFeature("remove"));
             _connection = Enable<ConnectionFeature>();
         }
 
         protected override async Task<int> Run()
         {
-            if (_entityIdentity.Title == null && _entityIdentity.Id == null)
+            if (_userIdentity.Name == null && _userIdentity.Id == null)
             {
-                Log.Error("A `title` or `id` must be specified");
+                Log.Error("A `name` or `id` must be specified");
                 return 1;
             }
 
             var connection = _connectionFactory.Connect(_connection);
 
-            var toRemove = _entityIdentity.Id != null ?
-                new[] { await connection.Signals.FindAsync(_entityIdentity.Id) } :
-                (await connection.Signals.ListAsync())
-                    .Where(signal => _entityIdentity.Title == signal.Title)
+            var toRemove = _userIdentity.Id != null ?
+                new[] {await connection.Users.FindAsync(_userIdentity.Id)} :
+                (await connection.Users.ListAsync())
+                    .Where(u => _userIdentity.Name == u.Username) 
                     .ToArray();
 
             if (!toRemove.Any())
             {
-                Log.Error("No matching signal was found");
+                Log.Error("No matching user was found");
                 return 1;
             }
 
-            foreach (var signal in toRemove)
-                await connection.Signals.RemoveAsync(signal);
+            foreach (var userEntity in toRemove)
+                await connection.Users.RemoveAsync(userEntity);
 
             return 0;
         }

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -104,7 +104,7 @@ namespace SeqCli.Cli.Features
             else
             {
                 var dyn = (dynamic) jo;
-                Console.WriteLine($"{entity.Id} {dyn.Title ?? dyn.Name}");
+                Console.WriteLine($"{entity.Id} {dyn.Title ?? dyn.Name ?? dyn.Username}");
             }
         }
     }

--- a/src/SeqCli/Cli/Features/UserIdentityFeature.cs
+++ b/src/SeqCli/Cli/Features/UserIdentityFeature.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2018 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace SeqCli.Cli.Features
+{
+    class UserIdentityFeature : CommandFeature
+    {
+        readonly string _verb;
+
+        string _name;
+        string _id;
+
+        public UserIdentityFeature(string verb)
+        {
+            _verb = verb ?? throw new ArgumentNullException(nameof(verb));
+        }
+
+        public override void Enable(OptionSet options)
+        {
+            options.Add(
+                "n=|name=",
+                $"The username of the user(s) to {_verb}",
+                t => _name = t);
+
+            options.Add(
+                "i=|id=",
+                $"The id of a single user to {_verb}",
+                t => _id = t);
+        }
+
+        public override IEnumerable<string> GetUsageErrors()
+        {
+            if (Name != null && Id != null)
+                yield return "Only one of either `name` or `id` can be specified";
+        }
+
+        public string Name => string.IsNullOrWhiteSpace(_name) ? null : _name.Trim();
+
+        public string Id => string.IsNullOrWhiteSpace(_id) ? null : _id.Trim();
+    }
+}

--- a/src/SeqCli/Program.cs
+++ b/src/SeqCli/Program.cs
@@ -57,7 +57,7 @@ namespace SeqCli
             {
                 Log.Debug(ex, "Unhandled command exception");
                 Log.Fatal("The command failed: {UnhandledExceptionMessage}", Presentation.FormattedMessage(ex));
-                return -1;
+                return 1;
             }
             finally
             {

--- a/src/SeqCli/Syntax/CombinedFilterBuilder.cs
+++ b/src/SeqCli/Syntax/CombinedFilterBuilder.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2018 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SeqCli.Syntax
+{
+    class CombinedFilterBuilder
+    {
+        readonly List<string> _elements = new List<string>();
+
+        public CombinedFilterBuilder Intersect(string filter)
+        {
+            if (filter == null)
+                return this;
+
+            if (string.IsNullOrWhiteSpace(filter))
+                throw new ArgumentNullException(nameof(filter));
+
+            _elements.Add(filter.Trim());
+            return this;
+        }
+
+        public string Build()
+        {
+            if (!_elements.Any())
+                return null;            
+
+            if (_elements.Count == 1)
+                return _elements.Single();
+
+            return "(" + string.Join(")and(", _elements) + ")";
+        }
+    }
+}

--- a/src/SeqCli/Syntax/DurationMoniker.cs
+++ b/src/SeqCli/Syntax/DurationMoniker.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2018 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace SeqCli.Syntax
+{
+    static class DurationMoniker
+    {
+        public static string FromTimeSpan(TimeSpan timeSpan)
+        {
+            if (timeSpan == TimeSpan.Zero || Math.Abs(timeSpan.Ticks) < TimeSpan.FromMilliseconds(1).Ticks)
+                return "0d";
+
+            return new[] {
+                Component(timeSpan.TotalDays, "d"),
+                Component(timeSpan.TotalHours, "h"),
+                Component(timeSpan.TotalMinutes, "m"),
+                Component(timeSpan.TotalSeconds, "s"),
+                Component(timeSpan.TotalMilliseconds, "ms")
+            }.First(c => c != "");
+        }
+
+        static string Component(double value, string moniker)
+        {
+            if (moniker == null) throw new ArgumentNullException(nameof(moniker));
+
+            if (Math.Abs(value) < double.Epsilon || Math.Abs(value - (int)value) > double.Epsilon)
+                return "";
+
+            return ((int)value).ToString(CultureInfo.InvariantCulture) + moniker;
+        }
+
+        public static TimeSpan ToTimeSpan(string duration)
+        {
+            if (duration == null) throw new ArgumentNullException(nameof(duration));
+
+            // This is not at all robust; we could use a decent duration parser for use here in `seqcli`.
+
+            if (duration.EndsWith("ms"))
+                return TimeSpan.FromMilliseconds(int.Parse(duration.Substring(0, duration.Length - 2)));
+
+            var value = int.Parse(duration.Substring(0, duration.Length - 1));
+            switch (duration[duration.Length - 1])
+            {
+                case 'd':
+                    return TimeSpan.FromDays(value);
+                case 'h':
+                    return TimeSpan.FromHours(value);
+                case 'm':
+                    return TimeSpan.FromMinutes(value);
+                case 's':
+                    return TimeSpan.FromSeconds(value);
+                default:
+                    throw new ArgumentException($"Unrecognized duration `{duration}`.");
+            }
+        }
+    }
+}

--- a/src/SeqCli/Syntax/QueryBuilder.cs
+++ b/src/SeqCli/Syntax/QueryBuilder.cs
@@ -1,0 +1,118 @@
+﻿// Copyright 2018 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SeqCli.Syntax
+{
+    class QueryBuilder
+    {
+        readonly List<(string, string)> _columns = new List<(string, string)>();
+        readonly List<string> _where = new List<string>();
+        readonly List<string> _groupBy = new List<string>();
+        readonly List<string> _having = new List<string>();
+
+        public void Select(string value, string label)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+            _columns.Add((value, label));
+        }
+
+        public bool FromStream { get; set; }
+
+        public void Where(string predicate)
+        {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            _where.Add(predicate);
+        }
+
+        public void GroupBy(string grouping)
+        {
+            if (grouping == null) throw new ArgumentNullException(nameof(grouping));
+            _groupBy.Add(grouping);
+        }
+
+        public void GroupBy(TimeSpan interval)
+        {
+            _groupBy.Add($"time({DurationMoniker.FromTimeSpan(interval)})");
+        }
+
+        public void Having(string predicate)
+        {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            _having.Add(predicate);
+        }
+
+        public int? Limit { get; set; }
+
+        public string Build()
+        {
+            var result = new StringBuilder(140);
+
+            result.Append("select");
+            var selectDelim = " ";
+            foreach (var (value, label) in _columns)
+            {
+                result.Append($"{selectDelim}{value}");
+                selectDelim = ", ";
+
+                if (label != null)
+                    result.Append($" as {label}");
+            }
+
+            if (FromStream)
+                result.Append(" from stream");
+
+            if (_where.Any())
+            {
+                var builder = new CombinedFilterBuilder();
+
+                foreach (var where in _where)
+                    builder.Intersect(where);
+
+                result.Append($" where {builder.Build()}");
+            }
+
+            if (_groupBy.Any())
+            {
+                result.Append(" group by");
+
+                var groupDelim = " ";
+                foreach (var grouping in _groupBy)
+                {
+                    result.Append($"{groupDelim}{grouping}");
+                    groupDelim = ", ";
+                }
+            }
+
+            if (_having.Any())
+            {
+                var builder = new CombinedFilterBuilder();
+
+                foreach (var having in _having)
+                    builder.Intersect(having);
+
+                result.Append($" having {builder.Build()}");
+            }
+
+            if (Limit.HasValue)
+                result.Append($" limit {Limit}");
+
+            return result.ToString();
+        }
+    }
+}

--- a/src/SeqCli/Util/ArgumentString.cs
+++ b/src/SeqCli/Util/ArgumentString.cs
@@ -12,18 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace SeqCli.Cli
+namespace SeqCli.Util
 {
-    static class Requirement
+    static class ArgumentString
     {
-        public static bool IsNonEmpty(string value)
+        public static string Normalize(string argument)
         {
-            return !string.IsNullOrWhiteSpace(value);
-        }
-
-        public static string NonEmptyDescription(string optionName)
-        {
-            return $"a {optionName} is required";
+            return string.IsNullOrWhiteSpace(argument) ? null : argument.Trim();
         }
     }
 }

--- a/test/SeqCli.EndToEnd/Dashboard/RenderTestCase.cs
+++ b/test/SeqCli.EndToEnd/Dashboard/RenderTestCase.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Dashboard
+{
+    public class RenderTestcase : ICliTestCase
+    {
+        public Task ExecuteAsync(
+            SeqConnection connection,
+            ILogger logger,
+            CliCommandRunner runner)
+        {
+            var exit = runner.Exec("dashboard list");
+            Assert.Equal(0, exit);
+
+            var id = runner.LastRunProcess.Output.Split(' ')[0];
+
+            exit = runner.Exec("dashboard render", $"-i {id} -c \"All Events\" --last 1d --by 1h");
+            Assert.Equal(0, exit);
+
+            var lines = new StringReader(runner.LastRunProcess.Output);
+            var firstLine = lines.ReadLine();
+            Assert.Equal("\"time\",\"count\"", firstLine);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Signal/SignalBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Signal/SignalBasicsTestCase.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Signal
+{
+    public class SignalBasicsTestcase : ICliTestCase
+    {
+        public Task ExecuteAsync(
+            SeqConnection connection,
+            ILogger logger,
+            CliCommandRunner runner)
+        {
+            var exit = runner.Exec("signal list", "-i signal-none");
+            Assert.Equal(1, exit);
+
+            exit = runner.Exec("signal list", "-t Warnings");
+            Assert.Equal(0, exit);
+
+            var output = runner.LastRunProcess.Output;
+            Assert.Equal("signal-m33302 Warnings", output.Trim());
+
+            exit = runner.Exec("signal remove", "-t Warnings");
+            Assert.Equal(0, exit);
+
+            exit = runner.Exec("signal list", "-t Warnings");
+            Assert.Equal(1, exit);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/SeqCli.Tests/Syntax/DurationMonikerTests.cs
+++ b/test/SeqCli.Tests/Syntax/DurationMonikerTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using SeqCli.Syntax;
+using Xunit;
+
+namespace SeqCli.Tests.Syntax
+{
+    public class DurationMonikerTests
+    {
+        [Theory]
+        [InlineData("1d", 1000L * 60 * 60 * 24)]
+        [InlineData("7d", 1000L * 60 * 60 * 24 * 7)]
+        [InlineData("30ms", 30L)]
+        public void MonikersAreParsedAndFormatted(string duration, long equivalentMilliseconds)
+        {
+            var ts = DurationMoniker.ToTimeSpan(duration);
+            Assert.Equal(TimeSpan.FromMilliseconds(equivalentMilliseconds), ts);
+
+            var dm = DurationMoniker.FromTimeSpan(ts);
+            Assert.Equal(duration, dm);
+        }
+    }
+}


### PR DESCRIPTION
Adds new `user` and `dashboard` commands, including a handy `dashboard render` that extracts the result set behind a chart (we have a lot of requests for this kind of thing in ETL/reporting scenarios).

![image](https://user-images.githubusercontent.com/342712/44505534-3adbb900-a6e5-11e8-8fe3-235de0a83b61.png)
