### PR TITLE
`seqcli license apply`

### DIFF
--- a/seqcli.sln.DotSettings
+++ b/seqcli.sln.DotSettings
@@ -4,6 +4,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appinstances/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BASEURI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Camelize/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ceci/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=command_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datalust/@EntryIndexedValue">True</s:Boolean>
@@ -14,6 +15,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gravatar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hackily/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mdash/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=n_0027est/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=retentionpolicies/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=retentionpolicy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=roastery/@EntryIndexedValue">True</s:Boolean>

--- a/src/SeqCli/Cli/Commands/License/ApplyCommand.cs
+++ b/src/SeqCli/Cli/Commands/License/ApplyCommand.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Connection;
+using SeqCli.Util;
+using Serilog;
+
+// ReSharper disable once UnusedType.Global
+
+#nullable enable
+
+namespace  SeqCli.Cli.Commands.License
+{
+    [Command("license", "apply", "Apply a license to the Seq server",
+        Example = "seqcli license apply --certificate=\"license.txt\"")]
+    class ApplyCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+        readonly ConnectionFeature _connection;
+
+        string? _certificateFilename;
+        bool _certificateStdin;
+        bool _automaticallyRefresh;
+        
+        public ApplyCommand(SeqConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add("c=|certificate=",
+                "Certificate file; the file must be UTF-8 text",
+                v => _certificateFilename = ArgumentString.Normalize(v));
+
+            Options.Add("certificate-stdin",
+                "Read the license certificate from `STDIN`",
+                _ => _certificateStdin = true);
+
+            Options.Add("automatically-refresh",
+                "If the license is for a subscription, periodically check `datalust.co` and automatically refresh " +
+                "the certificate when the subscription is changed or renewed",
+                _ => _automaticallyRefresh = true);
+            
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            string certificate;
+            if (_certificateStdin && _certificateFilename == null)
+            {
+                certificate = await Console.In.ReadToEndAsync();
+            }
+            else if (_certificateFilename != null)
+            {
+                if (!File.Exists(_certificateFilename))
+                {
+                    Log.Error("The file `{CertificateFilename}` does not exist", _certificateFilename);
+                    return 1;
+                }
+
+                certificate = await File.ReadAllTextAsync(_certificateFilename, Encoding.UTF8);
+            }
+            else
+            {
+                Log.Error("A certificate must be provided, using one of either `--certificate=` or `--certificate-stdin`");
+                return 1;
+            }
+
+            if (string.IsNullOrWhiteSpace(certificate))
+            {
+                Log.Error("The certificate cannot be blank");
+                return 1;
+            }
+
+            var connection = _connectionFactory.Connect(_connection);
+            var license = await connection.Licenses.FindCurrentAsync();
+            license.LicenseText = certificate;
+            license.AutomaticallyRefresh = _automaticallyRefresh;
+            await connection.Licenses.UpdateAsync(license);
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Util/ArgumentString.cs
+++ b/src/SeqCli/Util/ArgumentString.cs
@@ -14,22 +14,24 @@
 
 using System.Linq;
 
+#nullable enable
+
 namespace SeqCli.Util
 {
     static class ArgumentString
     {
-        public static string Normalize(string argument)
+        public static string? Normalize(string? argument)
         {
             return string.IsNullOrWhiteSpace(argument) ? null : argument.Trim();
         }
 
-        public static string[] NormalizeList(string argument)
+        public static string[] NormalizeList(string? argument)
         {
             return (argument ?? "")
                 .Split(',')
                 .Select(Normalize)
                 .Where(s => s != null)
-                .ToArray();
+                .ToArray()!;
         }
     }
 }

--- a/test/SeqCli.EndToEnd/License/LicenseApplyTestsCasecs.cs
+++ b/test/SeqCli.EndToEnd/License/LicenseApplyTestsCasecs.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.License
+{
+    public class LicenseApplyTestCase : ICliTestCase
+    {
+        readonly TestDataFolder _testDataFolder;
+
+        public LicenseApplyTestCase(TestDataFolder testDataFolder)
+        {
+            _testDataFolder = testDataFolder;
+        }
+        
+        public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+        {
+            var filename = _testDataFolder.ItemPath("license.txt");
+            File.WriteAllText(filename, "Ceci n'est pas une licence");
+            runner.Exec("license apply", $"--certificate=\"{filename}\"");
+            Assert.Equal(
+                "The command failed: 400 - The license format is invalid: data precedes any keys.",
+                runner.LastRunProcess.Output.Trim());
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/LicenseCliSetupTestCase.cs
+++ b/test/SeqCli.EndToEnd/Support/LicenseCliSetupTestCase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Seq.Api;
-using SeqCli.EndToEnd.Support;
 using Serilog;
 
 namespace SeqCli.EndToEnd.Support

--- a/test/SeqCli.EndToEnd/Support/TestDataFolder.cs
+++ b/test/SeqCli.EndToEnd/Support/TestDataFolder.cs
@@ -5,7 +5,7 @@ using Serilog.Core;
 
 namespace SeqCli.EndToEnd.Support
 {
-    sealed class TestDataFolder : IDisposable
+    public sealed class TestDataFolder : IDisposable
     {
         readonly string _basePath;
 
@@ -13,7 +13,7 @@ namespace SeqCli.EndToEnd.Support
         {
             _basePath = System.IO.Path.Combine(
                 System.IO.Path.GetTempPath(),
-                "Seq Test",
+                "SeqCli Test",
                 Guid.NewGuid().ToString("n"));
 
             Directory.CreateDirectory(_basePath);
@@ -21,7 +21,7 @@ namespace SeqCli.EndToEnd.Support
 
         public string Path => _basePath;
 
-        public string Folder(string relativePath)
+        public string ItemPath(string relativePath)
         {
             return System.IO.Path.Combine(_basePath, relativePath);
         }


### PR DESCRIPTION
```
seqcli license apply [<args>]

Apply a license to the Seq server

Arguments:
  -c, --certificate=VALUE    Certificate file; the file must be UTF-8 text
      --certificate-stdin    Read the license certificate from `STDIN`
      --automatically-refresh
                             If the license is for a subscription,
                               periodically check `datalust.co` and
                               automatically refresh the certificate when the
                               subscription is changed or renewed
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
```