### PR TITLE
Make the ingestion batch size configurable

### DIFF
--- a/src/SeqCli/Cli/Commands/IngestCommand.cs
+++ b/src/SeqCli/Cli/Commands/IngestCommand.cs
@@ -39,6 +39,7 @@ namespace SeqCli.Cli.Commands
         readonly PropertiesFeature _properties;
         readonly SendFailureHandlingFeature _sendFailureHandlingFeature;
         readonly ConnectionFeature _connection;
+        readonly BatchSizeFeature _batchSize;
         string _filter, _pattern = DefaultPattern, _level, _message;
         bool _json;
 
@@ -73,6 +74,7 @@ namespace SeqCli.Cli.Commands
 
             _sendFailureHandlingFeature = Enable<SendFailureHandlingFeature>();            
             _connection = Enable<ConnectionFeature>();
+            _batchSize = Enable<BatchSizeFeature>();
         }
 
         protected override async Task<int> Run()
@@ -96,6 +98,7 @@ namespace SeqCli.Cli.Commands
 
                 var connection = _connectionFactory.Connect(_connection);
                 var (_, apiKey) = _connectionFactory.GetConnectionDetails(_connection);
+                var batchSize = _batchSize.Value;
 
                 foreach (var input in _fileInputFeature.OpenInputs())
                 {
@@ -116,6 +119,7 @@ namespace SeqCli.Cli.Commands
                             reader,
                             _invalidDataHandlingFeature.InvalidDataHandling,
                             _sendFailureHandlingFeature.SendFailureHandling,
+                            batchSize,
                             filter);
 
                         if (exit != 0)

--- a/src/SeqCli/Cli/Commands/Sample/IngestCommand.cs
+++ b/src/SeqCli/Cli/Commands/Sample/IngestCommand.cs
@@ -28,17 +28,20 @@ namespace SeqCli.Cli.Commands.Sample
         
         readonly ConnectionFeature _connection;
         readonly ConfirmFeature _confirm;
+        readonly BatchSizeFeature _batchSize;
 
         public IngestCommand(SeqConnectionFactory connectionFactory)
         {
             _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
             _confirm = Enable<ConfirmFeature>();
             _connection = Enable<ConnectionFeature>();
+            _batchSize = Enable<BatchSizeFeature>();
         }
         
         protected override async Task<int> Run()
         {
             var (url, apiKey) = _connectionFactory.GetConnectionDetails(_connection);
+            var batchSize = _batchSize.Value;
             
             if (!_confirm.TryConfirm($"This will send sample events to the Seq server at {url}."))
             {
@@ -47,7 +50,7 @@ namespace SeqCli.Cli.Commands.Sample
             }
 
             var connection = _connectionFactory.Connect(_connection);
-            await Simulation.RunAsync(connection, apiKey);
+            await Simulation.RunAsync(connection, apiKey, batchSize);
             return 0;
         }
     }

--- a/src/SeqCli/Cli/Features/BatchSizeFeature.cs
+++ b/src/SeqCli/Cli/Features/BatchSizeFeature.cs
@@ -11,8 +11,8 @@ namespace SeqCli.Cli.Features
 
         public override void Enable(OptionSet options)
         {
-            options.Add("batchsize=",
-                "The number of events in each batch to send to Seq.",
+            options.Add("batch-size=",
+                $"The maximum number of events to send in each request to the ingestion endpoint; if not specified a value of `{DefaultBatchSize}` will be used",
                 v => _value = int.Parse(ArgumentString.Normalize(v)));
         }
     }

--- a/src/SeqCli/Cli/Features/BatchSizeFeature.cs
+++ b/src/SeqCli/Cli/Features/BatchSizeFeature.cs
@@ -1,0 +1,19 @@
+﻿using SeqCli.Util;
+
+namespace SeqCli.Cli.Features
+{
+    class BatchSizeFeature: CommandFeature
+    {
+        const int DefaultBatchSize = 100;
+        int? _value;
+
+        public int Value => _value ?? DefaultBatchSize;
+
+        public override void Enable(OptionSet options)
+        {
+            options.Add("batchsize=",
+                "The number of events in each batch to send to Seq.",
+                v => _value = int.Parse(ArgumentString.Normalize(v)));
+        }
+    }
+}

--- a/src/SeqCli/Ingestion/LogShipper.cs
+++ b/src/SeqCli/Ingestion/LogShipper.cs
@@ -29,9 +29,6 @@ namespace SeqCli.Ingestion
 {
     static class LogShipper
     {
-        // Keep things simple with a fixed batch size.
-        const int BatchSize = 100;
-
         static readonly SurrogateLevelAwareCompactJsonFormatter Formatter = new SurrogateLevelAwareCompactJsonFormatter();
 
         public static async Task<int> ShipEvents(
@@ -40,12 +37,13 @@ namespace SeqCli.Ingestion
             ILogEventReader reader,
             InvalidDataHandling invalidDataHandling,
             SendFailureHandling sendFailureHandling,
+            int batchSize,
             Func<LogEvent, bool> filter = null)
         {
             if (connection == null) throw new ArgumentNullException(nameof(connection));
             if (reader == null) throw new ArgumentNullException(nameof(reader));
 
-            var batch = await ReadBatchAsync(reader, filter, BatchSize, invalidDataHandling);
+            var batch = await ReadBatchAsync(reader, filter, batchSize, invalidDataHandling);
             var retries = 0;
             while (true)
             {
@@ -83,7 +81,7 @@ namespace SeqCli.Ingestion
                 if (batch.IsLast)
                     break;
                 
-                batch = await ReadBatchAsync(reader, filter, BatchSize, invalidDataHandling);
+                batch = await ReadBatchAsync(reader, filter, batchSize, invalidDataHandling);
             }
 
             return 0;

--- a/src/SeqCli/Sample/Loader/Simulation.cs
+++ b/src/SeqCli/Sample/Loader/Simulation.cs
@@ -21,7 +21,7 @@ namespace SeqCli.Sample.Loader
 {
     static class Simulation
     {
-        public static async Task RunAsync(SeqConnection connection, string apiKey)
+        public static async Task RunAsync(SeqConnection connection, string apiKey, int batchSize)
         {
             var reader = new BufferingSink();
             
@@ -34,7 +34,7 @@ namespace SeqCli.Sample.Loader
                 .CreateLogger();
 
             var ship = Task.Run(() => LogShipper.ShipEvents(connection, apiKey, reader,
-                InvalidDataHandling.Fail, SendFailureHandling.Continue));
+                InvalidDataHandling.Fail, SendFailureHandling.Continue, batchSize));
 
             await Roastery.Program.Main(logger);
             logger.Dispose();


### PR DESCRIPTION
The default batch size of 100 is ok for live scenarios, but can make ingestion of historical data slower than it needs to be (where each batch requires a couple of fsyncs).

This PR makes the batch size configurable while retaining the current as a default.