### PR TITLE
Fix test case covering API key JSON output formatting

### DIFF
--- a/test/SeqCli.EndToEnd/ApiKey/ApiKeyCreateTestCase.cs
+++ b/test/SeqCli.EndToEnd/ApiKey/ApiKeyCreateTestCase.cs
@@ -13,11 +13,11 @@ namespace SeqCli.EndToEnd.ApiKey
             var exit = runner.Exec("apikey create", "-t Test");
             Assert.Equal(0, exit);
 
-            exit = runner.Exec("apikey list", "-t Test --no-color");
+            exit = runner.Exec("apikey list", "-t Test --json --no-color");
             Assert.Equal(0, exit);
 
             var output = runner.LastRunProcess.Output;
-            Assert.Contains("\"AssignedPermissions\":[\"Ingest\"]", output);
+            Assert.Contains("\"AssignedPermissions\": [\"Ingest\"]", output);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
This was missed in the last PR. SUT code is fine, but the test case is broken.