### PR TITLE
Added create, remove and list commands for workspaces

### DIFF
--- a/src/SeqCli/Cli/Commands/Workspace/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/CreateCommand.cs
@@ -16,7 +16,7 @@ namespace SeqCli.Cli.Commands.Workspace
         readonly ConnectionFeature _connection;
         readonly OutputFormatFeature _output;
 
-        string _title, _description;
+        string _title, _description, _dashboard;
         bool _isProtected;
 
         public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
@@ -32,6 +32,11 @@ namespace SeqCli.Cli.Commands.Workspace
                 "description=",
                 "A description for the workspace",
                 d => _description = ArgumentString.Normalize(d));
+
+            Options.Add(
+                "dashboard=",
+                "The ID of a dashboard to connect the workspace to",
+                d => _dashboard = ArgumentString.Normalize(d));
 
             Options.Add(
                 "protected",
@@ -51,6 +56,11 @@ namespace SeqCli.Cli.Commands.Workspace
             workspace.Title = _title;
             workspace.Description = _description;
             workspace.IsProtected = _isProtected;
+
+            if (_dashboard != null)
+            {
+                workspace.Content.DashboardIds.Add(_dashboard);
+            }
 
             workspace = await connection.Workspaces.AddAsync(workspace);
 

--- a/src/SeqCli/Cli/Commands/Workspace/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/CreateCommand.cs
@@ -19,7 +19,7 @@ namespace SeqCli.Cli.Commands.Workspace
 
         string _title, _description, _dashboard;
         bool _isProtected;
-        List<string> _signals;
+        List<string> _signals = new List<string>();
 
         public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
         {

--- a/src/SeqCli/Cli/Commands/Workspace/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/CreateCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using SeqCli.Cli.Features;
 using SeqCli.Config;
@@ -18,6 +19,7 @@ namespace SeqCli.Cli.Commands.Workspace
 
         string _title, _description, _dashboard;
         bool _isProtected;
+        List<string> _signals;
 
         public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
         {
@@ -37,6 +39,11 @@ namespace SeqCli.Cli.Commands.Workspace
                 "dashboard=",
                 "The ID of a dashboard to connect the workspace to",
                 d => _dashboard = ArgumentString.Normalize(d));
+
+            Options.Add(
+                "signal=",
+                "The ID of a signal to connect to the workspace",
+                s => _signals.Add(ArgumentString.Normalize(s)));
 
             Options.Add(
                 "protected",
@@ -60,6 +67,14 @@ namespace SeqCli.Cli.Commands.Workspace
             if (_dashboard != null)
             {
                 workspace.Content.DashboardIds.Add(_dashboard);
+            }
+
+            if (_signals != null)
+            {
+                foreach (var signal in _signals)
+                {
+                    workspace.Content.SignalIds.Add(signal);
+                }
             }
 
             workspace = await connection.Workspaces.AddAsync(workspace);

--- a/src/SeqCli/Cli/Commands/Workspace/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/CreateCommand.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+using SeqCli.Util;
+
+namespace SeqCli.Cli.Commands.Workspace
+{
+    [Command("workspace", "create", "Create a workspace",
+       Example = "seqcli workspace create -t 'My Workspace'")]
+    class CreateCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+
+        string _title, _description;
+        bool _isProtected;
+
+        public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add(
+                "t=|title=",
+                "A title for the workspace",
+                t => _title = ArgumentString.Normalize(t));
+
+            Options.Add(
+                "description=",
+                "A description for the workspace",
+                d => _description = ArgumentString.Normalize(d));
+
+            Options.Add(
+                "protected",
+                "Specify that the workspace is editable only by administrators",
+                _ => _isProtected = true);
+
+            _connection = Enable<ConnectionFeature>();
+            _output = Enable(new OutputFormatFeature(config.Output));
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var workspace = await connection.Workspaces.TemplateAsync();
+
+            workspace.Title = _title;
+            workspace.Description = _description;
+            workspace.IsProtected = _isProtected;
+
+            workspace = await connection.Workspaces.AddAsync(workspace);
+
+            _output.WriteEntity(workspace);
+
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Workspace/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/ListCommand.cs
@@ -35,12 +35,12 @@ namespace SeqCli.Cli.Commands.Workspace
             var list = _entityIdentity.Id != null ?
                 new[] { await connection.Workspaces.FindAsync(_entityIdentity.Id) } :
                 (await connection.Workspaces.ListAsync(ownerId: _entityOwner.OwnerId, shared: _entityOwner.IncludeShared))
-                    .Where(signal => _entityIdentity.Title == null || _entityIdentity.Title == signal.Title)
+                    .Where(workspace => _entityIdentity.Title == null || _entityIdentity.Title == workspace.Title)
                     .ToArray();
 
-            foreach (var signal in list)
+            foreach (var workspace in list)
             {
-                _output.WriteEntity(signal);
+                _output.WriteEntity(workspace);
             }
 
             return 0;

--- a/src/SeqCli/Cli/Commands/Workspace/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/ListCommand.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+
+namespace SeqCli.Cli.Commands.Workspace
+{
+    [Command("workspace", "list", "List available workspaces", Example = "seqcli workspace list")]
+    class ListCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly EntityIdentityFeature _entityIdentity;
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+        readonly EntityOwnerFeature _entityOwner;
+
+        public ListCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            _entityIdentity = Enable(new EntityIdentityFeature("workspace", "list"));
+            _entityOwner = Enable(new EntityOwnerFeature("workspace", "list", _entityIdentity));
+            _output = Enable(new OutputFormatFeature(config.Output));
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var list = _entityIdentity.Id != null ?
+                new[] { await connection.Workspaces.FindAsync(_entityIdentity.Id) } :
+                (await connection.Workspaces.ListAsync(ownerId: _entityOwner.OwnerId, shared: _entityOwner.IncludeShared))
+                    .Where(signal => _entityIdentity.Title == null || _entityIdentity.Title == signal.Title)
+                    .ToArray();
+
+            foreach (var signal in list)
+            {
+                _output.WriteEntity(signal);
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Workspace/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/RemoveCommand.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Connection;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.Workspace
+{
+    [Command("workspace", "remove", "Remove a workspace from the server",
+       Example = "seqcli workspace remove -t 'My Workspace'")]
+    class RemoveCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly EntityIdentityFeature _entityIdentity;
+        readonly ConnectionFeature _connection;
+        readonly EntityOwnerFeature _entityOwner;
+
+        public RemoveCommand(SeqConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            _entityIdentity = Enable(new EntityIdentityFeature("workspace", "remove"));
+            _entityOwner = Enable(new EntityOwnerFeature("workspace", "remove", _entityIdentity));
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            if (_entityIdentity.Title == null && _entityIdentity.Id == null)
+            {
+                Log.Error("A `title` or `id` must be specified");
+                return 1;
+            }
+
+            var connection = _connectionFactory.Connect(_connection);
+
+            var toRemove = _entityIdentity.Id != null ?
+                new[] { await connection.Workspaces.FindAsync(_entityIdentity.Id) } :
+                (await connection.Workspaces.ListAsync(ownerId: _entityOwner.OwnerId, shared: _entityOwner.IncludeShared))
+                    .Where(workspace => _entityIdentity.Title == workspace.Title)
+                    .ToArray();
+
+            if (!toRemove.Any())
+            {
+                Log.Error("No matching signal was found");
+                return 1;
+            }
+
+            foreach (var workspace in toRemove)
+                await connection.Workspaces.RemoveAsync(workspace);
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
As referenced in [Issue 130](https://github.com/datalust/seqcli/issues/130). Added a new CLI command for workspace. These commands include:

- create
- list
- remove

Hope you find this useful. I'd be willing to have a go at implementing commands for adding and removing signals to the workspace as well if this PR looks good.