### PR TITLE
node list, node health, node demote commands; -v universal verbose option

### DIFF
--- a/src/SeqCli/Cli/Command.cs
+++ b/src/SeqCli/Cli/Command.cs
@@ -51,11 +51,16 @@ namespace SeqCli.Cli
 
         public void PrintUsage()
         {
-            if (Options.Any())
+            var allOptions = new OptionSet();
+            foreach (var option in Options)
             {
-                Console.Error.WriteLine("Arguments:");
-                Options.WriteOptionDescriptions(Console.Error);
+                allOptions.Add(option);
             }
+
+            allOptions.Add("v|verbose", "Print verbose output to `STDERR`", _ => { });
+
+            Console.Error.WriteLine("Arguments:");
+            allOptions.WriteOptionDescriptions(Console.Error);
         }
 
         public async Task<int> Invoke(string[] args)

--- a/src/SeqCli/Cli/Commands/Node/DemoteCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/DemoteCommand.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Seq.Api.Model.Cluster;
+using SeqCli.Cli.Features;
+using SeqCli.Connection;
+using Serilog;
+
+#nullable enable
+
+namespace SeqCli.Cli.Commands.Node
+{
+    [Command("node", "demote", "Begin demotion of the current leader node", 
+        Example = "seqcli node demote -v --wait")]
+    class DemoteCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly ConnectionFeature _connection;
+        bool _wait;
+
+        public DemoteCommand(SeqConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+            Options.Add("wait", "Wait for the leader to be demoted before exiting", _ => _wait = true);
+            
+            _connection = Enable<ConnectionFeature>();
+        }
+
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var demoting = (await connection.ClusterNodes.ListAsync()).SingleOrDefault(n => n.Role == NodeRole.Leader);
+
+            if (demoting == null)
+            {
+                Log.Error("No cluster node is in the leader role");
+                return 1;
+            }
+            
+            await connection.ClusterNodes.DemoteAsync(demoting);
+
+            if (!_wait)
+            {
+                Log.Information("Demotion of node {ClusterNodeId}/{ClusterNodeName} commenced", demoting.Id, demoting.Name);
+                return 0;
+            }
+
+            var lastStatus = demoting.StateDescription;
+            Log.Information("Waiting for demotion of node {ClusterNodeId}/{ClusterNodeName} to complete ({LeaderNodeStatus})", demoting.Id, demoting.Name, lastStatus);
+
+            while (true)
+            {
+                await Task.Delay(100);
+                
+                var nodes = await connection.ClusterNodes.ListAsync();
+                demoting = nodes.FirstOrDefault(n => n.Id == demoting.Id);
+
+                if (demoting == null)
+                {
+                    var newLeader = nodes.Single(n => n.Role == NodeRole.Leader);
+                    Log.Information("Demotion completed; old leader is out of service, new leader is {ClusterNodeId}/{ClusterNodeName}", newLeader.Id, newLeader.Name);
+                    return 0;
+                }
+
+                if (demoting.StateDescription != lastStatus)
+                {
+                    lastStatus = demoting.StateDescription;
+                    Log.Information("Demotion in progress ({LeaderNodeStatus})", lastStatus);
+                }
+            }
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Connection;
+using SeqCli.Util;
+using Serilog;
+
+#nullable enable
+
+namespace SeqCli.Cli.Commands.Node
+{
+    [Command("node", "health",
+        "Probe a Seq node's `/health` endpoint, and print the returned HTTP status code, or 'Unreachable' if the endpoint could not be queried",
+        Example = "seqcli node health -s https://seq-2.example.com")]
+    class HealthCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        string? _profileName, _serverUrl;
+
+        public HealthCommand(SeqConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+            
+            Options.Add("s=|server=",
+                "The URL of the Seq server; by default the `connection.serverUrl` config value will be used",
+                v => _serverUrl = ArgumentString.Normalize(v));
+
+            Options.Add("profile=",
+                "A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used",
+                v => _profileName = ArgumentString.Normalize(v));
+        }
+
+        protected override async Task<int> Run()
+        {
+            // An API key is not accepted; we don't want to imply that /health requires authentication.
+            var surrogateConnectionFeature = new ConnectionFeature { ProfileName = _profileName, Url = _serverUrl };
+            var connection = _connectionFactory.Connect(surrogateConnectionFeature);
+
+            try
+            {
+                var response = await connection.Client.HttpClient.GetAsync("health");
+                Console.WriteLine($"HTTP {response.Version} {((int)response.StatusCode).ToString(CultureInfo.InvariantCulture)} {response.ReasonPhrase}");
+                foreach (var (key, values) in response.Headers.Concat(response.Content.Headers))
+                foreach (var value in values)
+                {
+                    Console.WriteLine($"{key}: {value}");
+                }
+                Console.WriteLine(await response.Content.ReadAsStringAsync());
+                return response.IsSuccessStatusCode ? 0 : 1;
+            }
+            catch (Exception ex)
+            {
+                Log.Information(ex, "Exception thrown when calling health endpoint");
+                
+                Console.WriteLine("Unreachable");
+                Console.WriteLine(Presentation.FormattedMessage(ex));
+                return 1;
+            }
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Node/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/ListCommand.cs
@@ -1,0 +1,73 @@
+﻿// Copyright Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+
+#nullable enable
+
+namespace SeqCli.Cli.Commands.Node
+{
+    [Command("node", "list", "List nodes in the Seq cluster",
+        Example = "seqcli node list --json")]
+    class ListCommand : Command
+    {
+        readonly SeqConnectionFactory _connectionFactory;
+
+        readonly ConnectionFeature _connection;
+        readonly OutputFormatFeature _output;
+
+        string? _name, _id;
+        
+        public ListCommand(SeqConnectionFactory connectionFactory, SeqCliOutputConfig outputConfig)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+            
+            Options.Add(
+                "n=|name=",
+                "The name of the cluster node to list",
+                n => _name = n);
+
+            Options.Add(
+                "i=|id=",
+                "The id of a single cluster node to list",
+                id => _id = id);
+            
+            _output = Enable(new OutputFormatFeature(outputConfig));
+            _connection = Enable<ConnectionFeature>();
+        }
+        
+        protected override async Task<int> Run()
+        {
+            var connection = _connectionFactory.Connect(_connection);
+
+            var list = _id != null ?
+                new[] { await connection.ClusterNodes.FindAsync(_id) } :
+                (await connection.ClusterNodes.ListAsync())
+                .Where(n => _name == null || _name == n.Name)
+                .ToArray();
+
+            foreach (var clusterNode in list)
+            {
+                _output.WriteEntity(clusterNode);
+            }
+            
+            return 0;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/VersionCommand.cs
+++ b/src/SeqCli/Cli/Commands/VersionCommand.cs
@@ -30,7 +30,7 @@ namespace SeqCli.Cli.Commands
             return Task.FromResult(0);
         }
 
-        static string GetVersion()
+        public static string GetVersion()
         {
             return typeof(VersionCommand).GetTypeInfo().Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;

--- a/src/SeqCli/Cli/Commands/VersionCommand.cs
+++ b/src/SeqCli/Cli/Commands/VersionCommand.cs
@@ -16,6 +16,8 @@ using System;
 using System.Reflection;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace SeqCli.Cli.Commands
 {
     [Command("version", "Print the current executable version")]
@@ -28,10 +30,10 @@ namespace SeqCli.Cli.Commands
             return Task.FromResult(0);
         }
 
-        public static string GetVersion()
+        static string GetVersion()
         {
             return typeof(VersionCommand).GetTypeInfo().Assembly
-                .GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
         }
     }
 }

--- a/src/SeqCli/Cli/Features/ConnectionFeature.cs
+++ b/src/SeqCli/Cli/Features/ConnectionFeature.cs
@@ -14,6 +14,8 @@
 
 using SeqCli.Util;
 
+#nullable enable
+
 namespace SeqCli.Cli.Features
 {
     class ConnectionFeature : CommandFeature
@@ -22,9 +24,9 @@ namespace SeqCli.Cli.Features
         public bool IsApiKeySpecified => ApiKey != null;
         public bool IsProfileNameSpecified => ProfileName != null;
 
-        public string Url { get; set; }
-        public string ApiKey { get; set; }
-        public string ProfileName { get; set; }
+        public string? Url { get; set; }
+        public string? ApiKey { get; set; }
+        public string? ProfileName { get; set; }
 
         public override void Enable(OptionSet options)
         {

--- a/src/SeqCli/Connection/SeqConnectionFactory.cs
+++ b/src/SeqCli/Connection/SeqConnectionFactory.cs
@@ -17,6 +17,8 @@ using Seq.Api;
 using SeqCli.Cli.Features;
 using SeqCli.Config;
 
+#nullable enable
+
 namespace SeqCli.Connection
 {
     class SeqConnectionFactory
@@ -34,11 +36,11 @@ namespace SeqCli.Connection
             return new SeqConnection(url, apiKey);
         }
         
-        public (string, string) GetConnectionDetails(ConnectionFeature connection)
+        public (string? serverUrl, string? apiKey) GetConnectionDetails(ConnectionFeature connection)
         {
             if (connection == null) throw new ArgumentNullException(nameof(connection));
 
-            string url, apiKey;
+            string? url, apiKey;
             if (connection.IsUrlSpecified)
             {
                 url = connection.Url;
@@ -46,7 +48,7 @@ namespace SeqCli.Connection
             }
             else if (connection.IsProfileNameSpecified)
             {
-                if (!_config.Profiles.TryGetValue(connection.ProfileName, out var profile))
+                if (!_config.Profiles.TryGetValue(connection.ProfileName!, out var profile))
                     throw new ArgumentException($"A profile named `{connection.ProfileName}` was not found; see `seqcli profile list` for available profiles.");
                 
                 url = profile.ServerUrl;

--- a/test/SeqCli.EndToEnd/Node/NodeDemoteTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeDemoteTestCase.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace SeqCli.EndToEnd.Node
 {
+    [CliTestCase(MinimumApiVersion = "2021.3.6410")]
     public class NodeDemoteTestCase: ICliTestCase
     {
         public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)

--- a/test/SeqCli.EndToEnd/Node/NodeDemoteTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeDemoteTestCase.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Node
+{
+    public class NodeDemoteTestCase: ICliTestCase
+    {
+        public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+        {
+            var exit = runner.Exec("node demote -v --wait --confirm");
+            Assert.Equal(1, exit);
+            Assert.Contains("No cluster node is in the leader role", runner.LastRunProcess!.Output);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Node/NodeHealthTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeHealthTestCase.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Node
+{
+    public class NodeHealthTestCase: ICliTestCase
+    {
+        public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+        {
+            var exit = runner.Exec("node health");
+            Assert.Equal(0, exit);
+            Assert.StartsWith("HTTP 1.1 200 OK", runner.LastRunProcess!.Output);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Node/NodeHealthTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeHealthTestCase.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace SeqCli.EndToEnd.Node
 {
+    [CliTestCase(MinimumApiVersion = "2021.3.6410")]
     public class NodeHealthTestCase: ICliTestCase
     {
         public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)

--- a/test/SeqCli.EndToEnd/Node/NodeListTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeListTestCase.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Node
+{
+    public class NodeListTestCase: ICliTestCase
+    {
+        public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+        {
+            var exit = runner.Exec("node list --json");
+            Assert.Equal(0, exit);
+            
+            Assert.Contains("\"Role\":", runner.LastRunProcess!.Output);
+            Assert.Contains("\"Name\":", runner.LastRunProcess!.Output);
+            Assert.Contains("\"StateDescription\":", runner.LastRunProcess!.Output);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Node/NodeListTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeListTestCase.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace SeqCli.EndToEnd.Node
 {
+    [CliTestCase(MinimumApiVersion = "2021.3.6410")]
     public class NodeListTestCase: ICliTestCase
     {
         public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)

--- a/test/SeqCli.EndToEnd/Support/CliCommandRunner.cs
+++ b/test/SeqCli.EndToEnd/Support/CliCommandRunner.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+#nullable enable
+
 namespace SeqCli.EndToEnd.Support
 {
     public class CliCommandRunner
@@ -7,20 +9,18 @@ namespace SeqCli.EndToEnd.Support
         readonly TestConfiguration _configuration;
         static readonly TimeSpan DefaultExecTimeout = TimeSpan.FromSeconds(10);
         
-        public ITestProcess LastRunProcess { get; private set; }
+        public ITestProcess? LastRunProcess { get; private set; }
 
         public CliCommandRunner(TestConfiguration configuration)
         {
             _configuration = configuration;
         }
 
-        public int Exec(string command, string args = null, bool disconnected = false)
+        public int Exec(string command, string? args = null, bool disconnected = false)
         {
-            using (var process = _configuration.SpawnCliProcess(command, args, skipServerArg: disconnected))
-            {
-                LastRunProcess = process;
-                return process.WaitForExit(DefaultExecTimeout);
-            }
+            using var process = _configuration.SpawnCliProcess(command, args, skipServerArg: disconnected);
+            LastRunProcess = process;
+            return process.WaitForExit(DefaultExecTimeout);
         }
     }
 }


### PR DESCRIPTION
```
> seqcli node list
clusternode-7c368fb0dd3d47f2b7431a268ddd1573 seq002.datalust.example.com
clusternode-1f90287152a4098aac97fa445465c58 seq001.datalust.example.com

> seqcli node list --json
{"Role": "Leader", "Name": "seq002.datalust.example.com", "Generation": "0:0", 
"IsUpToDate": null, "MillisecondsSinceLastSync": null, "StateDescription": "The 
node is online.", "Id": "clusternode-7c368fb0dd3d47f2b7431a268ddd1573"}
{"Role": "Follower", "Name": "seq001.datalust.example.com", "Generation": "0:0", 
"IsUpToDate": true, "MillisecondsSinceLastSync": 272, "StateDescription": null,
 "Id": "clusternode-1f90287152a4098aac97fa445465c58"}

> seqcli node health
HTTP 1.1 200 OK
Transfer-Encoding: chunked
Server: Microsoft-HTTPAPI/2.0
Date: Thu, 09 Sep 2021 04:51:46 GMT
Content-Type: application/json; charset=utf-8
{"status": "The Seq node is in service."}

> seqcli node demote -v --wait
Waiting for demotion of node clusternode-7c368fb0dd3d47f2b7431a268ddd15
73/seq002.datalust.example.com to complete (The node is online.)
Demotion in progress (The node is stopping inputs in preparation for demotion.)
Demotion in progress (The node is flushing queued read operations in preparation for demotion.)
Demotion completed; old leader is out of service, new leader is clusternode-
1f90287152a4098aac97fa445465c58/seq001.datalust.example.com
```
