### PR TITLE
Throw rather than exit when commands fail

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -61,7 +61,7 @@ function Publish-Archives($version)
 function Publish-DotNetTool($version)
 {	
 	# Tool packages have to target a single non-platform-specific TFM; doing this here is cleaner than attempting it in the CSPROJ directly
-	dotnet pack ./src/SeqCli/SeqCli.csproj -c Release --output ./artifacts /p:VersionPrefix=$version /p:TargetFramework=$framework /p:TargetFrameworks=
+	dotnet pack ./src/SeqCli/SeqCli.csproj -c Release --output ./artifacts /p:VersionPrefix=$version /p:TargetFrameworks=$framework
     if($LASTEXITCODE -ne 0) { throw "Build failed" }
 }
 


### PR DESCRIPTION
Seems like AppVeyor may ignore exit codes from `pwsh` scripts?

https://ci.appveyor.com/project/datalust/seqcli/builds/41948492/job/bp52vlyikgx8xh1x

This PR uses the more robust `throw` mechanism.

The builds script now also adds our installed .NET SDK path to `$env:PATH` (it doesn't seem that Setup.ps1 is effective in exporting it).