### PR TITLE
`seqcli feed (create|list|remove)` commands

### DIFF
--- a/src/SeqCli/Cli/Commands/Feed/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Feed/CreateCommand.cs
@@ -1,0 +1,102 @@
+﻿// Copyright 2018 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+using SeqCli.Util;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.Feed
+{
+    [Command("feed", "create", "Create a NuGet feed",
+        Example = "seqcli feed create -n 'CI' --location=\"https://f.feedz.io/example/ci\" -u Seq --password-stdin")]
+    class CreateCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+
+        string _name, _location, _username, _password;
+        bool _passwordStdin;
+
+        public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add(
+                "n=|name=",
+                "A unique name for the feed",
+                n => _name = ArgumentString.Normalize(n));
+            
+            Options.Add(
+                "l=|location=",
+                "The feed location; this may be a NuGet v2 or v3 feed URL, or a local filesystem path on the Seq server",
+                l => _location = ArgumentString.Normalize(l));
+            
+            Options.Add(
+                "u=|username=",
+                "The username Seq should supply when connecting to the feed, if authentication is required",
+                n => _username = ArgumentString.Normalize(n));
+
+            Options.Add(
+                "p=|password=",
+                "A feed password, if authentication is required; note that `--password-stdin` is more secure",
+                p => _password = ArgumentString.Normalize(p));
+
+            Options.Add(
+                "password-stdin",
+                "Read the feed password from `STDIN`",
+                _ => _passwordStdin = true);
+
+            _connection = Enable<ConnectionFeature>();
+            _output = Enable(new OutputFormatFeature(config.Output));
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var feed = await connection.Feeds.TemplateAsync();
+            feed.Name = _name;
+            feed.Location = _location;
+            feed.Username = _username;
+
+            if (_passwordStdin)
+            {
+                if (_password != null)
+                {
+                    Log.Error("The `password` and `password-stdin` options are mutually exclusive");
+                    return 1;
+                }
+
+                _password = await Console.In.ReadLineAsync();
+            }
+
+            if (_password != null)
+            {
+                feed.NewPassword = _password;
+            }
+            
+            feed = await connection.Feeds.AddAsync(feed);
+
+            _output.WriteEntity(feed);
+
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Feed/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Feed/ListCommand.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2018 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+
+namespace SeqCli.Cli.Commands.Feed
+{
+    [Command("feed", "list", "List NuGet feeds", Example="seqcli feed list")]
+    class ListCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+        
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+
+        string _name, _id;
+
+        public ListCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add(
+                "n=|name=",
+                "The name of the feed to list",
+                n => _name = n);
+
+            Options.Add(
+                "i=|id=",
+                "The id of a single feed to list",
+                id => _id = id);
+            
+            _output = Enable(new OutputFormatFeature(config.Output));
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var list = _id != null ?
+                new[] { await connection.Feeds.FindAsync(_id) } :
+                (await connection.Feeds.ListAsync())
+                    .Where(f => _name == null || _name == f.Name)
+                    .ToArray();
+
+            foreach (var feed in list)
+            {
+                _output.WriteEntity(feed);
+            }
+            
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Feed/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Feed/RemoveCommand.cs
@@ -1,0 +1,79 @@
+﻿// Copyright 2018 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Connection;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.Feed
+{
+    [Command("feed", "remove", "Remove a NuGet feed from the server",
+        Example="seqcli feed remove -n CI")]
+    class RemoveCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+        
+        readonly ConnectionFeature _connection;
+        
+        string _name, _id;
+        
+        public RemoveCommand(SeqConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add(
+                "n=|name=",
+                "The name of the feed to remove",
+                n => _name = n);
+
+            Options.Add(
+                "i=|id=",
+                "The id of a single feed to remove",
+                id => _id = id);
+            
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            if (_name == null && _id == null)
+            {
+                Log.Error("A `name` or `id` must be specified");
+                return 1;
+            }
+
+            var connection = _connectionFactory.Connect(_connection);
+
+            var toRemove = _id != null ?
+                new[] {await connection.Feeds.FindAsync(_id)} :
+                (await connection.Feeds.ListAsync())
+                    .Where(f => _name == f.Name) 
+                    .ToArray();
+
+            if (!toRemove.Any())
+            {
+                Log.Error("No matching feed was found");
+                return 1;
+            }
+
+            foreach (var feed in toRemove)
+                await connection.Feeds.RemoveAsync(feed);
+
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/User/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/User/CreateCommand.cs
@@ -16,7 +16,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Seq.Api.Model.Shared;
-using Seq.Api.Model.Signals;
 using SeqCli.Cli.Features;
 using SeqCli.Config;
 using SeqCli.Connection;
@@ -98,8 +97,14 @@ namespace SeqCli.Cli.Commands.User
                     return 1;
                 }
 
-                while (string.IsNullOrEmpty(_password))
-                    _password = await Console.In.ReadLineAsync();
+                _password = await Console.In.ReadLineAsync();
+                if (string.IsNullOrEmpty(_password))
+                {
+                    // Prevent accidental creation of empty-password accounts if scripts malfunction and empty
+                    // lines appear in the input.
+                    Log.Error("The `password-stdin` option requires that a non-empty password be supplied");
+                    return 1;
+                }
             }
 
             if (_password != null)

--- a/test/SeqCli.EndToEnd/Feed/FeedBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Feed/FeedBasicsTestCase.cs
@@ -31,7 +31,7 @@ namespace SeqCli.EndToEnd.Feed
             Assert.Equal("Test", feed.Username);
             Assert.Null(feed.NewPassword);
 
-            exit = runner.Exec("feed remove", "-t Example");
+            exit = runner.Exec("feed remove", "-n Example");
             Assert.Equal(0, exit);
             
             AssertExistence(runner, "Example", false);

--- a/test/SeqCli.EndToEnd/Feed/FeedBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Feed/FeedBasicsTestCase.cs
@@ -13,6 +13,9 @@ namespace SeqCli.EndToEnd.Feed
         public async Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
         {
             var exit = runner.Exec("feed list", "-n nuget.org");
+            Assert.Equal(0, exit);
+
+            exit = runner.Exec("feed list", "-i feed-missing");
             Assert.Equal(1, exit);
 
             AssertExistence(runner, "Example", false);

--- a/test/SeqCli.EndToEnd/Feed/FeedBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Feed/FeedBasicsTestCase.cs
@@ -1,0 +1,54 @@
+﻿using System.Threading.Tasks;
+using System.Linq;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Feed
+{
+    // ReSharper disable once UnusedType.Global
+    public class FeedBasicsTestCase : ICliTestCase
+    {
+        public async Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+        {
+            var exit = runner.Exec("feed list", "-n nuget.org");
+            Assert.Equal(1, exit);
+
+            AssertExistence(runner, "Example", false);
+
+            exit = runner.Exec("feed create", "-n Example -l \"https://example.com\" -u Test -p Pass");
+            Assert.Equal(0, exit);
+            
+            AssertExistence(runner, "Example", true);
+ 
+            var feed = (await connection.Feeds.ListAsync()).Single(f => f.Name == "Example");
+            Assert.Equal("Example", feed.Name);
+            Assert.Equal("https://example.com", feed.Location);
+            Assert.Equal("Test", feed.Username);
+            Assert.Null(feed.NewPassword);
+
+            exit = runner.Exec("feed remove", "-t Example");
+            Assert.Equal(0, exit);
+            
+            AssertExistence(runner, "Example", false);
+        }
+
+        static void AssertExistence(CliCommandRunner runner, string feedName, bool exists)
+        {
+            var exit = runner.Exec("feed list", $"-n {feedName}");
+            Assert.Equal(0, exit);
+
+            var output = runner.LastRunProcess.Output;
+
+            if (exists)
+            {
+                Assert.Contains(feedName, output);
+            }
+            else
+            {
+                Assert.Equal("", output.Trim());
+            }
+        }
+    }
+}


### PR DESCRIPTION
```
> seqcli help feed
Usage: seqcli feed <sub-command> [<args>]

Available sub-commands are:
  create     Create a NuGet feed
  list       List NuGet feeds
  remove     Remove a NuGet feed from the server

Type `seqcli help feed <sub-command>` for detailed help

> seqcli help feed create
seqcli feed create [<args>]

Create a NuGet feed

Arguments:
  -n, --name=VALUE           A unique name for the feed
  -l, --location=VALUE       The feed location; this may be a NuGet v2 or v3
                               feed URL, or a local filesystem path on the
                               Seq server
  -u, --username=VALUE       The username Seq should supply when connecting to
                               the feed, if authentication is required
  -p, --password=VALUE       A feed password, if authentication is required;
                               note that `--password-stdin` is more secure
      --password-stdin       Read the feed password from `STDIN`
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --no-color             Don't colorize text output

> seqcli help feed list
seqcli feed list [<args>]

List NuGet feeds

Arguments:
  -n, --name=VALUE           The name of the feed to list
  -i, --id=VALUE             The id of a single feed to list
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --no-color             Don't colorize text output
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used

> seqcli help feed remove
seqcli feed remove [<args>]

Remove a NuGet feed from the server

Arguments:
  -n, --name=VALUE           The name of the feed to remove
  -i, --id=VALUE             The id of a single feed to remove
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
```
