### PR TITLE
Track import state and update when re-importing

### DIFF
--- a/src/SeqCli/Cli/Commands/Sample/SetupCommand.cs
+++ b/src/SeqCli/Cli/Commands/Sample/SetupCommand.cs
@@ -79,7 +79,7 @@ namespace SeqCli.Cli.Commands.Sample
                 templates.Add(template);
             }
 
-            var err = await TemplateSetImporter.ImportAsync(templates, connection, templateArgs);
+            var err = await TemplateSetImporter.ImportAsync(templates, connection, templateArgs, new TemplateImportState());
             if (err != null)
             {
                 await Console.Error.WriteLineAsync(err);

--- a/src/SeqCli/Cli/Commands/Sample/SetupCommand.cs
+++ b/src/SeqCli/Cli/Commands/Sample/SetupCommand.cs
@@ -79,7 +79,7 @@ namespace SeqCli.Cli.Commands.Sample
                 templates.Add(template);
             }
 
-            var err = await TemplateSetImporter.ImportAsync(templates, connection, templateArgs, new TemplateImportState());
+            var err = await TemplateSetImporter.ImportAsync(templates, connection, templateArgs, new TemplateImportState(), merge: false);
             if (err != null)
             {
                 await Console.Error.WriteLineAsync(err);

--- a/src/SeqCli/Cli/Commands/Template/ImportCommand.cs
+++ b/src/SeqCli/Cli/Commands/Template/ImportCommand.cs
@@ -30,6 +30,7 @@ namespace SeqCli.Cli.Commands.Template
 
         string? _inputDir = ".";
         string? _stateFile;
+        bool _merge;
         
         public ImportCommand(SeqConnectionFactory connectionFactory)
         {
@@ -46,6 +47,12 @@ namespace SeqCli.Cli.Commands.Template
                 "entities on the target server, avoiding duplicates when multiple imports are performed; by default, " +
                 "`import.state` in the input directory will be used",
                 s => _stateFile = ArgumentString.Normalize(s));
+
+            Options.Add(
+                "merge",
+                "For templates with no entries in the `.state` file, first check for existing entities with matching names or titles; " +
+                "does not support merging of retention policies",
+                _ => _merge = true);
 
             _args = Enable(new PropertiesFeature("g", "arg", "Template arguments, e.g. `-g ownerId=user-314159`"));
             _connection = Enable<ConnectionFeature>();
@@ -93,7 +100,7 @@ namespace SeqCli.Cli.Commands.Template
                 }));
 
             var connection = _connectionFactory.Connect(_connection);
-            var err = await TemplateSetImporter.ImportAsync(templates, connection, args, state);
+            var err = await TemplateSetImporter.ImportAsync(templates, connection, args, state, _merge);
 
             await TemplateImportState.SaveAsync(stateFile, state);
 

