### PR TITLE
Add extra commands for Settings, License, Truncate, Retention Policy and extra options to Ingest and Create

### DIFF
--- a/src/SeqCli/Cli/Commands/License/FindCommand.cs
+++ b/src/SeqCli/Cli/Commands/License/FindCommand.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+
+namespace SeqCli.Cli.Commands.License
+{
+    [Command("licence", "find", "Retrieve current license key",
+        Example = "seqcli licence find")]
+    class FindCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+
+        public FindCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+           
+            _connection = Enable<ConnectionFeature>();
+            _output = Enable(new OutputFormatFeature(config.Output));
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var licenceEntity = await connection.Licenses.FindCurrentAsync();
+
+            _output.WriteEntity(licenceEntity);
+            
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/License/UpdateCommand.cs
+++ b/src/SeqCli/Cli/Commands/License/UpdateCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+
+namespace SeqCli.Cli.Commands.License
+{
+    [Command("licence", "update", "Update license key",
+        Example = "cat license.txt | seqcli licence update")]
+    class UpdateCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly FileInputFeature _fileInputFeature;
+        readonly ConnectionFeature _connection;
+        
+        public UpdateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            _fileInputFeature = Enable(new FileInputFeature("License file to import"));
+            
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var current = await connection.Licenses.FindCurrentAsync();
+            using var input = _fileInputFeature.OpenInput();
+            current.LicenseText = await input.ReadToEndAsync();
+            if (!string.IsNullOrWhiteSpace(current.LicenseText))
+            {
+                await connection.Licenses.UpdateAsync(current);
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Setting/FindCommand.cs
+++ b/src/SeqCli/Cli/Commands/Setting/FindCommand.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Seq.Api.Model.Inputs;
+using Seq.Api.Model.LogEvents;
+using Seq.Api.Model.Settings;
+using Seq.Api.Model.Shared;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+using SeqCli.Levels;
+using SeqCli.Util;
+
+namespace SeqCli.Cli.Commands.Setting
+{
+    [Command("setting", "find", "Create an API key for ingestion",
+        Example = "seqcli apikey create -t 'Test API Key' -p Environment=Test")]
+    class FindCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+
+        private string _name, _value;
+
+        public FindCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add(
+                "n=|name=",
+                "The name of the setting you want to update",
+                t => _name = ArgumentString.Normalize(t));
+
+            Options.Add(
+                "value=",
+                "A JSON encoded value to be provided",
+                t => _value = ArgumentString.Normalize(t));
+            
+            _connection = Enable<ConnectionFeature>();
+            _output = Enable(new OutputFormatFeature(config.Output));
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var settingName = Enum.Parse<SettingName>(_name);
+
+            var settingEntity = await connection.Settings.FindNamedAsync(settingName);
+
+            Console.Write(JsonConvert.SerializeObject(settingEntity.Value));
+            
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Setting/UpdateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Setting/UpdateCommand.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Seq.Api.Model.Inputs;
+using Seq.Api.Model.LogEvents;
+using Seq.Api.Model.Settings;
+using Seq.Api.Model.Shared;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+using SeqCli.Levels;
+using SeqCli.Util;
+
+namespace SeqCli.Cli.Commands.Setting
+{
+    [Command("setting", "update", "Create an API key for ingestion",
+        Example = "seqcli apikey create -t 'Test API Key' -p Environment=Test")]
+    class UpdateCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+
+        private string _name, _value;
+
+        public UpdateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add(
+                "n=|name=",
+                "The name of the setting you want to update",
+                t => _name = ArgumentString.Normalize(t));
+
+            Options.Add(
+                "v=|value=",
+                "A JSON encoded value to be provided",
+                t => _value = ArgumentString.Normalize(t));
+            
+            _connection = Enable<ConnectionFeature>();
+            _output = Enable(new OutputFormatFeature(config.Output));
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var settingName = Enum.Parse<SettingName>(_name);
+            var settingEntity = await connection.Settings.FindNamedAsync(settingName);
+            settingEntity.Value = _value;
+            
+            await connection.Settings.UpdateAsync(settingEntity);
+
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Signal/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/CreateCommand.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Seq.Api.Model.Shared;
@@ -33,6 +34,7 @@ namespace SeqCli.Cli.Commands.Signal
         readonly ConnectionFeature _connection;
         readonly OutputFormatFeature _output;
 
+        readonly List<string> _columns = new List<string>();
         string _title, _description, _filter, _group;
         bool _isProtected, _noGrouping;
 
@@ -69,6 +71,15 @@ namespace SeqCli.Cli.Commands.Signal
                 "protected",
                 "Specify that the signal is editable only by administrators",
                 _ => _isProtected = true);
+            
+            Options.Add(
+                "c=|column=",
+                "Specify columns to display, e.g. `-c Customer -c Environment`",
+                (n) =>
+                {
+                    if(!string.IsNullOrWhiteSpace(n))
+                        _columns.Add(n.Trim());
+                });
 
             _connection = Enable<ConnectionFeature>();
             _output = Enable(new OutputFormatFeature(config.Output));
@@ -109,6 +120,11 @@ namespace SeqCli.Cli.Commands.Signal
                         FilterNonStrict = _filter
                     }
                 }.ToList();
+            }
+
+            if (_columns.Any())
+            {
+                signal.Columns = _columns.Select(c => new SignalColumnPart() {Expression = c}).ToList();
             }
 
             signal = await connection.Signals.AddAsync(signal);

--- a/src/SeqCli/Cli/Commands/TruncateCommand.cs
+++ b/src/SeqCli/Cli/Commands/TruncateCommand.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2018 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+using Serilog;
+
+// ReSharper disable UnusedType.Global
+
+namespace SeqCli.Cli.Commands
+{
+    [Command("query", "Execute an SQL query and receive results in CSV format",
+        Example = "seqcli truncate -q \"select count(*) from stream group by @Level\" --start=\"2018-02-28T13:00Z\"")]
+    class TruncateCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+        readonly ConnectionFeature _connection;
+        readonly DateRangeFeature _range;
+        readonly SignalExpressionFeature _signal;
+        readonly TimeoutFeature _timeout;
+        string _query;
+
+        public TruncateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+            Options.Add("q=|query=", "The query to execute", v => _query = v);
+            _range = Enable<DateRangeFeature>();
+            _signal = Enable<SignalExpressionFeature>();
+            _timeout = Enable<TimeoutFeature>();
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            if (string.IsNullOrWhiteSpace(_query))
+            {
+                Log.Error("A query must be specified");
+                return 1;
+            }
+
+            var connection = _connectionFactory.Connect(_connection);
+
+            await connection.Events.DeleteInSignalAsync(
+                filter: _query,
+                fromDateUtc: _range.Start,
+                toDateUtc: _range.End,
+                signal: _signal.Signal);
+
+            return 0;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/License/LicenseUpdateFindTestCase.cs
+++ b/test/SeqCli.EndToEnd/License/LicenseUpdateFindTestCase.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.License
+{
+    public class LicenseUpdateFindTestCase : ICliTestCase
+    {
+        public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+        {
+            int exit = 0;
+            
+            exit = runner.Exec("license update", "-n InstanceTitle -v TestInstance");
+            Assert.Equal(0, exit);
+
+            exit = runner.Exec("license find");
+            Assert.Equal(0, exit);
+
+            var output = runner.LastRunProcess.Output;
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Setting/SettingUpdateGetTestCase.cs
+++ b/test/SeqCli.EndToEnd/Setting/SettingUpdateGetTestCase.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Setting
+{
+    public class SettingUpdateGetTestCase : ICliTestCase
+    {
+        public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+        {
+            int exit = 0;
+            
+            exit = runner.Exec("setting update", "-n InstanceTitle -v TestInstance");
+            Assert.Equal(0, exit);
+
+            exit = runner.Exec("setting find", "-n InstanceTitle");
+            Assert.Equal(0, exit);
+
+            var output = runner.LastRunProcess.Output;
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
This is adding the ability to find and update settings. 

Value is currently an `Object` in the `Seq.Api` project. Are there particular types that need to be handled or is it just int or string?

I am doing this so I can mainly update the authentication settings in an automated manner. 