### PR TITLE
Connect as a named user when creating the first API key

### DIFF
--- a/src/SeqCli/Cli/Commands/ApiKey/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/ApiKey/CreateCommand.cs
@@ -186,7 +186,7 @@ namespace SeqCli.Cli.Commands.ApiKey
 
                 var (url, _) = _connectionFactory.GetConnectionDetails(_connection);
                 connection = new SeqConnection(url);
-                await connection.Users.LoginAsync(_connectUsername, _connectPassword);
+                await connection.Users.LoginAsync(_connectUsername, _connectPassword ?? "");
             }
             else
             {

--- a/src/SeqCli/Cli/Commands/User/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/User/CreateCommand.cs
@@ -35,7 +35,7 @@ namespace SeqCli.Cli.Commands.User
         readonly OutputFormatFeature _output;
 
         string _username, _displayName, _roleTitle, _filter, _emailAddress, _password;
-        bool _passwordStdin;
+        bool _passwordStdin, _noPasswordChange;
 
         public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
         {
@@ -76,6 +76,11 @@ namespace SeqCli.Cli.Commands.User
                 "Read the initial password for the user from `STDIN`, if username/password authentication is in use",
                 _ => _passwordStdin = true);
 
+            Options.Add(
+                "no-password-change",
+                "Don't force the user to change their password at next login",
+                _ => _noPasswordChange = true);
+            
             _connection = Enable<ConnectionFeature>();
             _output = Enable(new OutputFormatFeature(config.Output));
         }
@@ -105,7 +110,7 @@ namespace SeqCli.Cli.Commands.User
             if (_password != null)
             {
                 user.NewPassword = _password;
-                user.MustChangePassword = true;
+                user.MustChangePassword = !_noPasswordChange;
             }
             
             if (_roleTitle == null)

--- a/src/SeqCli/Util/ArgumentString.cs
+++ b/src/SeqCli/Util/ArgumentString.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Linq;
+
 namespace SeqCli.Util
 {
     static class ArgumentString
@@ -19,6 +21,15 @@ namespace SeqCli.Util
         public static string Normalize(string argument)
         {
             return string.IsNullOrWhiteSpace(argument) ? null : argument.Trim();
+        }
+
+        public static string[] NormalizeList(string argument)
+        {
+            return (argument ?? "")
+                .Split(',')
+                .Select(Normalize)
+                .Where(s => s != null)
+                .ToArray();
         }
     }
 }

--- a/test/SeqCli.EndToEnd/ApiKey/ApiKeyDelegatePermissionsTestCase.cs
+++ b/test/SeqCli.EndToEnd/ApiKey/ApiKeyDelegatePermissionsTestCase.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.ApiKey
+{
+    [CliTestCase(Multiuser = true)]
+    public class ApiKeyDelegatePermissionsTestCase : ICliTestCase
+    {
+        public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+        {
+            var exit = runner.Exec(
+                "user create",
+                "-n carol -r \"Administrator\" -p test@1234 --no-password-change");
+            Assert.Equal(0, exit);
+
+            exit = runner.Exec(
+                "apikey create",
+                "-t Setup --permissions=Setup,Write --connect-username=carol --connect-password=\"test@1234\"");
+            Assert.Equal(0, exit);
+
+            exit = runner.Exec("apikey list", "-t Setup --json --no-color");
+            Assert.Equal(0, exit);
+
+            var output = runner.LastRunProcess.Output;
+            Assert.Contains("\"AssignedPermissions\": [\"Setup\", \"Write\"]", output);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/TestDriver.cs
+++ b/test/SeqCli.EndToEnd/Support/TestDriver.cs
@@ -32,7 +32,8 @@ namespace SeqCli.EndToEnd.Support
 
             foreach (var testCaseFactory in _cases.OrderBy(c => Guid.NewGuid()))
             {
-                if (testCaseFactory.Metadata.TryGetValue("Multiuser", out var multiuser) && true.Equals(multiuser) && !_configuration.IsMultiuser)
+                var isMultiuser = testCaseFactory.Metadata.TryGetValue("Multiuser", out var multiuser) && true.Equals(multiuser);
+                if (isMultiuser != _configuration.IsMultiuser)
                     continue;
 
                 count++;


### PR DESCRIPTION
Fixes #188

This enables:

```
seqcli apikey create -t First --token="yourtokenhere" --connect-username=admin --connect-password=password --permissions="Read,Write,Setup"
```

~~Some form of testing still outstanding.~~ ✔️ 