### PR TITLE
Add an `:s` one-or-more whitespace matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,28 @@ There are three kinds of matchers:
  * The special matchers `*`, `**` and so-on, are _non-greedy content_ matchers; these will match any text up until the next pattern element matches (`*`), the next two elements match, and so-on. We saw this in action with the `{@m:*}{:n}` elements in the example - the message is all of the text up until the next newline.
  * More complex _compound_ matchers are described using a sub-expression. These are prefixed with an equals sign `=`, like `{Phone:={:nat}-{:nat}-{:nat}}`. This will extract chunks of text like `123-456-7890` into the `Phone` property.
 
+| Matcher | Description | Example |
+|---|---|---|
+| `*`, `**`, ... | Non-greedy content | |
+| `alpha` | One or more letters | `Abc` |
+| `alphanum` | One or more letters or numbers | `a1b2` |
+| `dec` | A decimal number | `12.345` |
+| `ident` | A C-style identifier  | `countOfMatches` |
+| `int` | An integer | `-123` |
+| `iso8601dt` | An ISO-8601 date-time | `2020-01-28T13:50:01.123` |
+| `level` | A logging level name | `INF` |
+| `line` | Any single-line content | `one line!` |
+| `n` | A newline character or sequence | |
+| `nat` | A nonzero number | `123` |
+| `s` | One or more space or tab characters | ` ` |
+| `serilogdt` | A datetime in the default Serilog file logging format | `2020-01-28 13:50:01.123 +10:00` |
+| `syslogdt` | A datetime in syslog format | `Dec  8 09:12:13` |
+| `t` | A single tab character | `	` |
+| `timestamp` | A datetime in any recognized format | `` |
+| `token` | Any sequence of non-whitespace characters | `1+x$3` |
+| `trailingident` | Multiline content with indented trailing lines | |
+| `w3cdt` | A W3C log format date/time pair | `2019-04-02 05:18:01` |
+
 ### Processing
 
 Extraction patterns are processed from left to right. When the first non-matching pattern is encountered, extraction stops; any remaining text that couldn't be matched will be attached to the resulting event in an `@unmatched` property.

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ There are three kinds of matchers:
 | `serilogdt` | A datetime in the default Serilog file logging format | `2020-01-28 13:50:01.123 +10:00` |
 | `syslogdt` | A datetime in syslog format | `Dec  8 09:12:13` |
 | `t` | A single tab character | `	` |
-| `timestamp` | A datetime in any recognized format | `` |
+| `timestamp` | A datetime in any recognized format | |
 | `token` | Any sequence of non-whitespace characters | `1+x$3` |
 | `trailingident` | Multiline content with indented trailing lines | |
 | `w3cdt` | A W3C log format date/time pair | `2019-04-02 05:18:01` |

--- a/seqcli.sln.DotSettings
+++ b/seqcli.sln.DotSettings
@@ -1,0 +1,5 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=serilogdt/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=syslogdt/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=trailingindent/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -50,7 +50,7 @@ namespace SeqCli.PlainText.Extraction
 
         [Matcher("s")]
         public static TextParser<object> WhiteSpace { get; } =
-            Span.WhiteSpace
+            Span.WithAll(ch => ch == ' ' || ch == '\t')
                 .Cast<TextSpan, object>();
 
         [Matcher("iso8601dt")]

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -17,42 +17,47 @@ namespace SeqCli.PlainText.Extraction
         [Matcher("ident")]
         public static TextParser<object> Identifier { get; } =
             Superpower.Parsers.Identifier.CStyle
-                .Select(span => (object) span);
+                .Cast<TextSpan, object>();
         
         [Matcher("nat")]
         public static TextParser<object> Natural { get; } =
             Numerics.NaturalUInt64
-                .Select(span => (object) span);
+                .Cast<ulong, object>();
         
         [Matcher("int")]
         public static TextParser<object> Integer { get; } =
             Numerics.IntegerInt64
-                .Select(span => (object) span);
+                .Cast<long, object>();
         
         [Matcher("dec")]
         public static TextParser<object> Decimal { get; } =
             Numerics.Decimal
-                .Select(span => (object) span);
+                .Cast<TextSpan, object>();
         
         [Matcher("alpha")]
         public static TextParser<object> Alphabetical { get; } =
             Span.WithAll(char.IsLetter)
-                .Select(span => (object) span);
+                .Cast<TextSpan, object>();
         
         [Matcher("alphanum")]
         public static TextParser<object> Alphanumeric { get; } =
             Span.WithAll(char.IsLetterOrDigit)
-                .Select(span => (object) span);
+                .Cast<TextSpan, object>();
         
         [Matcher("token")]
         public static TextParser<object> Token { get; } =
-            SpanEx.NonWhiteSpace.Select(span => (object)span);
+            SpanEx.NonWhiteSpace.Cast<TextSpan, object>();
+
+        [Matcher("s")]
+        public static TextParser<object> WhiteSpace { get; } =
+            Span.WhiteSpace
+                .Cast<TextSpan, object>();
 
         [Matcher("iso8601dt")]
         // A date and time are required by this pattern, though not necessarily by the spec.
         public static TextParser<object> Iso8601DateTime { get; } =
             Instant.Iso8601DateTime
-                .Select(span => (object) span);
+                .Cast<TextSpan, object>();
 
         [Matcher("syslogdt")]
         public static TextParser<object> SyslogDefaultTimestamp { get; } =
@@ -138,7 +143,7 @@ namespace SeqCli.PlainText.Extraction
 
         public static TextParser<object> LiteralText(string literalText)
         {
-            return Span.EqualTo(literalText).Select(span => (object) span);
+            return Span.EqualTo(literalText).Cast<TextSpan, object>();
         }
 
         public static TextParser<object> NonGreedyContent(params PatternElement[] following)

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using SeqCli.PlainText.Extraction;
 using Superpower;
+using Superpower.Model;
 using Xunit;
 
 namespace SeqCli.Tests.PlainText
@@ -38,6 +39,28 @@ namespace SeqCli.Tests.PlainText
             var timestamp = "2019-03-26 21:48:26 xxx";
             var result = Matchers.W3CTimestamp.Parse(timestamp);
             Assert.Equal(DateTimeOffset.Parse("2019-03-26 21:48:26 Z"), result);
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("       ")]
+        public void WhiteSpaceMatcherEatsOneOrMoreSpaces(string space)
+        {
+            var input = new TextSpan(space + "x");
+            var s = Matchers.WhiteSpace(input);
+            Assert.Equal(space, ((TextSpan)s.Value).ToStringValue());
+            Assert.Equal('x', s.Remainder.ConsumeChar().Value);
+        }
+
+        // Zero-length whitespace is not supported as it's then incompatible
+        // with `*`.
+        [Fact]
+        public void WhiteSpaceMatcherDoesNotSucceedOnZeroLength()
+        {
+            var input = new TextSpan("x");
+            var s = Matchers.WhiteSpace(input);
+            Assert.False(s.HasValue);
         }
     }
 }


### PR DESCRIPTION
This has been omitted so far because either ` ` or `{:*}` is suitable for this in almost all cases. Looking for and thinking in terms of `{:s}` is natural, however, and there doesn't seem to be any harm in including it.

README updated with current matchers.