### PR TITLE
DRAFT: Support for Unix time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ There are three kinds of matchers:
 | `timestamp` | A datetime in any recognized format | |
 | `token` | Any sequence of non-whitespace characters | `1+x$3` |
 | `trailingident` | Multiline content with indented trailing lines | |
-| `unixdt` | A datetime in Unix time format (seconds since Unix epoch) | `1608694199` |
+| `unixdt` | A datetime in Unix time format (seconds since Unix epoch) | `1608694199.999` |
 | `w3cdt` | A W3C log format date/time pair | `2019-04-02 05:18:01` |
 
 ### Processing

--- a/README.md
+++ b/README.md
@@ -629,6 +629,8 @@ There are three kinds of matchers:
 | `timestamp` | A datetime in any recognized format | |
 | `token` | Any sequence of non-whitespace characters | `1+x$3` |
 | `trailingident` | Multiline content with indented trailing lines | |
+| `unixdt` | A datetime in Unix time format (seconds since epoch) | `1608694199` |
+| `unixmsdt` | A datetime in Unix time format (milliseconds since epoch) | `1608707704559` |
 | `w3cdt` | A W3C log format date/time pair | `2019-04-02 05:18:01` |
 
 ### Processing

--- a/README.md
+++ b/README.md
@@ -629,8 +629,7 @@ There are three kinds of matchers:
 | `timestamp` | A datetime in any recognized format | |
 | `token` | Any sequence of non-whitespace characters | `1+x$3` |
 | `trailingident` | Multiline content with indented trailing lines | |
-| `unixdt` | A datetime in Unix time format (seconds since epoch) | `1608694199` |
-| `unixmsdt` | A datetime in Unix time format (milliseconds since epoch) | `1608707704559` |
+| `unixdt` | A datetime in Unix time format (seconds since Unix epoch) | `1608694199` |
 | `w3cdt` | A W3C log format date/time pair | `2019-04-02 05:18:01` |
 
 ### Processing

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -87,6 +87,19 @@ namespace SeqCli.PlainText.Extraction
             Span.Regex("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d+)?( [+-]\\d{2}:\\d{2})?")
                 .Select(span => (object)DateTimeOffset.Parse(span.ToStringValue(), CultureInfo.InvariantCulture));
 
+        [Matcher("unixdt")]
+        // "1608189125220" or "1608189125220.1239"
+        public static TextParser<object> UnixTimestamp { get; } =
+            Numerics.Decimal
+                .Select(span => (object)DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(1000 *
+                    Math.Round(Convert.ToDecimal(span.ToStringValue(), CultureInfo.InvariantCulture), 3))));
+
+        [Matcher("unixmsdt")]
+        // "1608189125220"
+        public static TextParser<object> UnixMsTimestamp { get; } =
+          Numerics.Integer
+              .Select(span => (object)DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(span.ToStringValue())));
+
         [Matcher("timestamp")]
         public static TextParser<object> Timestamp { get; } =
             Iso8601DateTime.Try()     

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -18,32 +18,32 @@ namespace SeqCli.PlainText.Extraction
         public static TextParser<object> Identifier { get; } =
             Superpower.Parsers.Identifier.CStyle
                 .Cast<TextSpan, object>();
-
+        
         [Matcher("nat")]
         public static TextParser<object> Natural { get; } =
             Numerics.NaturalUInt64
                 .Cast<ulong, object>();
-
+        
         [Matcher("int")]
         public static TextParser<object> Integer { get; } =
             Numerics.IntegerInt64
                 .Cast<long, object>();
-
+        
         [Matcher("dec")]
         public static TextParser<object> Decimal { get; } =
             Numerics.Decimal
                 .Cast<TextSpan, object>();
-
+        
         [Matcher("alpha")]
         public static TextParser<object> Alphabetical { get; } =
             Span.WithAll(char.IsLetter)
                 .Cast<TextSpan, object>();
-
+        
         [Matcher("alphanum")]
         public static TextParser<object> Alphanumeric { get; } =
             Span.WithAll(char.IsLetterOrDigit)
                 .Cast<TextSpan, object>();
-
+        
         [Matcher("token")]
         public static TextParser<object> Token { get; } =
             SpanEx.NonWhiteSpace.Cast<TextSpan, object>();
