### PR TITLE
Allow owner to be specified when searching for shareable items

### DIFF
--- a/src/SeqCli/Cli/Commands/Signal/ImportCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/ImportCommand.cs
@@ -30,6 +30,7 @@ namespace SeqCli.Cli.Commands.Signal
     {
         readonly SeqConnectionFactory _connectionFactory;
         readonly FileInputFeature _fileInputFeature;
+        readonly EntityOwnerFeature _entityOwner;
         readonly ConnectionFeature _connection;
         
         readonly JsonSerializer _serializer = JsonSerializer.Create(
@@ -42,6 +43,7 @@ namespace SeqCli.Cli.Commands.Signal
             if (config == null) throw new ArgumentNullException(nameof(config));
             _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
             _fileInputFeature = Enable(new FileInputFeature("File to import"));
+            _entityOwner = Enable(new EntityOwnerFeature("signal", "import"));
             _connection = Enable<ConnectionFeature>();
         }
 
@@ -68,6 +70,7 @@ namespace SeqCli.Cli.Commands.Signal
                         dest.IsProtected = src.IsProtected;
                         dest.Filters = src.Filters;
                         dest.TaggedProperties = src.TaggedProperties;
+                        dest.OwnerId = _entityOwner.OwnerId;
                         await connection.Signals.AddAsync(dest);
                     }
 

--- a/src/SeqCli/Cli/Commands/Signal/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/ListCommand.cs
@@ -29,6 +29,7 @@ namespace SeqCli.Cli.Commands.Signal
         readonly EntityIdentityFeature _entityIdentity;
         readonly ConnectionFeature _connection;
         readonly OutputFormatFeature _output;
+        readonly EntityOwnerFeature _entityOwner;
 
         public ListCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
         {
@@ -36,6 +37,7 @@ namespace SeqCli.Cli.Commands.Signal
             _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
             _entityIdentity = Enable(new EntityIdentityFeature("signal", "list"));
+            _entityOwner = Enable(new EntityOwnerFeature("signal", "list", _entityIdentity));
             _output = Enable(new OutputFormatFeature(config.Output));
             _connection = Enable<ConnectionFeature>();
         }
@@ -46,7 +48,7 @@ namespace SeqCli.Cli.Commands.Signal
 
             var list = _entityIdentity.Id != null ?
                 new[] { await connection.Signals.FindAsync(_entityIdentity.Id) } :
-                (await connection.Signals.ListAsync())
+                (await connection.Signals.ListAsync(ownerId: _entityOwner.OwnerId, shared: _entityOwner.IncludeShared))
                     .Where(signal => _entityIdentity.Title == null || _entityIdentity.Title == signal.Title)
                     .ToArray();
 
@@ -59,3 +61,4 @@ namespace SeqCli.Cli.Commands.Signal
         }
     }
 }
+

--- a/src/SeqCli/Cli/Commands/Signal/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/RemoveCommand.cs
@@ -29,12 +29,14 @@ namespace SeqCli.Cli.Commands.Signal
 
         readonly EntityIdentityFeature _entityIdentity;
         readonly ConnectionFeature _connection;
+        readonly EntityOwnerFeature _entityOwner;
 
         public RemoveCommand(SeqConnectionFactory connectionFactory)
         {
             _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
             _entityIdentity = Enable(new EntityIdentityFeature("signal", "remove"));
+            _entityOwner = Enable(new EntityOwnerFeature("signal", "remove", _entityIdentity));
             _connection = Enable<ConnectionFeature>();
         }
 
@@ -50,7 +52,7 @@ namespace SeqCli.Cli.Commands.Signal
 
             var toRemove = _entityIdentity.Id != null ?
                 new[] { await connection.Signals.FindAsync(_entityIdentity.Id) } :
-                (await connection.Signals.ListAsync())
+                (await connection.Signals.ListAsync(ownerId: _entityOwner.OwnerId, shared: _entityOwner.IncludeShared))
                     .Where(signal => _entityIdentity.Title == signal.Title)
                     .ToArray();
 

--- a/src/SeqCli/Cli/Commands/TailCommand.cs
+++ b/src/SeqCli/Cli/Commands/TailCommand.cs
@@ -62,7 +62,10 @@ namespace SeqCli.Cli.Commands
             }
 
             using (var output = _output.CreateOutputLogger())
-            using (var stream = await connection.Events.StreamAsync<JObject>(filter: strict, signal: _signal.Signal, token: cancel.Token))
+            using (var stream = await connection.Events.StreamAsync<JObject>(
+                filter: strict, 
+                signal: _signal.Signal,
+                cancellationToken: cancel.Token))
             {
                 var subscription = stream
                     .Select(JsonLogEventReader.ReadFromJObject)

--- a/src/SeqCli/Cli/Features/EntityOwnerFeature.cs
+++ b/src/SeqCli/Cli/Features/EntityOwnerFeature.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2018 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace SeqCli.Cli.Features
+{
+    class EntityOwnerFeature : CommandFeature
+    {
+        readonly string _entityName;
+        readonly string _verb;
+        readonly EntityIdentityFeature _identityFeature;
+
+        public EntityOwnerFeature(string entityName, string verb, EntityIdentityFeature identityFeature = null)
+        {
+            _entityName = entityName ?? throw new ArgumentNullException(nameof(entityName));
+            _verb = verb ?? throw new ArgumentNullException(nameof(verb));
+            _identityFeature = identityFeature;
+        }
+
+        public override void Enable(OptionSet options)
+        {
+            options.Add(
+                "o=|owner=",
+                $"The id of the user to {_verb} {_entityName}s for; by default, shared {_entityName}s are listed",
+                o =>
+                {
+                    OwnerId = StringNormalizationExtensions.Normalize(o);
+                    if (OwnerId != null)
+                        IncludeShared = false;
+                });
+        }
+
+        public override IEnumerable<string> GetUsageErrors()
+        {
+
+            if (OwnerId != null && _identityFeature?.Id != null)
+            {
+                yield return "Only one of either `owner` or `id` can be specified";
+            }
+        }
+
+        public string OwnerId { get; set; }
+
+        public bool IncludeShared { get; set; } = true;
+    }
+}

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -29,6 +29,6 @@
     <PackageReference Include="Superpower" Version="2.0.0" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
-    <PackageReference Include="Seq.Api" Version="5.0.0-dev-00084" />
+    <PackageReference Include="Seq.Api" Version="5.0.0-dev-00088" />
   </ItemGroup>
 </Project>

--- a/test/SeqCli.EndToEnd/Signal/SignalBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Signal/SignalBasicsTestCase.cs
@@ -25,8 +25,11 @@ namespace SeqCli.EndToEnd.Signal
             exit = runner.Exec("signal remove", "-t Warnings");
             Assert.Equal(0, exit);
 
-            exit = runner.Exec("signal list", "-t Warnings");
+            exit = runner.Exec("signal list", "-i signal-m33302");
             Assert.Equal(1, exit);
+
+            exit = runner.Exec("signal list", "-t Warnings");
+            Assert.Equal(0, exit);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
This is required for compatibility with Seq 5 beta 2, which will be out shortly.

Example usage:

```
seqcli signal list
seqcli signal list -o user-admin
```
