### PR TITLE
Multiple dashboard/query support in 'worskpace create'; ensure consistent creation of shared signals and workspaces

### DIFF
--- a/src/SeqCli/Apps/AppLoader.cs
+++ b/src/SeqCli/Apps/AppLoader.cs
@@ -22,7 +22,6 @@ using Serilog;
 
 namespace SeqCli.Apps
 {
-
     class AppLoader : IDisposable
     {
         readonly string _packageBinaryPath;

--- a/src/SeqCli/Cli/Commands/Signal/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/CreateCommand.cs
@@ -79,6 +79,7 @@ namespace SeqCli.Cli.Commands.Signal
             var connection = _connectionFactory.Connect(_connection);
 
             var signal = await connection.Signals.TemplateAsync();
+            signal.OwnerId = null;
 
             signal.Title = _title;
             signal.Description = _description;

--- a/src/SeqCli/Cli/Features/EntityOwnerFeature.cs
+++ b/src/SeqCli/Cli/Features/EntityOwnerFeature.cs
@@ -52,8 +52,8 @@ namespace SeqCli.Cli.Features
             }
         }
 
-        public string OwnerId { get; set; }
+        public string OwnerId { get; private set; }
 
-        public bool IncludeShared { get; set; } = true;
+        public bool IncludeShared { get; private set; } = true;
     }
 }

--- a/test/SeqCli.EndToEnd/Workspace/WorkspaceBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Workspace/WorkspaceBasicsTestCase.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Workspace
+{
+    class WorkspaceBasicsTestCase : ICliTestCase
+    {
+        public async Task ExecuteAsync(
+            SeqConnection connection,
+            ILogger logger,
+            CliCommandRunner runner)
+        {
+            var exit = runner.Exec("workspace list", "-i workspace-none");
+            Assert.Equal(1, exit);
+
+            exit = runner.Exec("workspace list", "-t Example");
+            Assert.Equal(0, exit);
+
+            var output = runner.LastRunProcess.Output;
+            Assert.Equal("", output.Trim());
+
+            var items = "";
+            var dashboard = (await connection.Dashboards.ListAsync(shared: true)).First();
+            items += $" --dashboard={dashboard.Id}";
+
+            var query = (await connection.SqlQueries.ListAsync(shared: true)).First();
+            items += $" --query={query.Id}";
+
+            foreach (var signal in (await connection.Signals.ListAsync(shared: true)).Take(2))
+            {
+                items += $" --signal={signal.Id}";
+            }
+
+            exit = runner.Exec("workspace create", $"-t Example {items}");
+            Assert.Equal(0, exit);
+            
+            exit = runner.Exec("workspace list", "-t Example");
+            Assert.Equal(0, exit);
+            
+            output = runner.LastRunProcess.Output;
+            Assert.Contains("Example", output.Trim());
+
+            var workspace = (await connection.Workspaces.ListAsync(shared: true)).Single(w => w.Title == "Example");
+            Assert.Single(workspace.Content.DashboardIds);
+            Assert.Single(workspace.Content.QueryIds);
+            Assert.Equal(2, workspace.Content.SignalIds.Count);
+
+            exit = runner.Exec("workspace remove", "-t Example");
+            Assert.Equal(0, exit);
+        }
+    }
+}


### PR DESCRIPTION
This makes the last few changes to `workspace create` discussed in #131:

```
seqcli workspace create -t 'test' --signal=signal-123 --signal=signal-124 --dashboard=dashboard-456
```

Multi-arg support for `--signal` is extended to `--dashboard` and `--query`.

To get the newly-added tests to pass, it was necessary to make `workspace create` behave consistently WRT sharing. In practice, `seqcli` always creates shared signals, workspaces, and API keys. Running against test instances without authentication enabled, however, signals and workspaces would be created as owned by the admin user. Fixed this to behave consistently across all three entity types in both auth modes.