### PR TITLE
Generate correct documentation TOC for command groups of only one subcommand

### DIFF
--- a/src/SeqCli/Cli/Commands/HelpCommand.cs
+++ b/src/SeqCli/Cli/Commands/HelpCommand.cs
@@ -96,7 +96,11 @@ namespace SeqCli.Cli.Commands
             {
                 if (cmd.Count() == 1)
                 {
-                    Console.WriteLine($" - [`{cmd.Key}`](#{cmd.Key}) &mdash; {cmd.Single().Metadata.HelpText}.");
+                    var single = cmd.Single();
+                    if (single.Metadata.SubCommand == null)
+                        Console.WriteLine($" - [`{cmd.Key}`](#{cmd.Key}) &mdash; {single.Metadata.HelpText}.");
+                    else
+                        Console.WriteLine($" - [`{cmd.Key} {single.Metadata.SubCommand}`](#{cmd.Key}-{single.Metadata.SubCommand}) &mdash; {single.Metadata.HelpText}.");
                 }
                 else
                 {


### PR DESCRIPTION
Just a tiny fix for the markdown README generation; the fix for #124 introduced a regression causing single-command groups to show only the group name in the TOC.

Fixed in this PR; see `app run` below for an example.

```
 - `apikey`
   - [`apikey create`](#apikey-create) &mdash; Create an API key for ingestion.
   - [`apikey list`](#apikey-list) &mdash; List available API keys.
   - [`apikey remove`](#apikey-remove) &mdash; Remove an API key from the server.
 - [`app run`](#app-run) &mdash; Host a .NET `[SeqApp]` plug-in.
 - [`config`](#config) &mdash; View and set fields in the `SeqCli.json` file; run with no argu...
 - `dashboard`
   - [`dashboard list`](#dashboard-list) &mdash; List dashboards.
   - [`dashboard remove`](#dashboard-remove) &mdash; Remove a dashboard from the server.
```