### PR TITLE
Adds the seqcli print command

### DIFF
--- a/src/SeqCli/Apps/AppHost.cs
+++ b/src/SeqCli/Apps/AppHost.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Seq.Apps;
 using Serilog;
@@ -37,8 +36,7 @@ namespace SeqCli.Apps
             if (appSettings == null) throw new ArgumentNullException(nameof(appSettings));
             if (storagePath == null) throw new ArgumentNullException(nameof(storagePath));
             if (seqBaseUri == null) throw new ArgumentNullException(nameof(seqBaseUri));
-            Console.InputEncoding = new UTF8Encoding(false);
-            Console.OutputEncoding = new UTF8Encoding(false);
+
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             using (var log = new LoggerConfiguration()

--- a/src/SeqCli/Cli/Commands/App/RunCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/RunCommand.cs
@@ -21,7 +21,7 @@ using SeqCli.Util;
 
 namespace SeqCli.Cli.Commands.App
 {
-    [Command("app", "run", "Host a .NET [SeqApp] plug-in",
+    [Command("app", "run", "Host a .NET `[SeqApp]` plug-in",
         Example = "seqcli tail --json | seqcli app run -d \"./bin/Debug/netstandard2.2\" -p ToAddress=example@example.com")]
     class RunCommand : Command
     {

--- a/src/SeqCli/Cli/Commands/PrintCommand.cs
+++ b/src/SeqCli/Cli/Commands/PrintCommand.cs
@@ -1,0 +1,106 @@
+﻿// Copyright 2019 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Ingestion;
+using SeqCli.Output;
+using SeqCli.Util;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.SystemConsole.Themes;
+
+namespace SeqCli.Cli.Commands
+{
+    [Command("print", "Pretty-print events in CLEF/JSON format, from a file or `STDIN`",
+        Example = "seqcli print -i log-20201028.clef")]
+    class PrintCommand : Command
+    {
+        readonly FileInputFeature _fileInputFeature;
+        readonly InvalidDataHandlingFeature _invalidDataHandlingFeature;
+
+        string _filter, _template = OutputFormatFeature.DefaultOutputTemplate;
+        bool _noColor;
+
+        public PrintCommand(SeqCliOutputConfig outputConfig)
+        {
+            if (outputConfig == null) throw new ArgumentNullException(nameof(outputConfig));
+            _noColor = outputConfig.DisableColor;
+
+            _fileInputFeature = Enable(new FileInputFeature("CLEF file to read", supportsWildcard: true));
+
+            Options.Add("f=|filter=",
+                "Filter expression to select a subset of events",
+                v => _filter = ArgumentString.Normalize(v));
+
+            Options.Add("template=",
+                "Specify an output template to control plain text formatting",
+                v => _template = ArgumentString.Normalize(v));
+
+            _invalidDataHandlingFeature = Enable<InvalidDataHandlingFeature>();
+
+            Options.Add("no-color", "Don't colorize text output", v => _noColor = true);
+        }
+
+        protected override async Task<int> Run()
+        {
+            var outputConfiguration = new LoggerConfiguration()
+                .MinimumLevel.Is(LevelAlias.Minimum)
+                .Enrich.With<RedundantEventTypeRemovalEnricher>()
+                .Enrich.With<SurrogateLevelRemovalEnricher>()
+                .WriteTo.Console(
+                    outputTemplate: _template,
+                    theme: _noColor ? ConsoleTheme.None : OutputFormatFeature.DefaultTheme);
+
+            if (_filter != null)
+                outputConfiguration.Filter.ByIncludingOnly(_filter);
+
+            using (var logger = outputConfiguration.CreateLogger())
+            {
+                foreach (var input in _fileInputFeature.OpenInputs())
+                {
+                    using (input)
+                    {
+                        var reader = new JsonLogEventReader(input);
+
+                        var isAtEnd = false;
+                        do
+                        {
+                            try
+                            {
+                                var result = await reader.TryReadAsync();
+                                isAtEnd = result.IsAtEnd;
+
+                                if (result.LogEvent != null)
+                                    logger.Write(result.LogEvent);
+                            }
+                            catch (Exception ex)
+                            {
+                                if (!(ex is JsonReaderException) && !(ex is InvalidDataException) ||
+                                    _invalidDataHandlingFeature.InvalidDataHandling != InvalidDataHandling.Ignore)
+                                    throw;
+                            }
+                        } while (!isAtEnd);
+                    }
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -31,6 +31,11 @@ namespace SeqCli.Cli.Features
 {
     class OutputFormatFeature : CommandFeature
     {
+        public const string DefaultOutputTemplate =
+            "[{Timestamp:o} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}";
+
+        public static readonly ConsoleTheme DefaultTheme = SystemConsoleTheme.Literate;
+
         bool _json, _noColor;
 
         public OutputFormatFeature(SeqCliOutputConfig outputConfig)
@@ -40,7 +45,7 @@ namespace SeqCli.Cli.Features
 
         public bool Json => _json;
 
-        ConsoleTheme Theme => _noColor ? ConsoleTheme.None : SystemConsoleTheme.Literate;
+        ConsoleTheme Theme => _noColor ? ConsoleTheme.None : DefaultTheme;
 
         public override void Enable(OptionSet options)
         {
@@ -66,7 +71,7 @@ namespace SeqCli.Cli.Features
             {
                 outputConfiguration.Enrich.With<SurrogateLevelRemovalEnricher>();
                 outputConfiguration.WriteTo.Console(
-                    outputTemplate: "[{Timestamp:o} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}",
+                    outputTemplate: DefaultOutputTemplate,
                     theme: Theme);
             }
 

--- a/src/SeqCli/Program.cs
+++ b/src/SeqCli/Program.cs
@@ -32,7 +32,7 @@ namespace SeqCli
             // Windows proxy settings are respected 
             AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
 #endif
-            
+
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Error()
                 .WriteTo.Console(
@@ -42,9 +42,8 @@ namespace SeqCli
             
             try
             {
-                Console.InputEncoding =
-                    Console.OutputEncoding =
-                        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                Console.InputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
                 TaskScheduler.UnobservedTaskException += 
                     (s,e) => Log.Error(e.Exception, "Unobserved task exception");

--- a/src/SeqCli/SeqCliModule.cs
+++ b/src/SeqCli/SeqCliModule.cs
@@ -30,6 +30,8 @@ namespace SeqCli
                 .WithMetadataFrom<CommandAttribute>();
             builder.RegisterType<SeqConnectionFactory>();
             builder.Register(c => SeqCliConfig.Read()).SingleInstance();
+            builder.Register(c => c.Resolve<SeqCliConfig>().Connection).SingleInstance();
+            builder.Register(c => c.Resolve<SeqCliConfig>().Output).SingleInstance();
         }
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/342712/55924291-9d6dcf00-5c4c-11e9-90e3-e3e3e84d6e40.png)

```
> seqcli help print
seqcli print [<args>]

Pretty-print events in CLEF/JSON format, from a file or `STDIN`

Arguments:
  -i, --input=VALUE          CLEF file to read, including the `*` wildcard; if
                               not specified, `STDIN` will be used
  -f, --filter=VALUE         Filter expression to select a subset of events
      --template=VALUE       Specify an output template to control plain text
                               formatting
      --invalid-data=VALUE   Specify how invalid data is handled: `fail` (
                               default) or `ignore`
      --no-color             Don't colorize text output
```