### PR TITLE
Add columns as an option when creating signals

### DIFF
--- a/Build.Docker.ps1
+++ b/Build.Docker.ps1
@@ -14,7 +14,11 @@ function Execute-Tests
     cd ./test/SeqCli.EndToEnd/
     docker pull datalust/seq:latest
     & dotnet run -f $framework -- --docker-server
-    if ($LASTEXITCODE -ne 0) { exit 1 }
+    if ($LASTEXITCODE -ne 0)
+    { 
+        cd ../..
+        exit 1 
+    }
     cd ../..
 }
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ seqcli apikey create -t 'Test API Key' -p Environment=Test
 |       `--filter=VALUE` | A filter to apply to incoming events |
 |       `--minimum-level=VALUE` | The minimum event level/severity to accept; the default is to accept all events |
 |       `--use-server-timestamps` | Discard client-supplied timestamps and use server clock values |
-|       `--permissions=VALUE` | A comma-separated list of permissions to delegate to the API key; the default is `Ingest`. Options are `Ingest`,`Read`,`Setup`,`Write` |
+|       `--permissions=VALUE` | A comma-separated list of permissions to delegate to the API key; valid permissions are `Ingest` (default), `Read`, `Setup`, and `Write` |
 |       `--connect-username=VALUE` | A username to connect with, useful primarily when setting up the first API key |
 |       `--connect-password=VALUE` | When `connect-username` is specified, a corresponding password |
 |       `--connect-password-stdin` | When `connect-username` is specified, read the corresponding password from `STDIN` |

--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ seqcli signal create -t 'Exceptions' -f "@Exception is not null"
 | `-t`, `--title=VALUE` | A title for the signal |
 |       `--description=VALUE` | A description for the signal |
 | `-f`, `--filter=VALUE` | Filter to associate with the signal |
-| `-c`, `--columns=VALUE` | A comma-separated list of columns to associate with the signal |
+| `-c`, `--column=VALUE` | Column to associate with the signal; this argument can be used multiple times |
 |       `--group=VALUE` | An explicit group name to associate with the signal; the default is to infer the group from the filter |
 |       `--no-group` | Specify that no group should be inferred; the default is to infer the group from the filter |
 |       `--protected` | Specify that the signal is editable only by administrators |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ seqcli apikey create -t 'Test API Key' -p Environment=Test
 |       `--filter=VALUE` | A filter to apply to incoming events |
 |       `--minimum-level=VALUE` | The minimum event level/severity to accept; the default is to accept all events |
 |       `--use-server-timestamps` | Discard client-supplied timestamps and use server clock values |
-|       `--permissions=VALUE` | The permissions to delegate to the API key; the default is `Ingest` |
+|       `--permissions=VALUE` | A comma-separated list of permissions to delegate to the API key; the default is `Ingest`. Options are `Ingest`,`Read`,`Setup`,`Write` |
 |       `--connect-username=VALUE` | A username to connect with, useful primarily when setting up the first API key |
 |       `--connect-password=VALUE` | When `connect-username` is specified, a corresponding password |
 |       `--connect-password-stdin` | When `connect-username` is specified, read the corresponding password from `STDIN` |
@@ -742,6 +742,7 @@ seqcli signal create -t 'Exceptions' -f "@Exception is not null"
 | `-t`, `--title=VALUE` | A title for the signal |
 |       `--description=VALUE` | A description for the signal |
 | `-f`, `--filter=VALUE` | Filter to associate with the signal |
+| `-c`, `--columns=VALUE` | A comma-separated list of columns to associate with the signal |
 |       `--group=VALUE` | An explicit group name to associate with the signal; the default is to infer the group from the filter |
 |       `--no-group` | Specify that no group should be inferred; the default is to infer the group from the filter |
 |       `--protected` | Specify that the signal is editable only by administrators |

--- a/src/SeqCli/Cli/Commands/ApiKey/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/ApiKey/CreateCommand.cs
@@ -75,7 +75,7 @@ namespace SeqCli.Cli.Commands.ApiKey
 
             Options.Add(
                 "permissions=",
-                "A comma-separated list of permissions to delegate to the API key; the default is `Ingest`. Options are `Ingest`,`Read`,`Setup`,`Write`",
+                "A comma-separated list of permissions to delegate to the API key; valid permissions are `Ingest` (default), `Read`, `Setup`, and `Write`",
                 v => _permissions = ArgumentString.NormalizeList(v));
 
             Options.Add(

--- a/src/SeqCli/Cli/Commands/ApiKey/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/ApiKey/CreateCommand.cs
@@ -75,7 +75,7 @@ namespace SeqCli.Cli.Commands.ApiKey
 
             Options.Add(
                 "permissions=",
-                "The comma-separated list of permissions to delegate to the API key; the default is `Ingest`. Options are `Ingest`,`Read`,`Setup`,`Write`",
+                "A comma-separated list of permissions to delegate to the API key; the default is `Ingest`. Options are `Ingest`,`Read`,`Setup`,`Write`",
                 v => _permissions = ArgumentString.NormalizeList(v));
 
             Options.Add(

--- a/src/SeqCli/Cli/Commands/Signal/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/CreateCommand.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Seq.Api.Model.Shared;
@@ -33,8 +34,9 @@ namespace SeqCli.Cli.Commands.Signal
         readonly ConnectionFeature _connection;
         readonly OutputFormatFeature _output;
 
+        readonly List<string> _columns = new();
+
         string _title, _description, _filter, _group;
-        string[] _columns;
         bool _isProtected, _noGrouping;
 
         public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
@@ -57,9 +59,9 @@ namespace SeqCli.Cli.Commands.Signal
                 f => _filter = ArgumentString.Normalize(f));
 
             Options.Add(
-                "c=|columns=",
-                "Comma-separated list of columns to associate with the signal",
-                c => _columns = ArgumentString.NormalizeList(c));
+                "c=|column=",
+                "Column to associate with the signal; this argument can be used multiple times",
+                c => _columns.Add(ArgumentString.Normalize(c)));
 
             Options.Add(
                 "group=",
@@ -117,11 +119,8 @@ namespace SeqCli.Cli.Commands.Signal
                 }.ToList();
             }
 
