### PR TITLE
Handle non-Serilog level names in tail/search

### DIFF
--- a/src/SeqCli/Cli/Commands/SearchCommand.cs
+++ b/src/SeqCli/Cli/Commands/SearchCommand.cs
@@ -115,7 +115,9 @@ namespace SeqCli.Cli.Commands
                 LevelMapping.ToSerilogLevel(evt.Level),
                 string.IsNullOrWhiteSpace(evt.Exception) ? null : new TextException(evt.Exception),
                 new MessageTemplate(evt.MessageTemplateTokens.Select(ToMessageTemplateToken)),
-                evt.Properties.Select(p => CreateProperty(p.Name, p.Value)));
+                evt.Properties
+                    .Select(p => CreateProperty(p.Name, p.Value))
+                    .Concat(new[] { new LogEventProperty(SurrogateLevelProperty.PropertyName, new ScalarValue(evt.Level)) }));
         }
 
         static MessageTemplateToken ToMessageTemplateToken(MessageTemplateTokenPart mttp)

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -14,16 +14,15 @@
 
 using System;
 using Destructurama;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Seq.Api.Model;
 using SeqCli.Config;
 using SeqCli.Csv;
+using SeqCli.Levels;
 using SeqCli.Output;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
-using Serilog.Formatting.Compact;
 using Serilog.Sinks.SystemConsole.Themes;
 
 namespace SeqCli.Cli.Features
@@ -58,11 +57,16 @@ namespace SeqCli.Cli.Features
                 .Enrich.With<RedundantEventTypeRemovalEnricher>();
 
             if (_json)
-                outputConfiguration.WriteTo.Console(new CompactJsonFormatter());
+            {
+                outputConfiguration.WriteTo.Console(new SurrogateLevelAwareCompactJsonFormatter());
+            }
             else
+            {
+                outputConfiguration.Enrich.With<SurrogateLevelRemovalEnricher>();
                 outputConfiguration.WriteTo.Console(
                     outputTemplate: "[{Timestamp:o} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}",
                     theme: Theme);
+            }
 
             return outputConfiguration.CreateLogger();
         }

--- a/src/SeqCli/Output/SurrogateLevelRemovalEnricher.cs
+++ b/src/SeqCli/Output/SurrogateLevelRemovalEnricher.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2018 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using SeqCli.Levels;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SeqCli.Output
+{
+    public class SurrogateLevelRemovalEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            logEvent.RemovePropertyIfPresent(SurrogateLevelProperty.PropertyName);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #54.

Because of the approach taken, any non-Serilog level name that's interpreted as equivalent to "Information" won't be written in JSON output. Information == no level is a CLEF convention; we might revisit this sometime.