### PR TITLE
Add an initial dockerfile

### DIFF
--- a/dockerfiles/seqcli/.gitignore
+++ b/dockerfiles/seqcli/.gitignore
@@ -1,0 +1,1 @@
+seqcli.tar.gz

--- a/dockerfiles/seqcli/Dockerfile
+++ b/dockerfiles/seqcli/Dockerfile
@@ -1,0 +1,25 @@
+# based on: https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile
+
+FROM ubuntu:18.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        liblmdb-dev \
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu60 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        libstdc++6 \
+        zlib1g \
+&& rm -rf /var/lib/apt/lists/*
+
+COPY run.sh /run.sh
+ADD seqcli.tar.gz /tmp/
+RUN mv /tmp/seqcli-* /bin/seqcli
+
+ENTRYPOINT ["/run.sh"]
+
+LABEL Description="Seq" Vendor="Datalust Pty Ltd"

--- a/dockerfiles/seqcli/run.sh
+++ b/dockerfiles/seqcli/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Default arguments to those passed to the container
+args=$@
+
+exec /bin/seqcli/seqcli $args


### PR DESCRIPTION
This `Dockerfile` expects the `seqcli-{version}-linux-x64.tar.gz` to bundle into a container. Having a container for `seqcli` will be helpful for workflows that are already built on Docker.