-            if (_columns != null)
-            {
-                foreach (var column in _columns)
-                    signal.Columns.Add(new SignalColumnPart { Expression = column });
-            }
+            foreach (var column in _columns)
+                signal.Columns.Add(new SignalColumnPart { Expression = column });
 
             signal = await connection.Signals.AddAsync(signal);
 

--- a/src/SeqCli/Cli/Commands/Signal/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/CreateCommand.cs
@@ -34,6 +34,7 @@ namespace SeqCli.Cli.Commands.Signal
         readonly OutputFormatFeature _output;
 
         string _title, _description, _filter, _group;
+        string[] _columns;
         bool _isProtected, _noGrouping;
 
         public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
@@ -54,6 +55,11 @@ namespace SeqCli.Cli.Commands.Signal
                 "f=|filter=",
                 "Filter to associate with the signal",
                 f => _filter = ArgumentString.Normalize(f));
+
+            Options.Add(
+                "c=|columns=",
+                "Comma-separated list of columns to associate with the signal",
+                c => _columns = ArgumentString.NormalizeList(c));
 
             Options.Add(
                 "group=",
@@ -109,6 +115,12 @@ namespace SeqCli.Cli.Commands.Signal
                         FilterNonStrict = _filter
                     }
                 }.ToList();
+            }
+
+            if (_columns != null)
+            {
+                foreach (var column in _columns)
+                    signal.Columns.Add(new SignalColumnPart { Expression = column });
             }
 
             signal = await connection.Signals.AddAsync(signal);

--- a/test/SeqCli.EndToEnd/Signal/SignalCreateTestCase.cs
+++ b/test/SeqCli.EndToEnd/Signal/SignalCreateTestCase.cs
@@ -13,7 +13,7 @@ namespace SeqCli.EndToEnd.Signal
             ILogger logger,
             CliCommandRunner runner)
         {
-            var exit = runner.Exec("signal create", " -t TestSignal -f \"@Exception is not null\" -c ApplicationName,AssemblyVersion");
+            var exit = runner.Exec("signal create", "-t TestSignal -f \"@Exception is not null\" -c Column1 -c \"round(Property2, 1)\"");
             Assert.Equal(0, exit);
 
             exit = runner.Exec("signal list", "-t TestSignal --json");
@@ -22,7 +22,7 @@ namespace SeqCli.EndToEnd.Signal
             var output = runner.LastRunProcess.Output.Trim();
 
             Assert.Contains("\"Filter\": \"@Exception is not null\"", output);
-            Assert.Contains("\"Columns\": [{\"Expression\": \"ApplicationName\"}, {\"Expression\": \"AssemblyVersion\"}]", output);
+            Assert.Contains("\"Columns\": [{\"Expression\": \"Column1\"}, {\"Expression\": \"round(Property2, 1)\"}]", output);
 
             return Task.CompletedTask;
         }

--- a/test/SeqCli.EndToEnd/Signal/SignalCreateTestCase.cs
+++ b/test/SeqCli.EndToEnd/Signal/SignalCreateTestCase.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Signal
+{
+    public class SignalCreateTestCase : ICliTestCase
+    {
+        public Task ExecuteAsync(
+            SeqConnection connection,
+            ILogger logger,
+            CliCommandRunner runner)
+        {
+            var exit = runner.Exec("signal create", " -t TestSignal -f \"@Exception is not null\" -c ApplicationName,AssemblyVersion");
+            Assert.Equal(0, exit);
+
+            exit = runner.Exec("signal list", "-t TestSignal --json");
+            Assert.Equal(0, exit);
+
+            var output = runner.LastRunProcess.Output.Trim();
+
+            Assert.Contains("\"Filter\": \"@Exception is not null\"", output);
+            Assert.Contains("\"Columns\": [{\"Expression\": \"ApplicationName\"}, {\"Expression\": \"AssemblyVersion\"}]", output);
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Solves #146

This adds an option, -c or -columns, to the seqcli signal create command.