### PR TITLE
Fix seqcli user create (#168); add multi-user testing support to the end-to-end tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2020.5.{build}
+version: 2021.1.{build}
 skip_tags: true
 image:
 - Visual Studio 2019

--- a/src/SeqCli/Cli/Commands/User/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/User/CreateCommand.cs
@@ -124,7 +124,7 @@ namespace SeqCli.Cli.Commands.User
                     return 1;
                 }
 
-                user.RoleIds.Add(role.Title);
+                user.RoleIds.Add(role.Id);
             }
 
             if (_filter != null)

--- a/test/SeqCli.EndToEnd/Args.cs
+++ b/test/SeqCli.EndToEnd/Args.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace SeqCli.EndToEnd
 {
-    class Args
+    public class Args
     {
         readonly string[] _args;
 
@@ -19,5 +19,9 @@ namespace SeqCli.EndToEnd
 
         // Simple replacement so `Events.*` becomes `Events\..*`
         static Regex ToArgRegex(string arg) => new Regex(arg.Replace(".", "\\.").Replace("*", ".*"));
+
+        public bool Multiuser() => _args.Any(a => a == "--license-certificate-stdin");
+
+        public bool UseDockerSeq() => _args.Any(a => a == "--docker-server");
     }
 }

--- a/test/SeqCli.EndToEnd/Support/CaptiveProcess.cs
+++ b/test/SeqCli.EndToEnd/Support/CaptiveProcess.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace SeqCli.EndToEnd.Support
 {
-    public sealed class CaptiveProcess : ITestProcess, IDisposable
+    public class CaptiveProcess : ITestProcess, IDisposable
     {
         readonly bool _captureOutput;
         readonly string _stopCommandFullExePath;

--- a/test/SeqCli.EndToEnd/Support/CaptiveProcess.cs
+++ b/test/SeqCli.EndToEnd/Support/CaptiveProcess.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace SeqCli.EndToEnd.Support
 {
-    public class CaptiveProcess : ITestProcess, IDisposable
+    public sealed class CaptiveProcess : ITestProcess, IDisposable
     {
         readonly bool _captureOutput;
         readonly string _stopCommandFullExePath;

--- a/test/SeqCli.EndToEnd/Support/CliTestCaseAttribute.cs
+++ b/test/SeqCli.EndToEnd/Support/CliTestCaseAttribute.cs
@@ -5,7 +5,6 @@ namespace SeqCli.EndToEnd.Support
     [AttributeUsage(AttributeTargets.Class)]
     public class CliTestCaseAttribute : Attribute
     {
-        public bool IsSetup { get; set; }
         public bool Multiuser { get; set; }
     }
 }

--- a/test/SeqCli.EndToEnd/Support/CliTestCaseAttribute.cs
+++ b/test/SeqCli.EndToEnd/Support/CliTestCaseAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace SeqCli.EndToEnd.Support
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class CliTestCaseAttribute : Attribute
+    {
+        public bool IsSetup { get; set; }
+        public bool Multiuser { get; set; }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/IsolatedTestCase.cs
+++ b/test/SeqCli.EndToEnd/Support/IsolatedTestCase.cs
@@ -11,6 +11,7 @@ namespace SeqCli.EndToEnd.Support
         readonly Lazy<SeqConnection> _connection;
         readonly Lazy<ILogger> _logger;
         readonly CliCommandRunner _commandRunner;
+        readonly Lazy<LicenseSetup> _licenseSetup;
         readonly ICliTestCase _testCase;
 
         ITestProcess _lastRunProcess;
@@ -20,12 +21,14 @@ namespace SeqCli.EndToEnd.Support
             Lazy<SeqConnection> connection,
             Lazy<ILogger> logger,
             CliCommandRunner commandRunner,
+            Lazy<LicenseSetup> licenseSetup,
             ICliTestCase testCase)
         {
             _serverProcess = serverProcess;
             _connection = connection;
             _logger = logger;
             _commandRunner = commandRunner;
+            _licenseSetup = licenseSetup;
             _testCase = testCase ?? throw new ArgumentNullException(nameof(testCase));
         }
 
@@ -35,7 +38,8 @@ namespace SeqCli.EndToEnd.Support
         public async Task ExecuteTestCaseAsync()
         {
             _lastRunProcess = _serverProcess.Value;
-            await _connection.Value.EnsureConnected();            
+            await _connection.Value.EnsureConnected();
+            await _licenseSetup.Value.SetupAsync(_connection.Value, _logger.Value);
             await _testCase.ExecuteAsync(_connection.Value, _logger.Value, _commandRunner);
         }
     }

--- a/test/SeqCli.EndToEnd/Support/IsolatedTestCaseRegistrationSource.cs
+++ b/test/SeqCli.EndToEnd/Support/IsolatedTestCaseRegistrationSource.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using Autofac;
+using Autofac.Core;
+using Autofac.Core.Activators.Delegate;
+using Autofac.Core.Lifetime;
+using Autofac.Core.Registration;
+using Seq.Api;
+using Serilog;
+
+namespace SeqCli.EndToEnd.Support
+{
+    // Built-in decorator support didn't transfer metadata.
+    class IsolatedTestCaseRegistrationSource : IRegistrationSource
+    {
+        public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
+        {
+            if (!(service is TypedService ts && ts.ServiceType == typeof(IsolatedTestCase)))
+                yield break;
+
+            var innerService = ts.ChangeType(typeof(ICliTestCase));
+            foreach (var inner in registrationAccessor(innerService))
+            {
+                yield return new ComponentRegistration(
+                    Guid.NewGuid(),
+                    new DelegateActivator(typeof(IsolatedTestCase), (ctx, p) =>
+                    {
+                        var tc = (ICliTestCase) ctx.ResolveComponent(new ResolveRequest(innerService, inner, p));
+                        return new IsolatedTestCase(
+                            ctx.Resolve<Lazy<ITestProcess>>(),
+                            ctx.Resolve<Lazy<SeqConnection>>(),
+                            ctx.Resolve<Lazy<ILogger>>(),
+                            ctx.Resolve<CliCommandRunner>(),
+                            ctx.Resolve<Lazy<LicenseSetup>>(),
+                            tc);
+                    }),
+                    new CurrentScopeLifetime(),
+                    InstanceSharing.None,
+                    InstanceOwnership.OwnedByLifetimeScope,
+                    new[] {service},
+                    inner.Metadata);
+            }
+        }
+
+        public bool IsAdapterForIndividualComponents { get; } = true;
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/LicenseCliSetupTestCase.cs
+++ b/test/SeqCli.EndToEnd/Support/LicenseCliSetupTestCase.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+
+namespace SeqCli.EndToEnd.Support
+{
+    public class LicenseSetup
+    {
+        readonly bool _enabled;
+
+        bool _attempted;
+        string _certificate;
+
+        public LicenseSetup(Args args)
+        {
+            _enabled = args.Multiuser();
+        }
+        
+        public async Task SetupAsync(
+            SeqConnection connection,
+            ILogger logger)
+        {
+            if (!_enabled)
+                return;
+
+            if (!_attempted)
+            {
+                _attempted = true;
+                logger.Information("Reading license certificate from STDIN....");
+                _certificate = await Console.In.ReadToEndAsync();
+            }
+
+            var license = await connection.Licenses.FindCurrentAsync();
+            license.LicenseText = _certificate;
+            await connection.Licenses.UpdateAsync(license);
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
+++ b/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
@@ -6,6 +6,13 @@ namespace SeqCli.EndToEnd.Support
 {
     public class TestConfiguration
     {
+        readonly Args _args;
+
+        public TestConfiguration(Args args)
+        {
+            _args = args;
+        }
+        
         public int ServerListenPort { get; } = 9989;
 
         public string ServerListenUrl => $"http://localhost:{ServerListenPort}";
@@ -14,6 +21,8 @@ namespace SeqCli.EndToEnd.Support
             .Replace(Path.Combine("test", "SeqCli.EndToEnd"), Path.Combine("src", "SeqCli"));
 
         public string TestedBinary => Path.Combine(EquivalentBaseDirectory, "seqcli.dll");
+
+        public bool IsMultiuser => _args.Multiuser();
 
         public CaptiveProcess SpawnCliProcess(string command, string additionalArgs = null, Dictionary<string, string> environment = null, bool skipServerArg = false)
         {
@@ -32,7 +41,7 @@ namespace SeqCli.EndToEnd.Support
             if (storagePath == null) throw new ArgumentNullException(nameof(storagePath));
 
             var commandWithArgs = $"run --listen=\"{ServerListenUrl}\" --storage=\"{storagePath}\"";
-            if (Environment.GetEnvironmentVariable("ENDTOEND_USE_DOCKER_SEQ") == "Y")
+            if (_args.UseDockerSeq())
             {
                 return new CaptiveProcess("docker", $"run --name seq -it --rm -e ACCEPT_EULA=Y -p {ServerListenPort}:80 datalust/seq:latest", stopCommandFullExePath: "docker", stopCommandArgs: "stop seq");
             }

--- a/test/SeqCli.EndToEnd/User/UserListTestCase.cs
+++ b/test/SeqCli.EndToEnd/User/UserListTestCase.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.User
+{
+    public class UserListTestCase : ICliTestCase
+    {
+        public Task ExecuteAsync(
+            SeqConnection connection,
+            ILogger logger,
+            CliCommandRunner runner)
+        {
+            var exit = runner.Exec("user list");
+            Assert.Equal(0, exit);
+
+            exit = runner.Exec("user list", "-n admin");
+            Assert.Equal(0, exit);
+
+            var output = runner.LastRunProcess.Output;
+            Assert.Equal("user-admin admin", output.Trim());
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #168

To run multi-user tests (we now have one!), supply a valid license through `STDIN`:

```
test\SeqCli.EndToEnd>dotnet run --license-certificate-stdin < Certificate.txt
```

There's a bit of gunk required to get `[CliTestCase(Multiuser = true)]` propagated through Autofac, and argument handling isn't great. I'm out of time now but will come around and take another shot at it down the line :)