### PR TITLE
Extend app hosting to cover Seq requirements

### DIFF
--- a/seqcli.sln.DotSettings
+++ b/seqcli.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=apikey/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=appinstance/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Camelize/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=command_0027s/@EntryIndexedValue">True</s:Boolean>

--- a/seqcli.sln.DotSettings
+++ b/seqcli.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=apikey/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appinstance/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BASEURI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Camelize/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=command_0027s/@EntryIndexedValue">True</s:Boolean>
@@ -14,6 +15,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=serilogdt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=STDIN/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=STORAGEPATH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subcommand/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=syslogdt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tokenizes/@EntryIndexedValue">True</s:Boolean>

--- a/src/SeqCli/Apps/AppLoader.cs
+++ b/src/SeqCli/Apps/AppLoader.cs
@@ -69,7 +69,7 @@ namespace SeqCli.Apps
                 }
             }
 
-            if (seqAppType == null)
+            if (seqAppType == null && seqAppTypeName != null)
                 seqAppType = Type.GetType(seqAppTypeName);
 
             return seqAppType != null;
@@ -84,13 +84,13 @@ namespace SeqCli.Apps
                 var fn = Path.GetFileNameWithoutExtension(assemblyFile);
 
                 if (_contracts
-                    .Any(hosted => hosted.GetName().Name.Equals(fn, StringComparison.OrdinalIgnoreCase)))
+                    .Any(hosted => hosted.GetName().Name!.Equals(fn, StringComparison.OrdinalIgnoreCase)))
                     continue;
 
                 try
                 {
                     var assembly = Assembly.LoadFrom(assemblyFile);
-                    loaded.Add(assembly.FullName, assembly);
+                    loaded.Add(assembly.FullName!, assembly);
                 }
                 // ReSharper disable once EmptyGeneralCatchClause
                 catch
