### PR TITLE
Fix Seq.Api dependency version

### DIFF
--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Superpower" Version="2.3.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="5.0.0" />
-    <PackageReference Include="Seq.Api" Version="2021.3.0-dev-00168" />
+    <PackageReference Include="Seq.Api" Version="2021.3.0-dev-00167" />
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
     <!-- Seq.Api pulls in Tavis.UriTemplates which pulls in version 1.6.0 of this package, causing
          package downgrade warnings. -->


### PR DESCRIPTION
The last Seq.Api NuGet package was incorrectly published as 2020.3.*; this points us back to the correct, updated one.