--- a/src/SeqCli/Program.cs
+++ b/src/SeqCli/Program.cs
@@ -27,12 +27,6 @@ namespace SeqCli
     {
         static async Task<int> Main(string[] args)
         {
-#if WINDOWS
-            // This reverts to using the WinHTTP stack instead of managed sockets, so that
-            // Windows proxy settings are respected 
-            AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
-#endif
-
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Error()
                 .WriteTo.Console(

--- a/src/SeqCli/Sample/Templates/dashboard-Database.template
+++ b/src/SeqCli/Sample/Templates/dashboard-Database.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "dashboard",
   "OwnerId": arg("ownerId"),
   "Title": "Database",

--- a/src/SeqCli/Sample/Templates/dashboard-HTTP Requests.template
+++ b/src/SeqCli/Sample/Templates/dashboard-HTTP Requests.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "dashboard",
   "OwnerId": arg("ownerId"),
   "Title": "HTTP Requests",

--- a/src/SeqCli/Sample/Templates/dashboard-Orders.template
+++ b/src/SeqCli/Sample/Templates/dashboard-Orders.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "dashboard",
   "OwnerId": arg("ownerId"),
   "Title": "Orders",

--- a/src/SeqCli/Sample/Templates/retentionpolicy-Sample Data.template
+++ b/src/SeqCli/Sample/Templates/retentionpolicy-Sample Data.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "retentionpolicy",
   "RetentionTime": "30.00:00:00",
   "RemovedSignalExpression": {

--- a/src/SeqCli/Sample/Templates/signal-Bad Request.template
+++ b/src/SeqCli/Sample/Templates/signal-Bad Request.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Bad Request",

--- a/src/SeqCli/Sample/Templates/signal-Batch Processing.template
+++ b/src/SeqCli/Sample/Templates/signal-Batch Processing.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Batch Processing",

--- a/src/SeqCli/Sample/Templates/signal-Database.template
+++ b/src/SeqCli/Sample/Templates/signal-Database.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Database",

--- a/src/SeqCli/Sample/Templates/signal-HTTP Requests.template
+++ b/src/SeqCli/Sample/Templates/signal-HTTP Requests.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "HTTP Requests",

--- a/src/SeqCli/Sample/Templates/signal-Information.template
+++ b/src/SeqCli/Sample/Templates/signal-Information.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Information",

--- a/src/SeqCli/Sample/Templates/signal-Internal Server Error.template
+++ b/src/SeqCli/Sample/Templates/signal-Internal Server Error.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Internal Server Error",

--- a/src/SeqCli/Sample/Templates/signal-Not Found.template
+++ b/src/SeqCli/Sample/Templates/signal-Not Found.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Not Found",

--- a/src/SeqCli/Sample/Templates/signal-Order Abandoned.template
+++ b/src/SeqCli/Sample/Templates/signal-Order Abandoned.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Order Abandoned",

--- a/src/SeqCli/Sample/Templates/signal-Order Archived.template
+++ b/src/SeqCli/Sample/Templates/signal-Order Archived.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Order Archived",

--- a/src/SeqCli/Sample/Templates/signal-Order Created.template
+++ b/src/SeqCli/Sample/Templates/signal-Order Created.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Order Created",

--- a/src/SeqCli/Sample/Templates/signal-Order Placed.template
+++ b/src/SeqCli/Sample/Templates/signal-Order Placed.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Order Placed",

--- a/src/SeqCli/Sample/Templates/signal-Order Shipped.template
+++ b/src/SeqCli/Sample/Templates/signal-Order Shipped.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Order Shipped",

--- a/src/SeqCli/Sample/Templates/signal-Sample Data.template
+++ b/src/SeqCli/Sample/Templates/signal-Sample Data.template
@@ -1,5 +1,4 @@
 ﻿{
-    "$version": 1,
     "$entity": "signal",
     "Title": "Sample Data",
     "Description": "Created by `seqcli sample setup`",

--- a/src/SeqCli/Sample/Templates/signal-Stock Level Warnings.template
+++ b/src/SeqCli/Sample/Templates/signal-Stock Level Warnings.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Stock Level Warnings",

--- a/src/SeqCli/Sample/Templates/signal-Success.template
+++ b/src/SeqCli/Sample/Templates/signal-Success.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Success",

--- a/src/SeqCli/Sample/Templates/signal-Web Frontend.template
+++ b/src/SeqCli/Sample/Templates/signal-Web Frontend.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "signal",
   "OwnerId": arg("ownerId"),
   "Title": "Web Frontend",

--- a/src/SeqCli/Sample/Templates/sqlquery-Order Items by Product Size.template
+++ b/src/SeqCli/Sample/Templates/sqlquery-Order Items by Product Size.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "sqlquery",
   "OwnerId": arg("ownerId"),
   "Title": "Order Items by Product Size",

--- a/src/SeqCli/Sample/Templates/sqlquery-Route Bindings.template
+++ b/src/SeqCli/Sample/Templates/sqlquery-Route Bindings.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "sqlquery",
   "OwnerId": arg("ownerId"),
   "Title": "Route Bindings",

--- a/src/SeqCli/Sample/Templates/workspace-Sample.template
+++ b/src/SeqCli/Sample/Templates/workspace-Sample.template
@@ -1,5 +1,4 @@
 {
-  "$version": 1,
   "$entity": "workspace",
   "OwnerId": arg("ownerId"),
   "Title": "Sample",

--- a/src/SeqCli/Templates/Export/TemplateWriter.cs
+++ b/src/SeqCli/Templates/Export/TemplateWriter.cs
@@ -70,8 +70,6 @@ namespace SeqCli.Templates.Export
 
             if (annotateAsResource)
             {
-                await jw.WritePropertyNameAsync("$version");
-                await jw.WriteValueAsync(1);
                 await jw.WritePropertyNameAsync("$entity");
                 await jw.WriteValueAsync(EntityName.FromEntityType(o.GetType()));
             }

--- a/src/SeqCli/Templates/Import/EntityTemplateFileLoader.cs
+++ b/src/SeqCli/Templates/Import/EntityTemplateFileLoader.cs
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using SeqCli.Templates.Ast;
 using SeqCli.Templates.Export;
 using SeqCli.Templates.Parser;
 
+#nullable enable
+
 namespace SeqCli.Templates.Import
 {
     static class EntityTemplateLoader
     {
-        public static bool Load(string path, out EntityTemplate template, out string error)
+        public static bool Load(string path, [MaybeNullWhen(false)] out EntityTemplate template, [MaybeNullWhen(true)] out string error)
         {
             if (!File.Exists(path))
             {
@@ -48,15 +51,6 @@ namespace SeqCli.Templates.Import
                 return false;
             }
             
-            if (!rootDictionary.Members.TryGetValue("$version", out var versionToken) ||
-                versionToken is not JsonTemplateNumber version ||
-                version.Value != 1m)
-            {
-                template = null;
-                error = "the template must include a `$version` property with the value `1`";
-                return false;
-            }
-
             var resourceGroup = EntityName.ToResourceGroup(resource.Value);
             var filename = Path.GetFileName(path);
             

--- a/src/SeqCli/Templates/Import/EntityTemplateFunctions.cs
+++ b/src/SeqCli/Templates/Import/EntityTemplateFunctions.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using SeqCli.Templates.Ast;
+using SeqCli.Templates.Evaluator;
+
+#nullable enable
+
+namespace SeqCli.Templates.Import
+{
+    class EntityTemplateFunctions
+    {
+        readonly TemplateImportState _state;
+        readonly IReadOnlyDictionary<string, JsonTemplate> _templateArgs;
+
+        public EntityTemplateFunctions(TemplateImportState state, IReadOnlyDictionary<string, JsonTemplate> templateArgs)
+        {
+            _state = state;
+            _templateArgs = templateArgs;
+            
+            Exports = new Dictionary<string, JsonTemplateFunction>
+            {
+                ["ref"] = Ref,
+                ["arg"] = Arg
+            };
+        }
+
+        public IReadOnlyDictionary<string, JsonTemplateFunction> Exports { get; }
+
+        bool Ref(JsonTemplate[] args, [MaybeNullWhen(false)] out JsonTemplate result, [MaybeNullWhen(true)] out string err)
+        {
+            if (args.Length != 1 || args[0] is not JsonTemplateString { Value: { } filename })
+            {
+                result = null;
+                err = "The `ref()` function accepts a single string argument corresponding to the referenced template filename.";
+                return false;
+            }
+
+            if (!_state.TryGetCreatedEntityId(filename, out var referencedId))
+            {
+                result = null;
+                err = $"The referenced template file `{filename}` does not exist or has not been evaluated.";
+                return false;
+            }
+
+            result = new JsonTemplateString(referencedId);
+            err = null;
+            return true;
+        }
+
+        bool Arg(JsonTemplate[] args, [MaybeNullWhen(false)] out JsonTemplate result, [MaybeNullWhen(true)] out string err)
+        {
+            if (args.Length != 1 || args[0] is not JsonTemplateString { Value: { } templateArgName })
+            {
+                result = null;
+                err = "The `arg()` function accepts a single string argument corresponding to the template argument name.";
+                return false;
+            }
+
+            if (!_templateArgs.TryGetValue(templateArgName, out result))
+            {
+                err = $"The argument `{templateArgName}` is not defined.";
+                return false;
+            }
+
+            err = null;
+            return true;
+        }
+    }
+}

--- a/src/SeqCli/Templates/Import/GenericEntity.cs
+++ b/src/SeqCli/Templates/Import/GenericEntity.cs
@@ -14,8 +14,14 @@
 
 using Seq.Api.Model;
 
+#nullable enable
+
 namespace SeqCli.Templates.Import
 {
     // ReSharper disable once ClassNeverInstantiated.Global
-    class GenericEntity : Entity { }
+    class GenericEntity : Entity
+    {
+        public string? Title { get; set; }
+        public string? Name { get; set; }
+    }
 }

--- a/src/SeqCli/Templates/Import/TemplateImportState.cs
+++ b/src/SeqCli/Templates/Import/TemplateImportState.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace SeqCli.Templates.Import
+{
+    class TemplateImportState
+    {
+        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global, MemberCanBePrivate.Global
+        // Exposed just for serialization's sake.
+        public Dictionary<string, string> Created { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        
+        public static async Task<TemplateImportState> LoadAsync(string stateFile)
+        {
+            await using var file = File.OpenRead(stateFile);
+            var options = new JsonSerializerOptions {PropertyNamingPolicy = JsonNamingPolicy.CamelCase};
+            return await JsonSerializer.DeserializeAsync<TemplateImportState>(file, options)
+                   ?? throw new InvalidOperationException("File does not contain a valid import state.");
+        }
+
+        public static async Task SaveAsync(string stateFile, TemplateImportState state)
+        {
+            var tmp = stateFile + ".tmp";
+            await using (var file = File.Create(tmp))
+            {
+                var options = new JsonSerializerOptions {PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true};
+                await JsonSerializer.SerializeAsync(file, state, options);
+            }
+            if (File.Exists(stateFile))
+                File.Replace(tmp, stateFile, destinationBackupFileName: null);
+            else
+                File.Move(tmp, stateFile);
+        }
+
+        public bool TryGetCreatedEntityId(string templateName, [MaybeNullWhen(false)] out string entityId) =>
+            Created.TryGetValue(templateName, out entityId);
+
+        public void AddOrUpdateCreatedEntityId(string templateName, string entityId) =>
+            Created[templateName] = entityId;
+    }
+}

--- a/src/SeqCli/Templates/Import/TemplateSetImporter.cs
+++ b/src/SeqCli/Templates/Import/TemplateSetImporter.cs
@@ -25,17 +25,20 @@ using SeqCli.Templates.Evaluator;
 using SeqCli.Templates.ObjectGraphs;
 using Serilog;
 
-// ReSharper disable SuggestBaseTypeForParameter
+// ReSharper disable SuggestBaseTypeForParameter, CommentTypo
+
+#nullable enable
 
 namespace SeqCli.Templates.Import
 {
     static class TemplateSetImporter
     {
-        public static async Task<string> ImportAsync(
+        public static async Task<string?> ImportAsync(
             IEnumerable<EntityTemplate> templates,
             SeqConnection connection,
             IReadOnlyDictionary<string, JsonTemplate> args,
-            TemplateImportState state)
+            TemplateImportState state,
+            bool merge)
         {
             var ordering = new[] {"users", "signals", "apps", "appinstances",
                 "dashboards", "sqlqueries", "workspaces", "retentionpolicies"}.ToList();
@@ -43,10 +46,12 @@ namespace SeqCli.Templates.Import
             var sorted = templates.OrderBy(t => ordering.IndexOf(t.ResourceGroup));
             
             var apiRoot = await connection.Client.GetRootAsync();
+
+            var functions = new EntityTemplateFunctions(state, args);
             
             foreach (var entityTemplateFile in sorted)
             {
-                var err = await ApplyTemplateAsync(entityTemplateFile, args, state, connection, apiRoot);
+                var err = await ApplyTemplateAsync(entityTemplateFile, functions, state, connection, apiRoot, merge);
                 if (err != null)
                     return err;
             }
@@ -54,65 +59,20 @@ namespace SeqCli.Templates.Import
             return null;
         }
 
-        static async Task<string> ApplyTemplateAsync(
+        static async Task<string?> ApplyTemplateAsync(
             EntityTemplate template,
-            IReadOnlyDictionary<string, JsonTemplate> templateArgs, 
+            EntityTemplateFunctions functions,
             TemplateImportState state,
             SeqConnection connection,
-            RootEntity apiRoot)
+            RootEntity apiRoot,
+            bool merge)
         {
-            bool Ref(JsonTemplate[] args, out JsonTemplate result, out string err)
-            {
-                if (args.Length != 1 || args[0] is not JsonTemplateString { Value: { } filename })
-                {
-                    result = null;
-                    err = "The `ref()` function accepts a single string argument corresponding to the referenced template filename.";
-                    return false;
-                }
-
-                if (!state.TryGetCreatedEntityId(filename, out var referencedId))
-                {
-                    result = null;
-                    err = $"The referenced template file `{filename}` does not exist or has not been evaluated.";
-                    return false;
-                }
-
-                result = new JsonTemplateString(referencedId);
-                err = null;
-                return true;
-            }
-
-            bool Arg(JsonTemplate[] args, out JsonTemplate result, out string err)
-            {
-                if (args.Length != 1 || args[0] is not JsonTemplateString { Value: { } templateArgName })
-                {
-                    result = null;
-                    err = "The `arg()` function accepts a single string argument corresponding to the template argument name.";
-                    return false;
-                }
-
-                if (!templateArgs.TryGetValue(templateArgName, out result) ||
-                    result == null)
-                {
-                    err = $"The argument `{templateArgName}` is not defined.";
-                    return false;
-                }
-
-                err = null;
-                return true;
-            }
-
-            var functions = new Dictionary<string, JsonTemplateFunction>
-            {
-                ["ref"] = Ref,
-                ["arg"] = Arg
-            };
-            
-            if (!JsonTemplateEvaluator.TryEvaluate(template.Entity, functions, out var entity, out var error))
+            if (!JsonTemplateEvaluator.TryEvaluate(template.Entity, functions.Exports, out var entity, out var error))
                 return error;
 
-            var asObject = JsonTemplateObjectGraphConverter.Convert(entity);
+            var asObject = (IDictionary<string, object>) JsonTemplateObjectGraphConverter.Convert(entity);
 
+            // O(Ntemplates) - easy target for optimization with some caching.
             var resourceGroupLink = template.ResourceGroup + "Resources";
             var link = apiRoot.Links.Single(l => resourceGroupLink.Equals(l.Key, StringComparison.OrdinalIgnoreCase));
             var resourceGroup = await connection.Client.GetAsync<ResourceGroup>(apiRoot, link.Key);
@@ -120,9 +80,17 @@ namespace SeqCli.Templates.Import
             if (state.TryGetCreatedEntityId(template.Name, out var existingId) &&
                 await CheckEntityExistenceAsync(connection, resourceGroup, existingId))
             {
-                ((IDictionary<string, object>) asObject)["Id"] = existingId;
+                asObject["Id"] = existingId;
                 await UpdateEntityAsync(connection, resourceGroup, asObject, existingId);
                 Log.Information("Updated existing entity {EntityId} from {TemplateName}", existingId, template.Name);
+            }
+            else if (merge && !state.TryGetCreatedEntityId(template.Name, out _) &&
+                     await TryFindMergeTargetAsync(connection, resourceGroup, asObject) is { } mergedId)
+            {
+                asObject["Id"] = mergedId;
+                await UpdateEntityAsync(connection, resourceGroup, asObject, mergedId);
+                state.AddOrUpdateCreatedEntityId(template.Name, mergedId);
+                Log.Information("Merged and updated existing entity {EntityId} from {TemplateName}", existingId, template.Name);
             }
             else
             {
@@ -132,6 +100,25 @@ namespace SeqCli.Templates.Import
             }
             
             return null;
+        }
+
+        static async Task<string?> TryFindMergeTargetAsync(SeqConnection connection, ResourceGroup resourceGroup, IDictionary<string, object> entity)
+        {
+            if (!entity.TryGetValue("Title", out var nameOrTitleValue) &&
+                !entity.TryGetValue("Name", out nameOrTitleValue) ||
+                nameOrTitleValue is not string nameOrTitle)
+            {
+                return null;
+            }
+
+            // O(Ntemplates*Nentities) - easy target for optimization with some caching.
+            var candidates = await connection.Client.GetAsync<List<GenericEntity>>(resourceGroup, "Items",
+                new Dictionary<string, object>
+                {
+                    ["shared"] = true
+                });
+
+            return candidates.FirstOrDefault(e => e.Title == nameOrTitle || e.Name == nameOrTitle)?.Id;
         }
 
         static async Task<string> CreateEntityAsync(SeqConnection connection, ResourceGroup resourceGroup, object entity)

--- a/test/SeqCli.EndToEnd/Templates/TemplateExportImportTestCase.cs
+++ b/test/SeqCli.EndToEnd/Templates/TemplateExportImportTestCase.cs
@@ -47,6 +47,13 @@ namespace SeqCli.EndToEnd.Templates
 
             var created = Assert.Single(await connection.Signals.ListAsync(shared: true), s => s.Title == newTitle)!;
             Assert.Equal(description, created!.Description);
+            
+            // Uses import state
+            exit = runner.Exec("template import", $"-i \"{_testDataFolder.Path}\"");
+            Assert.Equal(0, exit);
+
+            var updated = Assert.Single(await connection.Signals.ListAsync(shared: true), s => s.Title == newTitle)!;
+            Assert.Equal(created.Id, updated.Id);
         }
     }
 }

--- a/test/SeqCli.EndToEnd/Templates/TemplateExportImportTestCase.cs
+++ b/test/SeqCli.EndToEnd/Templates/TemplateExportImportTestCase.cs
@@ -45,15 +45,15 @@ namespace SeqCli.EndToEnd.Templates
             exit = runner.Exec("template import", $"-i \"{_testDataFolder.Path}\"");
             Assert.Equal(0, exit);
 
-            var created = Assert.Single(await connection.Signals.ListAsync(shared: true), s => s.Title == newTitle)!;
+            var created = Assert.Single(await connection.Signals.ListAsync(shared: true), s => s.Title == newTitle);
             Assert.Equal(description, created!.Description);
             
             // Uses import state
             exit = runner.Exec("template import", $"-i \"{_testDataFolder.Path}\"");
             Assert.Equal(0, exit);
 
-            var updated = Assert.Single(await connection.Signals.ListAsync(shared: true), s => s.Title == newTitle)!;
-            Assert.Equal(created.Id, updated.Id);
+            var updated = Assert.Single(await connection.Signals.ListAsync(shared: true), s => s.Title == newTitle);
+            Assert.Equal(created.Id, updated!.Id);
         }
     }
 }

--- a/test/SeqCli.Tests/Templates/test-Expected.template
+++ b/test/SeqCli.Tests/Templates/test-Expected.template
@@ -1,5 +1,4 @@
 ﻿{
-  "$version": 1,
   "$entity": "test",
   "ReferencedId": ref("Referenced"),
   "Name": "Test Stuff",


### PR DESCRIPTION
Persists the mapping from template names to created entity ids when importing into the destination server. This information is used in subsequent imports to apply updates to any existing entities, instead of creating duplicates.

We don't yet do this for `seqcli sample setup` (could be one to do down the line).

Also removes `$version` support - it's unlikely that this will be able to ensure a better experience than just failing when a template is no longer usable because of breaking changes in the future.

Removes conditional use of `AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);`, this hasn't worked since `net5.0`.