@@ -103,11 +103,13 @@ namespace SeqCli.Apps
 
         Assembly OnAssemblyResolve(object _, ResolveEventArgs e)
         {
+            if (e.Name == null) return null;
+            
             var target = new AssemblyName(e.Name);
 
             foreach (var contract in _contracts)
             {
-                if (contract.GetName().Name.Equals(target.Name))
+                if (contract.GetName().Name!.Equals(target.Name))
                     return contract;
             }
 

--- a/src/SeqCli/Apps/AppLoader.cs
+++ b/src/SeqCli/Apps/AppLoader.cs
@@ -22,7 +22,6 @@ using Serilog;
 
 namespace SeqCli.Apps
 {
-
     class AppLoader : IDisposable
     {
         readonly string _packageBinaryPath;

--- a/src/SeqCli/Apps/Definitions/AppDefinition.cs
+++ b/src/SeqCli/Apps/Definitions/AppDefinition.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 
 namespace SeqCli.Apps.Definitions
 {
+    // ReSharper disable all
     class AppDefinition
     {
         public string Name { get; set; }
@@ -26,9 +27,5 @@ namespace SeqCli.Apps.Definitions
         public List<string> Capabilities { get; set; } = new List<string>();
         public Dictionary<string, AppPlatformDefinition> Platform { get; set; }
         public Dictionary<string, AppSettingDefinition> Settings { get; set; }
-
-        // The interrogator for assembly-based apps uses this.
-        // ReSharper disable once InconsistentNaming
-        public string __MainReactorTypeName { get; set; }
     }
 }

--- a/src/SeqCli/Apps/Definitions/AppDefinition.cs
+++ b/src/SeqCli/Apps/Definitions/AppDefinition.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace SeqCli.Apps.Definitions
+{
+    class AppDefinition
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool AllowReprocessing { get; set; }
+        public string Executable { get; set; }
+        public string Arguments { get; set; }
+        public List<string> Capabilities { get; set; } = new List<string>();
+        public Dictionary<string, AppPlatformDefinition> Platform { get; set; }
+        public Dictionary<string, AppSettingDefinition> Settings { get; set; }
+
+        // The interrogator for assembly-based apps uses this.
+        // ReSharper disable once InconsistentNaming
+        public string __MainReactorTypeName { get; set; }
+    }
+}

--- a/src/SeqCli/Apps/Definitions/AppMetadataReader.cs
+++ b/src/SeqCli/Apps/Definitions/AppMetadataReader.cs
@@ -1,0 +1,106 @@
+﻿// Copyright 2020 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Seq.Apps;
+
+namespace SeqCli.Apps.Definitions
+{
+    class AppMetadataReader
+    {
+        public static AppDefinition ReadFromReactorType(Type mainReactorType)
+        {
+            if (mainReactorType == null) throw new ArgumentNullException(nameof(mainReactorType));
+
+            var declared = mainReactorType.GetCustomAttribute<SeqAppAttribute>();
+            if (declared == null)
+                throw new ArgumentException($"The provided type '{mainReactorType}' is not marked with [SeqApp].");
+
+            var app = new AppDefinition
+            {
+                Name = declared.Name,
+                __MainReactorTypeName = mainReactorType.FullName,
+                Description = declared.Description,
+                AllowReprocessing = declared.AllowReprocessing,
+                Settings = GetAvailableSettings(mainReactorType),
+                Capabilities = GetCapabilities(mainReactorType)
+            };
+
+            return app;
+        }
+
+        static List<string> GetCapabilities(Type mainReactorType)
+        {
+            var caps = new List<string>();
+            if (typeof(IPublishJson).IsAssignableFrom(mainReactorType))
+                caps.Add("input");
+            return caps;
+        }
+
+        static Dictionary<string, AppSettingDefinition> GetAvailableSettings(Type mainReactorType)
+        {
+            var properties = mainReactorType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            return properties
+                .Select(pi => new { pi, attr = pi.GetCustomAttribute<SeqAppSettingAttribute>() })
+                .Where(p => p.attr != null)
+                .ToDictionary(
+                    p => p.pi.Name,
+                    p => new AppSettingDefinition
+                    {
+                        DisplayName = p.attr.DisplayName,
+                        IsOptional = p.attr.IsOptional,
+                        HelpText = p.attr.HelpText,
+                        InputType = p.attr.InputType == SettingInputType.Unspecified ?
+                            GetSettingType(p.pi.PropertyType) :
+                            (AppSettingType)Enum.Parse(typeof(AppSettingType), p.attr.InputType.ToString()),
+                        IsInvocationParameter = p.attr.IsInvocationParameter
+                    });
+        }
+
+        static readonly HashSet<Type> IntegerTypes = new HashSet<Type>
+        {
+            typeof(short), typeof(short?), typeof(ushort), typeof(ushort?),
+            typeof(int), typeof(int?), typeof(uint), typeof(uint?),
+            typeof(long), typeof(long?), typeof(ulong), typeof(ulong?)
+        };
+
+        static readonly HashSet<Type> DecimalTypes = new HashSet<Type>
+        {
+            typeof(float), typeof(double), typeof(decimal),
+            typeof(float?), typeof(double?), typeof(decimal?)
+        };
+
+        static readonly HashSet<Type> BooleanTypes = new HashSet<Type>
+        {
+            typeof(bool), typeof(bool?)
+        };
+
+        static AppSettingType GetSettingType(Type type)
+        {
+            if (IntegerTypes.Contains(type))
+                return AppSettingType.Integer;
+
+            if (DecimalTypes.Contains(type))
+                return AppSettingType.Decimal;
+
+            if (BooleanTypes.Contains(type))
+                return AppSettingType.Checkbox;
+
+            return AppSettingType.Text;
+        }
+    }
+}

--- a/src/SeqCli/Apps/Definitions/AppMetadataReader.cs
+++ b/src/SeqCli/Apps/Definitions/AppMetadataReader.cs
@@ -20,24 +20,30 @@ using Seq.Apps;
 
 namespace SeqCli.Apps.Definitions
 {
-    class AppMetadataReader
+    static class AppMetadataReader
     {
-        public static AppDefinition ReadFromReactorType(Type mainReactorType)
+        public static AppDefinition ReadFromSeqAppType(Type seqAppType)
         {
-            if (mainReactorType == null) throw new ArgumentNullException(nameof(mainReactorType));
+            if (seqAppType == null) throw new ArgumentNullException(nameof(seqAppType));
 
-            var declared = mainReactorType.GetCustomAttribute<SeqAppAttribute>();
+            var declared = seqAppType.GetCustomAttribute<SeqAppAttribute>();
             if (declared == null)
-                throw new ArgumentException($"The provided type '{mainReactorType}' is not marked with [SeqApp].");
+                throw new ArgumentException($"The provided type '{seqAppType}' is not marked with [SeqApp].");
 
             var app = new AppDefinition
             {
                 Name = declared.Name,
-                __MainReactorTypeName = mainReactorType.FullName,
                 Description = declared.Description,
                 AllowReprocessing = declared.AllowReprocessing,
-                Settings = GetAvailableSettings(mainReactorType),
-                Capabilities = GetCapabilities(mainReactorType)
+                Settings = GetAvailableSettings(seqAppType),
+                Capabilities = GetCapabilities(seqAppType),
+                Platform = new Dictionary<string, AppPlatformDefinition>
+                {
+                    ["hosted-dotnet"] = new AppPlatformDefinition
+                    {
+                        SeqAppTypeName = seqAppType.FullName
+                    }
+                }
             };
 
             return app;

--- a/src/SeqCli/Apps/Definitions/AppPlatformDefinition.cs
+++ b/src/SeqCli/Apps/Definitions/AppPlatformDefinition.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2020 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace SeqCli.Apps.Definitions
+{
+    class AppPlatformDefinition
+    {
+        public string Executable { get; set; }
+        public string Arguments { get; set; }
+    }
+}

--- a/src/SeqCli/Apps/Definitions/AppPlatformDefinition.cs
+++ b/src/SeqCli/Apps/Definitions/AppPlatformDefinition.cs
@@ -12,11 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Newtonsoft.Json;
+
 namespace SeqCli.Apps.Definitions
 {
+    // ReSharper disable all
     class AppPlatformDefinition
     {
         public string Executable { get; set; }
         public string Arguments { get; set; }
+        
+        // The generic host for assembly-based apps uses this.
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string SeqAppTypeName { get; set; }
     }
 }

--- a/src/SeqCli/Apps/Definitions/AppSettingDefinition.cs
+++ b/src/SeqCli/Apps/Definitions/AppSettingDefinition.cs
@@ -1,0 +1,25 @@
+// Copyright 2020 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace SeqCli.Apps.Definitions
+{
+    class AppSettingDefinition
+    {
+        public string DisplayName { get; set; }
+        public string HelpText { get; set; }
+        public bool IsOptional { get; set; }
+        public AppSettingType InputType { get; set; }
+        public bool IsInvocationParameter { get; set; }
+    }
+}

--- a/src/SeqCli/Apps/Definitions/AppSettingDefinition.cs
+++ b/src/SeqCli/Apps/Definitions/AppSettingDefinition.cs
@@ -14,6 +14,7 @@
 
 namespace SeqCli.Apps.Definitions
 {
+    // ReSharper disable all
     class AppSettingDefinition
     {
         public string DisplayName { get; set; }

--- a/src/SeqCli/Apps/Definitions/AppSettingType.cs
+++ b/src/SeqCli/Apps/Definitions/AppSettingType.cs
@@ -14,6 +14,7 @@
 
 namespace SeqCli.Apps.Definitions
 {
+    // Matches https://github.com/datalust/seq-apps-runtime/blob/dev/src/Seq.Apps/Apps/SettingInputType.cs
     public enum AppSettingType
     {
         Text,
@@ -23,7 +24,7 @@ namespace SeqCli.Apps.Definitions
         Decimal,
         Password,
 
-        // Unused
+        // Unused; required for (very early) legacy app support.
         Number = 1000
     }
 }

--- a/src/SeqCli/Apps/Definitions/AppSettingType.cs
+++ b/src/SeqCli/Apps/Definitions/AppSettingType.cs
@@ -1,0 +1,29 @@
+// Copyright 2020 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace SeqCli.Apps.Definitions
+{
+    public enum AppSettingType
+    {
+        Text,
+        LongText,
+        Checkbox,
+        Integer,
+        Decimal,
+        Password,
+
+        // Unused
+        Number = 1000
+    }
+}

--- a/src/SeqCli/Apps/Definitions/PackageInterrogator.cs
+++ b/src/SeqCli/Apps/Definitions/PackageInterrogator.cs
@@ -22,26 +22,27 @@ namespace SeqCli.Apps.Definitions
 {
     static class PackageInterrogator
     {
-        static readonly JsonSerializer Serializer = JsonSerializer.Create(
-            new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver
-                {
-                    NamingStrategy = new CamelCaseNamingStrategy { ProcessDictionaryKeys = false }
-                },
-                Converters =
-                {
-                    new StringEnumConverter(new CamelCaseNamingStrategy())
-                }
-            });
-
-        public static string FindAppConfiguration(string path, string mainAppTypeName)
+        public static string FindAppConfiguration(string path, string mainAppTypeName, bool formatIndented)
         {
             using var appLoader = new AppLoader(path);
             if (appLoader.TryLoadSeqAppType(mainAppTypeName, out var reactorType))
             {
                 var json = new StringWriter();
-                Serializer.Serialize(json, AppMetadataReader.ReadFromReactorType(reactorType));
+                var serializer = JsonSerializer.Create(
+                    new JsonSerializerSettings
+                    {
+                        Formatting = formatIndented ? Formatting.Indented : Formatting.None,
+                        ContractResolver = new CamelCasePropertyNamesContractResolver
+                        {
+                            NamingStrategy = new CamelCaseNamingStrategy { ProcessDictionaryKeys = false }
+                        },
+                        Converters =
+                        {
+                            new StringEnumConverter(new CamelCaseNamingStrategy())
+                        }
+                    });
+                
+                serializer.Serialize(json, AppMetadataReader.ReadFromSeqAppType(reactorType));
                 return json.ToString();
             }
             return null;

--- a/src/SeqCli/Apps/Definitions/PackageInterrogator.cs
+++ b/src/SeqCli/Apps/Definitions/PackageInterrogator.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2020 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using SeqCli.Apps.Hosting;
+
+namespace SeqCli.Apps.Definitions
+{
+    static class PackageInterrogator
+    {
+        static readonly JsonSerializer Serializer = JsonSerializer.Create(
+            new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver
+                {
+                    NamingStrategy = new CamelCaseNamingStrategy { ProcessDictionaryKeys = false }
+                },
+                Converters =
+                {
+                    new StringEnumConverter(new CamelCaseNamingStrategy())
+                }
+            });
+
+        public static string FindAppConfiguration(string path, string mainAppTypeName)
+        {
+            using var appLoader = new AppLoader(path);
+            if (appLoader.TryLoadSeqAppType(mainAppTypeName, out var reactorType))
+            {
+                var json = new StringWriter();
+                Serializer.Serialize(json, AppMetadataReader.ReadFromReactorType(reactorType));
+                return json.ToString();
+            }
+            return null;
+        }
+    }
+}

--- a/src/SeqCli/Apps/Hosting/AppContainer.cs
+++ b/src/SeqCli/Apps/Hosting/AppContainer.cs
@@ -29,7 +29,7 @@ using Serilog.Formatting.Compact.Reader;
 
 // ReSharper disable SuspiciousTypeConversion.Global
 
-namespace SeqCli.Apps
+namespace SeqCli.Apps.Hosting
 {
     class AppContainer : IAppHost, IDisposable
     {

--- a/src/SeqCli/Apps/Hosting/AppEnvironment.cs
+++ b/src/SeqCli/Apps/Hosting/AppEnvironment.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SeqCli.Apps.Hosting
+{
+    class AppEnvironment
+    {
+        AppEnvironment(
+            string appInstanceId,
+            string appInstanceTitle,
+            string storagePath,
+            string serverUrl,
+            string serverInstanceName,
+            IReadOnlyDictionary<string, string> settings)
+        {
+            AppInstanceId = appInstanceId ?? throw new ArgumentNullException(nameof(appInstanceId));
+            AppInstanceTitle = appInstanceTitle ?? throw new ArgumentNullException(nameof(appInstanceTitle));
+            StoragePath = storagePath ?? throw new ArgumentNullException(nameof(storagePath));
+            ServerUrl = serverUrl ?? throw new ArgumentNullException(nameof(serverUrl));
+            SeqInstanceName = serverInstanceName ?? throw new ArgumentNullException(nameof(serverInstanceName));
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        }
+
+        public static AppEnvironment ReadStandardEnvironment()
+        {
+            return new AppEnvironment(
+                GetEnvironmentVariable("SEQ_APP_ID"),
+                GetEnvironmentVariable("SEQ_APP_TITLE"),
+                GetEnvironmentVariable("SEQ_APP_STORAGEPATH"),
+                GetEnvironmentVariable("SEQ_INSTANCE_BASEURI"),
+                GetEnvironmentVariable("SEQ_INSTANCE_NAME"),
+                ReadSettingsFromEnvironment());
+        }
+
+        static string GetEnvironmentVariable(string name)
+        {
+            var var = Environment.GetEnvironmentVariable(name);
+            if (var == null) throw new Exception($"The `{name}` environment variable is not set.");
+            return var;
+        }
+
+        static IReadOnlyDictionary<string, string> ReadSettingsFromEnvironment()
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var variables = Environment.GetEnvironmentVariables();
+            foreach (string key in variables.Keys)
+            {
+                if (key.StartsWith("SEQ_APP_SETTING_"))
+                    result.Add(key.Substring(16), (string)variables[key]);
+            }
+            return result;
+        }
+
+        public IReadOnlyDictionary<string, string> Settings { get; }
+        public string StoragePath { get; }
+        public string ServerUrl { get; }
+        public string AppInstanceId { get; }
+        public string AppInstanceTitle { get; }
+        public string SeqInstanceName { get; }
+    }
+}

--- a/src/SeqCli/Apps/Hosting/AppHost.cs
+++ b/src/SeqCli/Apps/Hosting/AppHost.cs
@@ -30,12 +30,17 @@ namespace SeqCli.Apps.Hosting
             IReadOnlyDictionary<string, string> appSettings,
             string storagePath,
             string seqBaseUri,
+            string appInstanceId,
+            string appInstanceTitle,
+            string seqInstanceName = null,
             string mainAppTypeName = null)
         {
             if (packageBinaryPath == null) throw new ArgumentNullException(nameof(packageBinaryPath));
             if (appSettings == null) throw new ArgumentNullException(nameof(appSettings));
             if (storagePath == null) throw new ArgumentNullException(nameof(storagePath));
             if (seqBaseUri == null) throw new ArgumentNullException(nameof(seqBaseUri));
+            if (appInstanceId == null) throw new ArgumentNullException(nameof(appInstanceId));
+            if (appInstanceTitle == null) throw new ArgumentNullException(nameof(appInstanceTitle));
 
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
@@ -46,9 +51,8 @@ namespace SeqCli.Apps.Hosting
             
             try
             {
-                // Todo - accept values for the app id and title.
-                var app = new App("appinstance-0", "Test Instance", appSettings, storagePath);
-                var host = new Host(seqBaseUri, null);
+                var app = new App(appInstanceId, appInstanceTitle, appSettings, storagePath);
+                var host = new Host(seqBaseUri, seqInstanceName);
 
                 using var appContainer = new AppContainer(log, packageBinaryPath, app, host, mainAppTypeName);
                 appContainer.StartPublishing(Console.Out);

--- a/src/SeqCli/Apps/Hosting/EventFormat.cs
+++ b/src/SeqCli/Apps/Hosting/EventFormat.cs
@@ -20,7 +20,7 @@ using Seq.Apps.LogEvents;
 using Serilog.Events;
 using LogEventLevel = Seq.Apps.LogEvents.LogEventLevel;
 
-namespace SeqCli.Apps
+namespace SeqCli.Apps.Hosting
 {
     static class EventFormat
     {

--- a/src/SeqCli/Cli/Commands/App/DefineCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/DefineCommand.cs
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using SeqCli.Apps;
 using SeqCli.Apps.Definitions;
-using SeqCli.Apps.Hosting;
 using SeqCli.Config;
 using SeqCli.Util;
 
@@ -28,6 +25,7 @@ namespace SeqCli.Cli.Commands.App
     class DefineCommand : Command
     {
         string _dir = Environment.CurrentDirectory, _type;
+        bool _indented;
 
         public DefineCommand(SeqCliConfig config)
         {
@@ -39,14 +37,19 @@ namespace SeqCli.Cli.Commands.App
                 d => _dir = ArgumentString.Normalize(d) ?? _dir);
 
             Options.Add(
-                "t|type=",
+                "type=",
                 "The [SeqApp] plug-in type name; defaults to scanning assemblies for a single type marked with this attribute",
                 t => _type = ArgumentString.Normalize(t));
+
+            Options.Add(
+                "indented",
+                "Format the definition over multiple lines with indentation",
+                _ => _indented = true);
         }
 
         protected override Task<int> Run()
         {
-            var configuration = PackageInterrogator.FindAppConfiguration(_dir, _type);
+            var configuration = PackageInterrogator.FindAppConfiguration(_dir, _type, _indented);
 
             if (configuration == null)
             {

--- a/src/SeqCli/Cli/Commands/App/DefineCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/DefineCommand.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2020 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SeqCli.Apps;
+using SeqCli.Apps.Definitions;
+using SeqCli.Apps.Hosting;
+using SeqCli.Config;
+using SeqCli.Util;
+
+namespace SeqCli.Cli.Commands.App
+{
+    [Command("app", "define", "Generate an app definition for a .NET `[SeqApp]` plug-in",
+        Example = "seqcli app define -d \"./bin/Debug/netstandard2.2\"")]
+    class DefineCommand : Command
+    {
+        string _dir = Environment.CurrentDirectory, _type;
+
+        public DefineCommand(SeqCliConfig config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+
+            Options.Add(
+                "d=|directory=",
+                "The directory containing .NET Standard assemblies; defaults to the current directory",
+                d => _dir = ArgumentString.Normalize(d) ?? _dir);
+
+            Options.Add(
+                "t|type=",
+                "The [SeqApp] plug-in type name; defaults to scanning assemblies for a single type marked with this attribute",
+                t => _type = ArgumentString.Normalize(t));
+        }
+
+        protected override Task<int> Run()
+        {
+            var configuration = PackageInterrogator.FindAppConfiguration(_dir, _type);
+
+            if (configuration == null)
+            {
+                Console.Error.WriteLine("No type marked with `[SeqApp]` could be found.");
+                return Task.FromResult(1);
+            }
+
+            Console.WriteLine(configuration);
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/App/RunCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/RunCommand.cs
@@ -25,6 +25,7 @@ namespace SeqCli.Cli.Commands.App
         Example = "seqcli tail --json | seqcli app run -d \"./bin/Debug/netstandard2.2\" -p ToAddress=example@example.com")]
     class RunCommand : Command
     {
+        bool _readEnv;
         string _dir = Environment.CurrentDirectory,
             _type,
             _serverUrl,
@@ -83,12 +84,23 @@ namespace SeqCli.Cli.Commands.App
                 "id=",
                 "The app instance id, used only for app configuration; defaults to a placeholder id.",
                 v => _appInstanceId = ArgumentString.Normalize(v));
+
+            Options.Add(
+                "read-env",
+                "Read app configuration and settings from environment variables, as specified in " +
+                "https://docs.datalust.co/docs/seq-apps-in-other-languages; ignores all options " +
+                "except --directory and --type",
+                _ => _readEnv = true);
         }
 
         protected override async Task<int> Run()
         {
-            // Todo - accept settings from the environment.
-            return await AppHost.Run(_dir, _settings, _storage, _serverUrl, _appInstanceId, _appInstanceTitle, _seqInstanceName, _type);
+            if (!_readEnv)
+                return await AppHost.Run(_dir, _settings, _storage, _serverUrl, _appInstanceId, _appInstanceTitle, _seqInstanceName, _type);
+            
+            var fromEnv = AppEnvironment.ReadStandardEnvironment();
+            return await AppHost.Run(_dir, fromEnv.Settings, fromEnv.StoragePath, fromEnv.ServerUrl, 
+                fromEnv.AppInstanceId, fromEnv.AppInstanceTitle, fromEnv.SeqInstanceName, _type);
         }
     }
 }

--- a/src/SeqCli/Cli/Commands/App/RunCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/RunCommand.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using SeqCli.Apps;
+using SeqCli.Apps.Hosting;
 using SeqCli.Config;
 using SeqCli.Util;
 
@@ -65,6 +66,7 @@ namespace SeqCli.Cli.Commands.App
 
         protected override async Task<int> Run()
         {
+            // Todo - accept settings from the environment.
             return await AppHost.Run(_dir, _settings, _storage, _serverUrl, _type);
         }
     }

--- a/src/SeqCli/Cli/Commands/App/RunCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/RunCommand.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using SeqCli.Apps;
 using SeqCli.Apps.Hosting;
 using SeqCli.Config;
 using SeqCli.Util;
@@ -26,7 +25,14 @@ namespace SeqCli.Cli.Commands.App
         Example = "seqcli tail --json | seqcli app run -d \"./bin/Debug/netstandard2.2\" -p ToAddress=example@example.com")]
     class RunCommand : Command
     {
-        string _dir = Environment.CurrentDirectory, _type, _serverUrl, _storage = Environment.CurrentDirectory;
+        string _dir = Environment.CurrentDirectory,
+            _type,
+            _serverUrl,
+            _storage = Environment.CurrentDirectory,
+            _appInstanceId = "appinstance-0",
+            _appInstanceTitle = "Test Instance",
+            _seqInstanceName;
+        
         readonly Dictionary<string, string> _settings = new Dictionary<string, string>();
 
         public RunCommand(SeqCliConfig config)
@@ -40,7 +46,7 @@ namespace SeqCli.Cli.Commands.App
                 d => _dir = ArgumentString.Normalize(d) ?? _dir);
 
             Options.Add(
-                "t|type=",
+                "type=",
                 "The [SeqApp] plug-in type name; defaults to scanning assemblies for a single type marked with this attribute",
                 t => _type = ArgumentString.Normalize(t));
 
@@ -53,21 +59,36 @@ namespace SeqCli.Cli.Commands.App
                     var valueText = v?.Trim();
                     _settings.Add(name, valueText ?? "");
                 });
-
+            
+            Options.Add(
+                "storage=",
+                "A directory in which app-specific data can be stored; defaults to the current directory",
+                d => _storage = ArgumentString.Normalize(d) ?? _storage);
+            
             Options.Add("s=|server=",
                 "The URL of the Seq server, used only for app configuration (no connection is made to the server); by default the `connection.serverUrl` value will be used",
                 v => _serverUrl = ArgumentString.Normalize(v) ?? _serverUrl);
 
             Options.Add(
-                "storage=",
-                "A directory in which app-specific data can be stored; defaults to the current directory",
-                d => _storage = ArgumentString.Normalize(d) ?? _storage);
+                "server-instance=",
+                "The instance name of the Seq server, used only for app configuration; defaults to no instance name",
+                v => _seqInstanceName = ArgumentString.Normalize(v));
+
+            Options.Add(
+                "t=|title=",
+                "The app instance title, used only for app configuration; defaults to a placeholder title.",
+                v => _appInstanceTitle = ArgumentString.Normalize(v));
+
+            Options.Add(
+                "id=",
+                "The app instance id, used only for app configuration; defaults to a placeholder id.",
+                v => _appInstanceId = ArgumentString.Normalize(v));
         }
 
         protected override async Task<int> Run()
         {
             // Todo - accept settings from the environment.
-            return await AppHost.Run(_dir, _settings, _storage, _serverUrl, _type);
+            return await AppHost.Run(_dir, _settings, _storage, _serverUrl, _appInstanceId, _appInstanceTitle, _seqInstanceName, _type);
         }
     }
 }

--- a/src/SeqCli/Program.cs
+++ b/src/SeqCli/Program.cs
@@ -51,12 +51,10 @@ namespace SeqCli
                 var builder = new ContainerBuilder();
                 builder.RegisterModule<SeqCliModule>();
 
-                using (var container = builder.Build())
-                {
-                    var clh = container.Resolve<CommandLineHost>();
-                    var exit = await clh.Run(args);
-                    return exit;
-                }
+                using var container = builder.Build();
+                var clh = container.Resolve<CommandLineHost>();
+                var exit = await clh.Run(args);
+                return exit;
             }
             catch (Exception ex)
             {

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -33,7 +33,4 @@
     <PackageReference Include="Seq.Api" Version="2020.1.0" />
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Apps\Definitions" />
-  </ItemGroup>
 </Project>

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -33,4 +33,7 @@
     <PackageReference Include="Seq.Api" Version="2020.1.0" />
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Apps\Definitions" />
+  </ItemGroup>
 </Project>

--- a/test/SeqCli.Tests/Apps/AppContainerTests.cs
+++ b/test/SeqCli.Tests/Apps/AppContainerTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Seq.Apps;
 using SeqCli.Apps;
+using SeqCli.Apps.Hosting;
 using SeqCli.Tests.Support;
 using Serilog.Core;
 using Xunit;

--- a/test/SeqCli.Tests/Apps/PackageInterrogatorTests.cs
+++ b/test/SeqCli.Tests/Apps/PackageInterrogatorTests.cs
@@ -1,0 +1,27 @@
+﻿using System.IO;
+using Newtonsoft.Json;
+using SeqCli.Apps.Definitions;
+using Xunit;
+
+namespace SeqCli.Tests.Apps
+{
+    public class PackageInterrogatorTests
+    {
+        [Fact]
+        public void FindsAppConfiguration()
+        {
+            var appBinaries = "Apps/FirstOfTypeBinaries";
+            Assert.True(Directory.Exists(appBinaries));
+
+            var configuration = PackageInterrogator.FindAppConfiguration(appBinaries, null);
+            Assert.NotNull(configuration);
+
+            var definition = JsonConvert.DeserializeObject<AppDefinition>(configuration);
+            
+            Assert.Equal("First of Type", definition.Name);
+            
+            var typeName = definition.Platform["hosted-dotnet"].SeqAppTypeName;
+            Assert.Equal("Seq.App.FirstOfType.FirstOfTypeDetector", typeName);
+        }
+    }
+}

--- a/test/SeqCli.Tests/Apps/PackageInterrogatorTests.cs
+++ b/test/SeqCli.Tests/Apps/PackageInterrogatorTests.cs
@@ -13,7 +13,7 @@ namespace SeqCli.Tests.Apps
             var appBinaries = "Apps/FirstOfTypeBinaries";
             Assert.True(Directory.Exists(appBinaries));
 
-            var configuration = PackageInterrogator.FindAppConfiguration(appBinaries, null);
+            var configuration = PackageInterrogator.FindAppConfiguration(appBinaries, null, false);
             Assert.NotNull(configuration);
 
             var definition = JsonConvert.DeserializeObject<AppDefinition>(configuration);


### PR DESCRIPTION
Seq currently ships _Seq.Apps.GenericHost_ and _Seq.Apps.Interrogator_ binaries for working with .NET app packages. These two executables load and execute app packages, and read app package metadata.

In a near-future Seq release, we'd like to replace _GenericHost_ and _Interrogator_ with corresponding commands from `seqcli`. The `app run` command already implements the generic hosting functionality, with some minor feature gaps.

By closing those gaps, and adding a new `seqcli app define` command to play the role of _Interrogator_, we can remove the two standalone executables.

This will:

 - Reduce the sizes of the Windows installer and Docker image
 - Make the development-time app debugging infrastructure (`seqcli app run`) match the runtime app environment exactly, making behavior around dependent assembly resolution and binding more predictable

There are three parts to this work:

 1. This PR: introduce the required commands and features in `seqcli`
 1. A near-future Seq release: let users opt-in to running apps with the new host
 1. A Seq release on .NET 5, which will switch all app hosting to the new model, breaking Seq's last .NET Framework dependencies on Windows

Before this can be merged:

 - [x] Implement `seqcli app define`, to read app metadata from .NET attributes
 - [ ] ~Add code-level documentation for the app metadata format~ should be covered in docs
 - [x] Add tests for `app define`
 - [x] Allow `app run` to consume settings from environment variables, so that command-line length limits are avoided, and app configuration can trivially include newlines and other non-CLI-safe characters
 - [x] Set the app's id and title correctly in `app run`
 - [x] Migrate any remaining tests from the Seq codebase that cover the app loader, host, and interrogator
