### PR TITLE
Specify CultureInfo.InvariantCulture wherever numeric input or formatting is relied on programmatically

### DIFF
--- a/seqcli.sln.DotSettings
+++ b/seqcli.sln.DotSettings
@@ -8,6 +8,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datalust/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=delim/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=enrichers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=formattable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gravatar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hackily/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mdash/@EntryIndexedValue">True</s:Boolean>

--- a/src/SeqCli/Apps/Hosting/AppActivator.cs
+++ b/src/SeqCli/Apps/Hosting/AppActivator.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Seq.Apps;
@@ -64,7 +65,7 @@ namespace SeqCli.Apps.Hosting
                 return Enum.Parse(targetType, value);
             }
             
-            return Convert.ChangeType(value, targetType);
+            return Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/SeqCli/Cli/Commands/ConfigCommand.cs
+++ b/src/SeqCli/Cli/Commands/ConfigCommand.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -120,7 +121,7 @@ namespace SeqCli.Cli.Commands
             if (!second.SetMethod.IsPublic)
                 throw new ArgumentException("The value is not writeable.");
 
-            var targetValue = Convert.ChangeType(value, second.PropertyType);
+            var targetValue = Convert.ChangeType(value, second.PropertyType, CultureInfo.InvariantCulture);
             second.SetValue(v, targetValue);
         }
 

--- a/src/SeqCli/Cli/Commands/SearchCommand.cs
+++ b/src/SeqCli/Cli/Commands/SearchCommand.cs
@@ -53,7 +53,7 @@ namespace SeqCli.Cli.Commands
             Options.Add(
                 "c=|count=",
                 $"The maximum number of events to retrieve; the default is {_count}",
-                v => _count = int.Parse(v));
+                v => _count = int.Parse(v, CultureInfo.InvariantCulture));
 
             _range = Enable<DateRangeFeature>();
             _output = Enable(new OutputFormatFeature(config.Output));

--- a/src/SeqCli/Cli/Options.cs
+++ b/src/SeqCli/Cli/Options.cs
@@ -131,6 +131,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -454,7 +455,7 @@ namespace SeqCli.Cli
 			T t = default (T);
 			try {
 				if (value != null)
-					t = (T) Convert.ChangeType(value, targetType);
+					t = (T) Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
 			}
 			catch (Exception e) {
 				throw new OptionException (

--- a/src/SeqCli/Syntax/DurationMoniker.cs
+++ b/src/SeqCli/Syntax/DurationMoniker.cs
@@ -53,8 +53,8 @@ namespace SeqCli.Syntax
             if (duration.EndsWith("ms"))
                 return TimeSpan.FromMilliseconds(int.Parse(duration.Substring(0, duration.Length - 2)));
 
-            var value = int.Parse(duration.Substring(0, duration.Length - 1));
-            switch (duration[duration.Length - 1])
+            var value = int.Parse(duration.Substring(0, duration.Length - 1), CultureInfo.InvariantCulture);
+            switch (duration[^1])
             {
                 case 'd':
                     return TimeSpan.FromDays(value);


### PR DESCRIPTION
In several places we assume numbers are in a JSON-like format with `.` use as the decimal separator. Commas are generally used as separators between values, rather than being in the role of decimal separators as in many international number formats.

This PR makes the assumption explicit by specifying US-style number formatting and parsing in most places.