### PR TITLE
Fix `seqcli config` (regression in 2021.3.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Begin demotion of the current leader node.
 Example:
 
 ```
-seqcli node demote -v --wait
+seqcli node demote --verbose --wait
 ```
 
 | Option | Description |

--- a/src/SeqCli/Cli/Command.cs
+++ b/src/SeqCli/Cli/Command.cs
@@ -57,7 +57,7 @@ namespace SeqCli.Cli
                 allOptions.Add(option);
             }
 
-            allOptions.Add("v|verbose", "Print verbose output to `STDERR`", _ => { });
+            allOptions.Add("verbose", "Print verbose output to `STDERR`", _ => { });
 
             Console.Error.WriteLine("Arguments:");
             allOptions.WriteOptionDescriptions(Console.Error);

--- a/src/SeqCli/Cli/CommandLineHost.cs
+++ b/src/SeqCli/Cli/CommandLineHost.cs
@@ -42,7 +42,7 @@ namespace SeqCli.Cli
             if (args.Length > 0)
             {
                 var norm = args[0].ToLowerInvariant();
-                var subCommandNorm = args.Length > 1 && !args[1].Contains("-") ? args[1].ToLowerInvariant() : null;
+                var subCommandNorm = args.Length > 1 && !args[1].Contains('-') ? args[1].ToLowerInvariant() : null;
                 
                 var cmd = _availableCommands.SingleOrDefault(c =>
                     c.Metadata.Name == norm && (c.Metadata.SubCommand == subCommandNorm || c.Metadata.SubCommand == null));
@@ -52,7 +52,7 @@ namespace SeqCli.Cli
                     var amountToSkip = cmd.Metadata.SubCommand == null ? 1 : 2;
                     var commandSpecificArgs = args.Skip(amountToSkip).ToArray();
                     
-                    var verboseArg = commandSpecificArgs.FirstOrDefault(arg => arg is "-v" or "--verbose");
+                    var verboseArg = commandSpecificArgs.FirstOrDefault(arg => arg == "--verbose");
                     if (verboseArg != null)
                     {
                         levelSwitch.MinimumLevel = LogEventLevel.Information;

--- a/src/SeqCli/Cli/Commands/Node/DemoteCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/DemoteCommand.cs
@@ -11,7 +11,7 @@ using Serilog;
 namespace SeqCli.Cli.Commands.Node
 {
     [Command("node", "demote", "Begin demotion of the current leader node", 
-        Example = "seqcli node demote -v --wait")]
+        Example = "seqcli node demote --verbose --wait")]
     class DemoteCommand : Command
     {
         readonly SeqConnectionFactory _connectionFactory;

--- a/test/SeqCli.EndToEnd/Node/NodeDemoteTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeDemoteTestCase.cs
@@ -11,7 +11,7 @@ namespace SeqCli.EndToEnd.Node
     {
         public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
         {
-            var exit = runner.Exec("node demote -v --wait --confirm");
+            var exit = runner.Exec("node demote --verbose --wait --confirm");
             Assert.Equal(1, exit);
             Assert.Contains("No cluster node is in the leader role", runner.LastRunProcess!.Output);
             return Task.CompletedTask;

--- a/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
+++ b/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
@@ -18,10 +18,10 @@ namespace SeqCli.Tests.Cli
             var executed = new List<string>();
             var availableCommands = new List<Meta<Lazy<Command>, CommandMetadata>>
             {
-                new Meta<Lazy<Command>, CommandMetadata>(
+                new(
                     new Lazy<Command>(() => new ActionCommand(() => executed.Add("test"))),
                     new CommandMetadata {Name = "test"}),
-                new Meta<Lazy<Command>, CommandMetadata>(
+                new(
                     new Lazy<Command>(() => new ActionCommand(() => executed.Add("test2"))),
                     new CommandMetadata {Name = "test2"})
             };
@@ -38,10 +38,10 @@ namespace SeqCli.Tests.Cli
             var availableCommands =
                 new List<Meta<Lazy<Command>, CommandMetadata>>
                 {
-                    new Meta<Lazy<Command>, CommandMetadata>(
+                    new(
                         new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand1"))),
                         new CommandMetadata {Name = "test", SubCommand = "subcommand1"}),
-                    new Meta<Lazy<Command>, CommandMetadata>(
+                    new(
                         new Lazy<Command>(() => new ActionCommand(() => commandsRan.Add("test-subcommand2"))),
                         new CommandMetadata {Name = "test", SubCommand = "subcommand2"})
                 };
@@ -59,14 +59,14 @@ namespace SeqCli.Tests.Cli
             var availableCommands =
                 new List<Meta<Lazy<Command>, CommandMetadata>>
                 {
-                    new Meta<Lazy<Command>, CommandMetadata>(
+                    new(
                         new Lazy<Command>(() => new ActionCommand(() => { })),
                         new CommandMetadata {Name = "test"})
                 };
             
             var commandLineHost = new CommandLineHost(availableCommands);
             
-            await commandLineHost.Run(new[] { "test", "-v" }, levelSwitch);
+            await commandLineHost.Run(new[] { "test", "--verbose" }, levelSwitch);
             
             Assert.Equal(LogEventLevel.Information, levelSwitch.MinimumLevel);
         }


### PR DESCRIPTION
https://github.com/datalust/seqcli/pull/207 introduced a universal `-v|--verbose` command-line option. Unfortunately, the use of `-v` conflicts with the `--value` option accepted by `seqcli config`, breaking this (widely-used) command.

The PR removes the `-v` alias, leaving `--verbose` as the universal verbose output option.

We may reinstate this in the future if we can decide on how to reconcile these two different uses of `-v`, however with 2021.4 due within a week or so, best we make this change now.

The lack of an ability to override the storage location for `config` means this isn't currently testable using isolated end-to-end tests. We should consider following up with this capability in a future version.
