### PR TITLE
`seqcli retention (create|list|remove)`

### DIFF
--- a/seqcli.sln.DotSettings
+++ b/seqcli.sln.DotSettings
@@ -15,6 +15,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hackily/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mdash/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=retentionpolicies/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=retentionpolicy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=roastery/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=seqcli/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>

--- a/src/SeqCli/Cli/Commands/RetentionPolicy/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/RetentionPolicy/CreateCommand.cs
@@ -1,0 +1,84 @@
+﻿// Copyright © Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+using SeqCli.Syntax;
+using SeqCli.Util;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.RetentionPolicy
+{
+    [Command("retention", "create", "Create a retention policy",
+        Example = "seqcli retention create --after 30d --delete-all-events")]
+    class CreateCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+
+        string _afterDuration;
+        bool _deleteAllEvents; // Currently the only supported option
+
+        public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add(
+                "after=",
+                "A duration after which the policy will delete events, e.g. `7d`",
+                v => _afterDuration = ArgumentString.Normalize(v));
+            
+            Options.Add(
+                "delete-all-events",
+                "The policy should delete all events (currently the only supported option)",
+                _ => _deleteAllEvents = true);
+
+            _connection = Enable<ConnectionFeature>();
+            _output = Enable(new OutputFormatFeature(config.Output));
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            if (!_deleteAllEvents)
+            {
+                Log.Error("The `delete-all-events` option must be specified");
+                return 1;
+            }
+            
+            if (_afterDuration == null)
+            {
+                Log.Error("A duration must be specified using `after`");
+                return 1;
+            }
+
+            var duration = DurationMoniker.ToTimeSpan(_afterDuration);
+            
+            var policy = await connection.RetentionPolicies.TemplateAsync();
+            policy.RetentionTime = duration;
+
+            policy = await connection.RetentionPolicies.AddAsync(policy);
+
+            _output.WriteEntity(policy);
+
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/RetentionPolicy/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/RetentionPolicy/ListCommand.cs
@@ -1,0 +1,68 @@
+﻿// Copyright © Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+
+namespace SeqCli.Cli.Commands.RetentionPolicy
+{
+    [Command("retention", "list", "List retention policies", Example="seqcli retention list")]
+    class ListCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+        
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+
+        string _id;
+
+        public ListCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+            
+            Options.Add(
+                "i=|id=",
+                "The id of a single retention policy to list",
+                id => _id = id);
+            
+            _output = Enable(new OutputFormatFeature(config.Output));
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var list = _id != null ?
+                new[] { await connection.RetentionPolicies.FindAsync(_id) } :
+                (await connection.RetentionPolicies.ListAsync())
+                    .ToArray();
+
+            foreach (var policy in list)
+            {
+                if (_output.Json)
+                    _output.WriteEntity(policy);
+                else
+                    Console.WriteLine(policy.Id);
+            }
+            
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/RetentionPolicy/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/RetentionPolicy/RemoveCommand.cs
@@ -1,0 +1,62 @@
+﻿// Copyright © Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Connection;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.RetentionPolicy
+{
+    [Command("retention", "remove", "Remove a retention policy from the server",
+        Example="seqcli retention remove -i retentionpolicy-17")]
+    class RemoveCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+        
+        readonly ConnectionFeature _connection;
+        
+        string _id;
+        
+        public RemoveCommand(SeqConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add(
+                "i=|id=",
+                "The id of a single retention policy to remove",
+                id => _id = id);
+            
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            if (_id == null)
+            {
+                Log.Error("An `id` must be specified");
+                return 1;
+            }
+
+            var connection = _connectionFactory.Connect(_connection);
+
+            var toRemove = await connection.RetentionPolicies.FindAsync(_id);
+
+            await connection.RetentionPolicies.RemoveAsync(toRemove);
+
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Syntax/DurationMoniker.cs
+++ b/src/SeqCli/Syntax/DurationMoniker.cs
@@ -51,9 +51,9 @@ namespace SeqCli.Syntax
             // This is not at all robust; we could use a decent duration parser for use here in `seqcli`.
 
             if (duration.EndsWith("ms"))
-                return TimeSpan.FromMilliseconds(int.Parse(duration.Substring(0, duration.Length - 2)));
+                return TimeSpan.FromMilliseconds(int.Parse(duration[..^2]));
 
-            var value = int.Parse(duration.Substring(0, duration.Length - 1), CultureInfo.InvariantCulture);
+            var value = int.Parse(duration[..^1], CultureInfo.InvariantCulture);
             switch (duration[^1])
             {
                 case 'd':

--- a/test/SeqCli.EndToEnd/RetentionPolicy/RetentionPolicyBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/RetentionPolicy/RetentionPolicyBasicsTestCase.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Linq;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.RetentionPolicies
+{
+    // ReSharper disable once UnusedType.Global
+    public class RetentionPolicyBasicsTestCase : ICliTestCase
+    {
+        public async Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+        {
+            var exit = runner.Exec("retention list");
+            Assert.Equal(0, exit);
+
+            exit = runner.Exec("retention list", "-i retentionpolicy-missing");
+            Assert.Equal(1, exit);
+
+            exit = runner.Exec("retention create", "--after 10h --delete-all-events");
+            Assert.Equal(0, exit);
+
+            var id = runner.LastRunProcess.Output.Trim();
+            exit = runner.Exec("retention list", $"-i {id}");
+            Assert.Equal(0, exit);
+
+            var policy = await connection.RetentionPolicies.FindAsync(id);
+            Assert.Null(policy.RemovedSignalExpression);
+            Assert.Equal(TimeSpan.FromHours(10), policy.RetentionTime);
+
+            exit = runner.Exec("retention remove", $"-i {id}");
+            Assert.Equal(0, exit);
+            
+            exit = runner.Exec("retention list", $"-i {id}");
+            Assert.Equal(1, exit);
+        }
+    }
+}


### PR DESCRIPTION
Retention policy setup is quite fundamental, but missing from `seqcli`.

The requirement to specify removed signal expressions makes this task quite involved; this PR is just an "MVP" to get us started. Only `--delete-all-events` is supported. This will provide enough of a foundation that we can add full signal name/signal expression support in a follow-up.

```
> seqcli help retention
Usage: seqcli retention <sub-command> [<args>]

Available sub-commands are:
  create     Create a retention policy
  list       List retention policies
  remove     Remove a retention policy from the server

Type `seqcli help retention <sub-command>` for detailed help

> seqcli help retention create
seqcli retention create [<args>]

Create a retention policy

Arguments:
      --after=VALUE          A duration after which the policy will delete
                               events, e.g. `7d`
      --delete-all-events    The policy should delete all events (currently
                               the only supported option)
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --no-color             Don't colorize text output

> seqcli help retention list
seqcli retention list [<args>]

List retention policies

Arguments:
  -i, --id=VALUE             The id of a single retention policy to list
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --no-color             Don't colorize text output
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used

> seqcli help retention remove
seqcli retention remove [<args>]

Remove a retention policy from the server

Arguments:
  -i, --id=VALUE             The id of a single retention policy to remove
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used

```

The command name `retention` is a bit awkward, but `retentionpolicy` or `retention-policy` just seems like too many characters :-)