### PR TITLE
Send API key correctly when logging/ingesting

### DIFF
--- a/src/SeqCli/Api/ApiConstants.cs
+++ b/src/SeqCli/Api/ApiConstants.cs
@@ -18,5 +18,6 @@ namespace SeqCli.Api
     {
         public const string ClefMediatType = "application/vnd.serilog.clef";
         public const string IngestionEndpoint = "api/events/raw";
+        public const string ApiKeyHeaderName = "X-Seq-ApiKey";
     }
 }

--- a/src/SeqCli/Cli/Commands/IngestCommand.cs
+++ b/src/SeqCli/Cli/Commands/IngestCommand.cs
@@ -86,9 +86,11 @@ namespace SeqCli.Cli.Commands
                     var reader = _json ?
                         (ILogEventReader)new JsonLogEventReader(input) :
                         new PlainTextLogEventReader(input, _pattern);
-                    
+
+                    _connectionFactory.TryGetApiKey(_connection, out var apiKey);
                     return await LogShipper.ShipEvents(
                         _connectionFactory.Connect(_connection),
+                        apiKey,
                         reader,
                         enrichers,
                         _invalidDataHandlingFeature.InvalidDataHandling,

--- a/src/SeqCli/Cli/Commands/LogCommand.cs
+++ b/src/SeqCli/Cli/Commands/LogCommand.cs
@@ -104,10 +104,9 @@ namespace SeqCli.Cli.Commands
             var connection = _connectionFactory.Connect(_connection);
 
             var request = new HttpRequestMessage(HttpMethod.Post, ApiConstants.IngestionEndpoint) {Content = content};
+            if (_connectionFactory.TryGetApiKey(_connection, out var apiKey))
+                request.Headers.Add(ApiConstants.ApiKeyHeaderName, apiKey);
 
-            if (_connection.IsApiKeySpecified)
-                request.Headers.Add("X-Seq-ApiKey", _connection.ApiKey);
-            
             var result = await connection.Client.HttpClient.SendAsync(request);
 
             if (result.IsSuccessStatusCode)

--- a/src/SeqCli/Connection/SeqConnectionFactory.cs
+++ b/src/SeqCli/Connection/SeqConnectionFactory.cs
@@ -46,5 +46,15 @@ namespace SeqCli.Connection
 
             return new SeqConnection(url, apiKey);
         }
+
+        public bool TryGetApiKey(ConnectionFeature connection, out string apiKey)
+        {
+            apiKey = connection.IsUrlSpecified ?
+                                connection.ApiKey :
+                                connection.IsApiKeySpecified ? 
+                                    connection.ApiKey :
+                                    _config.Connection.ApiKey;
+            return apiKey != null;
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a bug causing API keys not to be sent by the `seqcli ingest` command, and the default API in _SeqCli.json_ to be ignored by `seqcli log`.

Ideally, _Seq.Api_ should be extended to cover these use cases in the future.