@@ -68,7 +68,7 @@ namespace SeqCli.PlainText.Extraction
                         DateTimeStyles.AllowInnerWhite | DateTimeStyles.AssumeLocal);
                     if (dt > DateTime.Now.AddDays(7)) // Tailing a late December log in early January :-)
                         dt = dt.AddYears(-1);
-                    return (object)dt;
+                    return (object) dt;
                 });
 
         [Matcher("w3cdt")]

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -88,7 +88,6 @@ namespace SeqCli.PlainText.Extraction
                 .Select(span => (object)DateTimeOffset.Parse(span.ToStringValue(), CultureInfo.InvariantCulture));
 
         [Matcher("unixdt")]
-        // "1608189125220" or "1608189125220.1239"
         public static TextParser<object> UnixTimestamp { get; } =
             Numerics.DecimalDouble.Select(span =>
                 {

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -89,18 +89,18 @@ namespace SeqCli.PlainText.Extraction
 
         [Matcher("unixdt")]
         public static TextParser<object> UnixTimestamp { get; } =
-            Numerics.DecimalDouble.Select(span =>
+            Numerics.DecimalDecimal.Select(span =>
                 {
                     long ms;
-                    if ((span >= 1E16) || (span <= -1E16))
+                    if ((span >= 1E16m) || (span <= -1E16m))
                     {
-                        ms = (long)(span * 0.000001); // nanoseconds
+                        ms = (long)(span * 0.000001m); // nanoseconds
                     }
-                    else if ((span >= 1E14) || (span <= -1E14))
+                    else if ((span >= 1E14m) || (span <= -1E14m))
                     {
-                        ms = (long)(span * .001); //  microseconds
+                        ms = (long)(span * .001m); //  microseconds
                     }
-                    else if ((span >= 1E11) || (span <= -3E10))
+                    else if ((span >= 1E11m) || (span <= -3E10m))
                     {
                         ms = (long)(span); // milliseconds
                     }

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -34,6 +34,30 @@ namespace SeqCli.Tests.PlainText
         }
 
         [Fact]
+        public void UnixDtMatcherProducesUtcTimestamps()
+        {
+            var timestamp = "1608694199";
+            var result = Matchers.UnixTimestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2020-12-23T03:29:59.0000000+00:00"), result);
+        }
+
+        [Fact]
+        public void UnixDtWithFractionalSecondsMatcherProducesUtcTimestamps()
+        {
+            var timestamp = "1608694199.0199";
+            var result = Matchers.UnixTimestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2020-12-23T03:29:59.0200000+00:00"), result);
+        }
+
+        [Fact]
+        public void UnixMsDtMatcherProducesUtcTimestamps()
+        {
+            var timestamp = "1608707704559";
+            var result = Matchers.UnixMsTimestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2020-12-23T07:15:04.5590000+00:00"), result);
+        }
+
+        [Fact]
         public void W3CMatcherProducesUtcTimestamps()
         {
             var timestamp = "2019-03-26 21:48:26 xxx";

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -70,7 +70,7 @@ namespace SeqCli.Tests.PlainText
         {
             var timestamp = "999999999999999999";
             var result = Matchers.UnixTimestamp.Parse(timestamp);
-            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:40.0000000+00:00"), result); 
+            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:39.9990000+00:00"), result); 
         }
 
         [Fact]

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -34,27 +34,43 @@ namespace SeqCli.Tests.PlainText
         }
 
         [Fact]
-        public void UnixDtMatcherProducesUtcTimestamps()
+        public void UnixDtMatcherAssumesSecondsProducesUtcTimestamps()
         {
-            var timestamp = "1608694199";
+            var timestamp = "999999999";
             var result = Matchers.UnixTimestamp.Parse(timestamp);
-            Assert.Equal(DateTimeOffset.Parse("2020-12-23T03:29:59.0000000+00:00"), result);
+            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:39.0000000+00:00"), result);
         }
 
         [Fact]
-        public void UnixDtWithFractionalSecondsMatcherProducesUtcTimestamps()
+        public void UnixDtMatcherAssumesFractionalSecondsProducesUtcTimestamps()
         {
-            var timestamp = "1608694199.019";
+            var timestamp = "999999999.999";
             var result = Matchers.UnixTimestamp.Parse(timestamp);
-            Assert.Equal(DateTimeOffset.Parse("2020-12-23T03:29:59.0190000+00:00"), result);
+            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:39.9990000+00:00"), result);
         }
 
         [Fact]
-        public void UnixMsDtMatcherProducesUtcTimestamps()
+        public void UnixDtMatcherAssumesMilliProducesUtcTimestamps()
         {
-            var timestamp = "1608707704559";
+            var timestamp = "999999999999";
             var result = Matchers.UnixTimestamp.Parse(timestamp);
-            Assert.Equal(DateTimeOffset.Parse("2020-12-23T07:15:04.5590000+00:00"), result);
+            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:39.9990000+00:00"), result);
+        }
+
+        [Fact]
+        public void UnixDtMatcherAssumesMicroProducesUtcTimestamps()
+        {
+            var timestamp = "999999999999999";
+            var result = Matchers.UnixTimestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:39.9990000+00:00"), result);
+        }
+
+        [Fact]
+        public void UnixDtMatcherAssumesNanoProducesUtcTimestamps()
+        {
+            var timestamp = "999999999999999999";
+            var result = Matchers.UnixTimestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:40.0000000+00:00"), result); 
         }
 
         [Fact]

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -44,16 +44,16 @@ namespace SeqCli.Tests.PlainText
         [Fact]
         public void UnixDtWithFractionalSecondsMatcherProducesUtcTimestamps()
         {
-            var timestamp = "1608694199.0199";
+            var timestamp = "1608694199.019";
             var result = Matchers.UnixTimestamp.Parse(timestamp);
-            Assert.Equal(DateTimeOffset.Parse("2020-12-23T03:29:59.0200000+00:00"), result);
+            Assert.Equal(DateTimeOffset.Parse("2020-12-23T03:29:59.0190000+00:00"), result);
         }
 
         [Fact]
         public void UnixMsDtMatcherProducesUtcTimestamps()
         {
             var timestamp = "1608707704559";
-            var result = Matchers.UnixMsTimestamp.Parse(timestamp);
+            var result = Matchers.UnixTimestamp.Parse(timestamp);
             Assert.Equal(DateTimeOffset.Parse("2020-12-23T07:15:04.5590000+00:00"), result);
         }
 


### PR DESCRIPTION
## Opportunity
I am working toward adding support for [Unix time](https://en.wikipedia.org/wiki/Unix_time) datetime format, a relatively common encoding of time in log files. This format is generally assumed to be the number of seconds elapsed since Unix epoch; however, in practice that definition can be bent to mean _whole seconds_, _fractional seconds_, or _whole milliseconds_ since epoch. While I haven't encountered any formats beyond these three, I have also read that both _nano_ and _micro_ seconds are used as well.

## Implementation
This draft PR introduces two new matchers `unixdt` and `unixmsdt` that follow the format literals in place in Logstash's [Date Filter](https://www.elastic.co/guide/en/logstash/current/plugins-filters-date.html#plugins-filters-date-match) plugin. While I appreciate the explicit nature of the separate matchers, I would like to consider if seqcli would rather implement this in a single matcher `unixdt` that supported both seconds and milliseconds (and perhaps nano & micro?). 

This pseudo code from an [online epoch converter](https://www.epochconverter.com/) illustrates this opinionated strategy based on length of the span:
```
if((inputtext>=1E16)||(inputtext<=-1E16)){
	outputtext+="Assuming that this timestamp is in <b>nanoseconds (1 billionth of a second)</b>:<br/>";
	inputtext=Math.floor(inputtext/1000000);
}else if((inputtext>=1E14)||(inputtext<=-1E14)){
	outputtext+="Assuming that this timestamp is in <b>microseconds (1/1,000,000 second)</b>:<br/>";
	inputtext=Math.floor(inputtext/1000);
}else if((inputtext>=1E11)||(inputtext<=-3E10)){
	outputtext+="Assuming that this timestamp is in <b>milliseconds</b>:<br/>";
}else{outputtext+="Assuming that this timestamp is in <b>seconds</b>:<br/>";
```

Given seqcli is processing log data it might be ok to lean toward assuming the dates are _recent_ in nature, but I wanted to hear from others on how best to approach this. Seqcli is so simple and clean, I think an opinionated decision on a single matcher would suit the library well rather than introducing explicit `unixdt`, `unixmsdt`, `unixnsdt`, `etc.` to support the various units.

Thanks for any feedback.