### PR TITLE
Adds support for unixdt matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ There are three kinds of matchers:
 | `timestamp` | A datetime in any recognized format | |
 | `token` | Any sequence of non-whitespace characters | `1+x$3` |
 | `trailingident` | Multiline content with indented trailing lines | |
+| `unixdt` | A datetime in Unix time format (seconds since Unix epoch) | `1608694199.999` |
 | `w3cdt` | A W3C log format date/time pair | `2019-04-02 05:18:01` |
 
 ### Processing

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ There are three kinds of matchers:
 | `timestamp` | A datetime in any recognized format | |
 | `token` | Any sequence of non-whitespace characters | `1+x$3` |
 | `trailingident` | Multiline content with indented trailing lines | |
-| `unixdt` | A datetime in Unix time format (seconds since Unix epoch) | `1608694199.999` |
+| `unixdt` | A datetime in Unix time format supporting seconds (10-digit) or milliseconds (12-digit) | `1608694199.999` |
 | `w3cdt` | A W3C log format date/time pair | `2019-04-02 05:18:01` |
 
 ### Processing

--- a/src/SeqCli/PlainText/Extraction/Matchers.cs
+++ b/src/SeqCli/PlainText/Extraction/Matchers.cs
@@ -87,6 +87,26 @@ namespace SeqCli.PlainText.Extraction
             Span.Regex("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}(\\.\\d+)?( [+-]\\d{2}:\\d{2})?")
                 .Select(span => (object)DateTimeOffset.Parse(span.ToStringValue(), CultureInfo.InvariantCulture));
 
+        [Matcher("unixdt")]
+        public static TextParser<object> UnixTimestamp { get; } =
+            Numerics.DecimalDecimal.Select(span =>
+            {
+                long ms;
+
+                if ((span >= 1E11m) || (span <= -3E10m))
+                {
+                    // milliseconds
+                    ms = (long)(span); 
+                }
+                else
+                {
+                    // seconds
+                    ms = (long)(span * 1000); 
+                }
+
+                return (object)(DateTimeOffset.FromUnixTimeMilliseconds(ms));
+            });
+
         [Matcher("timestamp")]
         public static TextParser<object> Timestamp { get; } =
             Iso8601DateTime.Try()     

--- a/test/SeqCli.Tests/PlainText/MatchersTests.cs
+++ b/test/SeqCli.Tests/PlainText/MatchersTests.cs
@@ -62,5 +62,29 @@ namespace SeqCli.Tests.PlainText
             var s = Matchers.WhiteSpace(input);
             Assert.False(s.HasValue);
         }
+
+        [Fact]
+        public void UnixDtMatcherAssumesSecondsProducesUtcTimestamps()
+        {
+            var timestamp = "999999999";
+            var result = Matchers.UnixTimestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:39.0000000+00:00"), result);
+        }
+
+        [Fact]
+        public void UnixDtMatcherAssumesFractionalSecondsProducesUtcTimestamps()
+        {
+            var timestamp = "999999999.999";
+            var result = Matchers.UnixTimestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:39.9990000+00:00"), result);
+        }
+
+        [Fact]
+        public void UnixDtMatcherAssumesMilliProducesUtcTimestamps()
+        {
+            var timestamp = "999999999999";
+            var result = Matchers.UnixTimestamp.Parse(timestamp);
+            Assert.Equal(DateTimeOffset.Parse("2001-09-09T01:46:39.9990000+00:00"), result);
+        }
     }
 }


### PR DESCRIPTION
This adds support for a Unix timestamp matcher. I've seen this format use seconds or milliseconds in the wild so I've used a simple opinionated cutoff for switching between the two based on the length of the field value. This has worked well in my use but I'm open to other strategies.

I basically took the approach of assuming log data was more likely _recent_ in nature, and so the length of 13 was chosen as the edge between seconds and milliseconds. 

Using these maximum values you can see the range of each in terms of ms:

- 9999999999999 (13 digits) means Sat Nov 20 2286 17:46:39 UTC
- 999999999999 (12 digits) means Sun Sep 09 2001 01:46:39 UTC
- 99999999999 (11 digits) means Sat Mar 03 1973 09:46:39 UTC

If we are to assume log data is typically not older than 2001, we should be safe to use a length of **12** to indicate milliseconds.

