### PR TITLE
Fix tool publishing - requires a single platform-independent TFM

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -59,7 +59,8 @@ function Publish-Archives($version)
 
 function Publish-DotNetTool($version)
 {	
-	dotnet pack ./src/SeqCli/SeqCli.csproj -c Release --output ./artifacts /p:VersionPrefix=$version
+	# Tool packages have to target a single non-platform-specific TFM; doing this here is cleaner than attempting it in the CSPROJ directly
+	dotnet pack ./src/SeqCli/SeqCli.csproj -c Release --output ./artifacts /p:VersionPrefix=$version /p:TargetFramework=$framework /p:TargetFrameworks=
 }
 
 Push-Location $PSScriptRoot


### PR DESCRIPTION
The last release regressed .NET tool publishing by adding the `net5.0-windows` TFM.

The fix here is to clear this out when performing pack-as-tool, and specifying `TargetFramework=net5.0`.