### PR TITLE
Support more verbose output

### DIFF
--- a/src/SeqCli/Cli/Command.cs
+++ b/src/SeqCli/Cli/Command.cs
@@ -16,7 +16,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using SeqCli.Config;
 using Serilog;
+using Serilog.Events;
 
 namespace SeqCli.Cli
 {
@@ -27,6 +29,10 @@ namespace SeqCli.Cli
         protected Command()
         {
             Options = new OptionSet();
+            
+            Options.Add("verbose",
+                "Output more detailed diagnostic information",
+                v => { LogConfig.SharedLevelSwitch.MinimumLevel = LogEventLevel.Debug; });
         }
 
         public OptionSet Options { get; }

--- a/src/SeqCli/Config/LogConfig.cs
+++ b/src/SeqCli/Config/LogConfig.cs
@@ -1,0 +1,10 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SeqCli.Config
+{
+    static class LogConfig
+    {
+        internal static readonly LoggingLevelSwitch SharedLevelSwitch = new LoggingLevelSwitch(LogEventLevel.Error);
+    }
+}

--- a/src/SeqCli/Program.cs
+++ b/src/SeqCli/Program.cs
@@ -17,6 +17,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Autofac;
 using SeqCli.Cli;
+using SeqCli.Config;
 using SeqCli.Util;
 using Serilog;
 using Serilog.Events;
@@ -28,7 +29,7 @@ namespace SeqCli
         static async Task<int> Main(string[] args)
         {
             Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Error()
+                .MinimumLevel.ControlledBy(LogConfig.SharedLevelSwitch)
                 .WriteTo.Console(
                     outputTemplate: "{Message:lj}{NewLine}{Exception}",
                     standardErrorFromLevel: LevelAlias.Minimum)


### PR DESCRIPTION
A slightly hacky implementation of a universal `--verbose` option that toggles a shared logging level switch.

I haven't thought hard about the implementation itself or the way it's exposed in the command line yet, so we should work through that before merging.