### PR TITLE
Added `w3cdt` W3C/IIS log file timestamp matcher

### DIFF
--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -64,15 +64,29 @@ namespace SeqCli.PlainText.Extraction
                     if (dt > DateTime.Now.AddDays(7)) // Tailing a late December log in early January :-)
                         dt = dt.AddYears(-1);
                     return (object) dt;
-                });            
+                });
 
+        [Matcher("w3cdt")]
+        // "yyyy-MM-dd HH:mm:ss"
+        public static TextParser<object> W3CTimestamp { get; } =
+            Span.Regex("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}")
+                .Select(span => (object)DateTimeOffset.ParseExact(
+                    span.ToStringValue(),
+                    "yyyy-MM-dd HH:mm:ss",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+
+        [Matcher("serilogdt")]
+        // "yyyy-MM-dd HH:mm:ss.fff zzz"
         public static TextParser<object> SerilogFileTimestamp { get; } =
-            Span.Regex("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d+)? ([+-]\\d{2}:\\d{2})?")
-                .Select(span => (object) DateTimeOffset.ParseExact(span.ToStringValue(), "yyyy-MM-dd HH:mm:ss.fff zzz", CultureInfo.InvariantCulture));
+            Span.Regex("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d+)?( [+-]\\d{2}:\\d{2})?")
+                .Select(span => (object)DateTimeOffset.Parse(span.ToStringValue(), CultureInfo.InvariantCulture));
 
         [Matcher("timestamp")]
         public static TextParser<object> Timestamp { get; } =
-            Iso8601DateTime.Try().Or(SerilogFileTimestamp).Try().Or(SyslogDefaultTimestamp);
+            Iso8601DateTime.Try()     
+                .Or(SerilogFileTimestamp).Try()
+                .Or(SyslogDefaultTimestamp);
 
         [Matcher("trailingindent")]
         public static TextParser<object> MultiLineMessage { get; } =

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -22,5 +22,21 @@ namespace SeqCli.Tests.PlainText
             Assert.Equal(second, dto.Second);
             Assert.Equal(TimeZoneInfo.Local.GetUtcOffset(dto), dto.Offset);
         }
+
+        [Fact]
+        public void TimestampMatcherCorrectlyExcludesTrailingWhitespace()
+        {
+            var timestamp = "2019-03-26 21:48:26 xxx";
+            var result = Matchers.Timestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2019-03-26 21:48:26 +10:00"), result);
+        }
+
+        [Fact]
+        public void W3CMatcherProducesUtcTimestamps()
+        {
+            var timestamp = "2019-03-26 21:48:26 xxx";
+            var result = Matchers.W3CTimestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2019-03-26 21:48:26 Z"), result);
+        }
     }
 }

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using SeqCli.PlainText.Extraction;
 using Superpower;
 using Xunit;
@@ -28,7 +29,7 @@ namespace SeqCli.Tests.PlainText
         {
             var timestamp = "2019-03-26 21:48:26 xxx";
             var result = Matchers.Timestamp.Parse(timestamp);
-            Assert.Equal(DateTimeOffset.Parse("2019-03-26 21:48:26 +10:00"), result);
+            Assert.Equal(DateTimeOffset.Parse("2019-03-26 21:48:26", CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal), result);
         }
 
         [Fact]


### PR DESCRIPTION
Accepts timestamps like `2019-01-02 03:04:05` as UTC timestamps.