### PR TITLE
2021.2.0 Release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2021.1.{build}
+version: 2021.2.{build}
 skip_tags: true
 image:
 - Visual Studio 2019

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net5.0;net5.0-windows</TargetFrameworks>
@@ -33,7 +33,7 @@
     <PackageReference Include="Superpower" Version="2.3.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="5.0.0" />
-    <PackageReference Include="Seq.Api" Version="2021.1.0" />
+    <PackageReference Include="Seq.Api" Version="2021.2.0" />
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
     <!-- Seq.Api pulls in Tavis.UriTemplates which pulls in version 1.6.0 of this package, causing
          package downgrade warnings. -->


### PR DESCRIPTION
Just a version bump - we rolled the new features slated for release in 2021.2 into the last 2021.1 patch:

https://github.com/datalust/seqcli/releases/tag/v2021.1.439
