### PR TITLE
Publish docker images in ci

### DIFF
--- a/Build.Docker.ps1
+++ b/Build.Docker.ps1
@@ -1,0 +1,49 @@
+$IsCIBuild = $null -ne $env:APPVEYOR_BUILD_NUMBER
+$IsPublishedBuild = $env:APPVEYOR_REPO_BRANCH -eq "master" -and $null -eq $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
+
+$version = @{ $true = $env:APPVEYOR_BUILD_VERSION; $false = "99.99.99" }[$env:APPVEYOR_BUILD_VERSION -ne $NULL];
+$framework = "netcoreapp2.2"
+$rid = "linux-x64"
+$tag = "datalust/seqcli-ci:$version"
+
+function Execute-Tests
+{
+    & dotnet test ./test/SeqCli.Tests/SeqCli.Tests.csproj -c Release /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version
+    if ($LASTEXITCODE -ne 0) { exit 1 }
+}
+
+function Build-DockerImage
+{
+    & dotnet publish src/SeqCli/SeqCli.csproj -c Release -f $framework -r $rid /p:VersionPrefix=$version /p:SeqCliRid=$rid /p:ShowLinkerSizeComparison=true
+    if($LASTEXITCODE -ne 0) { exit 2 }
+
+    & docker build -f dockerfiles/seqcli/Dockerfile -t $tag .
+    if($LASTEXITCODE -ne 0) { exit 3 }
+}
+
+function Publish-DockerImage
+{
+    $ErrorActionPreference = "SilentlyContinue"
+
+    if ($IsCIBuild) {
+        Write-Output "$env:DOCKER_TOKEN" | docker login -u $env:DOCKER_USER --password-stdin
+        if ($LASTEXITCODE) { exit 3 }
+    }
+
+    & docker push $tag
+    if($LASTEXITCODE -ne 0) { exit 3 }
+
+    $ErrorActionPreference = "Stop"
+}
+
+Push-Location $PSScriptRoot
+
+Execute-Tests
+
+Build-DockerImage
+
+if ($IsPublishedBuild) {
+    Publish-DockerImage
+}
+
+Pop-Location

--- a/Build.ps1
+++ b/Build.ps1
@@ -28,8 +28,8 @@ function Publish-Archives($version)
 	$rids = @("linux-x64", "osx-x64", "win-x64")
 	foreach ($rid in $rids) {
 		& dotnet publish src/SeqCli/SeqCli.csproj -c Release -f $framework -r $rid /p:VersionPrefix=$version /p:SeqCliRid=$rid /p:ShowLinkerSizeComparison=true
-	    if($LASTEXITCODE -ne 0) { exit 4 }
-	
+		if($LASTEXITCODE -ne 0) { exit 4 }
+
 		# Make sure the archive contains a reasonable root filename
 		mv ./src/SeqCli/bin/Release/$framework/$rid/publish/ ./src/SeqCli/bin/Release/$framework/$rid/seqcli-$version-$rid/
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,42 @@
 version: 5.1.{build}
 skip_tags: true
-image: Visual Studio 2017
-build_script:
-- ps: ./Build.ps1
+image:
+- Visual Studio 2017
+- Ubuntu1804
+environment:
+  DOCKER_TOKEN:
+   secure: QKr2YEuliXdFKe3jN7w97w==
+  DOCKER_USER:
+    'datalustbuild'
 test: off
 artifacts:
 - path: artifacts/seqcli-*.zip
 - path: artifacts/seqcli-*.tar.gz
-deploy:
-- provider: GitHub
-  auth_token:
-    secure: Bo3ypKpKFxinjR9ShkNekNvkob2iklHJU+UlYyfHtcFFIAa58SV2TkEd0xWxz633
-  artifact: /seqcli-.*\.(zip|tar\.gz)/
-  tag: v$(appveyor_build_version)
-  on:
-    branch: master
+
+for:
+-
+  matrix:
+    only:
+      - image: Visual Studio 2017
+
+  build_script:
+  - ps: ./Build.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)"
+
+  deploy:
+  - provider: GitHub
+    auth_token:
+      secure: Bo3ypKpKFxinjR9ShkNekNvkob2iklHJU+UlYyfHtcFFIAa58SV2TkEd0xWxz633
+    artifact: /seqcli-.*\.(zip|tar\.gz)/
+    tag: v$(appveyor_build_version)
+    on:
+      branch: master
+-
+  matrix:
+    only:
+      - image: Ubuntu1804
+
+  install:
+  - ./setup.sh
+
+  build_script:
+  - ps: $env:PATH = "$env:HOME/.dotnetcli:$env:PATH"; ./Build.Docker.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)"

--- a/dockerfiles/seqcli/Dockerfile
+++ b/dockerfiles/seqcli/Dockerfile
@@ -16,9 +16,8 @@ RUN apt-get update \
         zlib1g \
 && rm -rf /var/lib/apt/lists/*
 
-COPY run.sh /run.sh
-ADD seqcli.tar.gz /tmp/
-RUN mv /tmp/seqcli-* /bin/seqcli
+COPY dockerfiles/seqcli/run.sh /run.sh
+COPY src/SeqCli/bin/Release/netcoreapp2.2/linux-x64/publish /bin/seqcli
 
 ENTRYPOINT ["/run.sh"]
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Exit if any command fails
+set -e
+set -o pipefail
+
+sudo apt-get update || true
+sudo apt-get install -y --no-install-recommends jq
+
+RequiredDotnetVersion=$(jq -r '.sdk.version' global.json)
+
+curl https://dot.net/v1/dotnet-install.sh -sSf --output dotnet-install.sh
+chmod +x dotnet-install.sh
+./dotnet-install.sh --install-dir $HOME/.dotnetcli --no-path --version $RequiredDotnetVersion
+rm dotnet-install.sh


### PR DESCRIPTION
This PR adds an automated Docker build and publish to our CI environment.

Images are pushed to a `datalust/seqcli-ci` repository. We can then manually promote builds to `datalust/seqcli`.