### PR TITLE
Don't crash on empty trailing lines when reading frames

### DIFF
--- a/seqcli.sln.DotSettings
+++ b/seqcli.sln.DotSettings
@@ -2,11 +2,14 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=apikey/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Camelize/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmds/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=command_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datalust/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=hackily/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mdash/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=seqcli/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=serilogdt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=STDIN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=syslogdt/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=trailingindent/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=trailingindent/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unawaited/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SeqCli/PlainText/Framing/FrameReader.cs
+++ b/src/SeqCli/PlainText/Framing/FrameReader.cs
@@ -63,7 +63,7 @@ namespace SeqCli.PlainText.Framing
                     return new Frame();
                 
                 var line = await _unawaitedNextLine;
-                if (line[0] == 65279)
+                if (line?.Length > 0 && line[0] == 65279)
                     line = line.Substring(1);
 
                 _unawaitedNextLine = null;

--- a/test/SeqCli.Tests/PlainText/FrameReaderTests.cs
+++ b/test/SeqCli.Tests/PlainText/FrameReaderTests.cs
@@ -73,7 +73,7 @@ namespace SeqCli.Tests.PlainText
             var reader = new FrameReader(
                 new StringReader(source),
                 frameStart,
-                TimeSpan.FromMilliseconds(10));
+                TimeSpan.FromMilliseconds(100));
 
             var result = new List<Frame>();
             


### PR DESCRIPTION
Fixes #118.
Updated: fixes #122.