### PR TITLE
Refactor target platforms and add ARM docker publishing

### DIFF
--- a/dockerfiles/seqcli/linux-arm64.Dockerfile
+++ b/dockerfiles/seqcli/linux-arm64.Dockerfile
@@ -1,6 +1,6 @@
 # based on: https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile
 
-FROM ubuntu:20.04
+FROM --platform=linux/arm64 ubuntu:20.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -15,7 +15,7 @@ RUN apt-get update \
         zlib1g \
 && rm -rf /var/lib/apt/lists/*
 
-COPY src/SeqCli/bin/Release/net6.0/linux-x64/publish /bin/seqcli
+COPY src/SeqCli/bin/Release/net6.0/linux-arm64/publish /bin/seqcli
 
 ENTRYPOINT ["/bin/seqcli/seqcli"]
 

--- a/dockerfiles/seqcli/linux-x64.Dockerfile
+++ b/dockerfiles/seqcli/linux-x64.Dockerfile
@@ -1,0 +1,22 @@
+# based on: https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile
+
+FROM --platform=linux/amd64 ubuntu:20.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu66 \
+        liblttng-ust0 \
+        libssl1.1 \
+        libstdc++6 \
+        zlib1g \
+&& rm -rf /var/lib/apt/lists/*
+
+COPY src/SeqCli/bin/Release/net6.0/linux-x64/publish /bin/seqcli
+
+ENTRYPOINT ["/bin/seqcli/seqcli"]
+
+LABEL Description="seqcli" Vendor="Datalust Pty Ltd"

--- a/seqcli.sln
+++ b/seqcli.sln
@@ -47,26 +47,26 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Roastery", "src\Roastery\Ro
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
+		Debug|AnyCPU = Debug|AnyCPU
+		Release|AnyCPU = Release|AnyCPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EBDBEED2-A1BC-4269-B6B0-EA908CE4D687}.Debug|x64.ActiveCfg = Debug|x64
-		{EBDBEED2-A1BC-4269-B6B0-EA908CE4D687}.Debug|x64.Build.0 = Debug|x64
-		{EBDBEED2-A1BC-4269-B6B0-EA908CE4D687}.Release|x64.ActiveCfg = Release|x64
-		{EBDBEED2-A1BC-4269-B6B0-EA908CE4D687}.Release|x64.Build.0 = Release|x64
-		{DBC69360-519B-4A9B-829B-2AE1B5412521}.Debug|x64.ActiveCfg = Debug|x64
-		{DBC69360-519B-4A9B-829B-2AE1B5412521}.Debug|x64.Build.0 = Debug|x64
-		{DBC69360-519B-4A9B-829B-2AE1B5412521}.Release|x64.ActiveCfg = Release|x64
-		{DBC69360-519B-4A9B-829B-2AE1B5412521}.Release|x64.Build.0 = Release|x64
-		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|x64.ActiveCfg = Debug|x64
-		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|x64.Build.0 = Debug|x64
-		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|x64.ActiveCfg = Release|x64
-		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|x64.Build.0 = Release|x64
-		{D2CB1112-7CD3-4A1B-A114-25130C96295E}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{D2CB1112-7CD3-4A1B-A114-25130C96295E}.Debug|x64.Build.0 = Debug|Any CPU
-		{D2CB1112-7CD3-4A1B-A114-25130C96295E}.Release|x64.ActiveCfg = Release|Any CPU
-		{D2CB1112-7CD3-4A1B-A114-25130C96295E}.Release|x64.Build.0 = Release|Any CPU
+		{EBDBEED2-A1BC-4269-B6B0-EA908CE4D687}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{EBDBEED2-A1BC-4269-B6B0-EA908CE4D687}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{EBDBEED2-A1BC-4269-B6B0-EA908CE4D687}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{EBDBEED2-A1BC-4269-B6B0-EA908CE4D687}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{D2CB1112-7CD3-4A1B-A114-25130C96295E}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{D2CB1112-7CD3-4A1B-A114-25130C96295E}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{D2CB1112-7CD3-4A1B-A114-25130C96295E}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{D2CB1112-7CD3-4A1B-A114-25130C96295E}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{B86DEF3C-C461-4126-AD49-986EBB19B487}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{DBC69360-519B-4A9B-829B-2AE1B5412521}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{DBC69360-519B-4A9B-829B-2AE1B5412521}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{DBC69360-519B-4A9B-829B-2AE1B5412521}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{DBC69360-519B-4A9B-829B-2AE1B5412521}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -4,11 +4,10 @@
     <TargetFrameworks>net6.0;net6.0-windows</TargetFrameworks>
     <AssemblyName>seqcli</AssemblyName>
     <ApplicationIcon>..\..\asset\SeqCli.ico</ApplicationIcon>
-    <RuntimeIdentifiers>win-x64;linux-x64;linux-musl-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;linux-musl-x64;osx-x64;linux-arm64;linux-musl-arm64;osx-arm64</RuntimeIdentifiers>
     <GenerateAssemblyInformationalVersionAttribute>True</GenerateAssemblyInformationalVersionAttribute>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
-    <Platforms>x64</Platforms>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>seqcli</ToolCommandName>
   </PropertyGroup>

--- a/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
+++ b/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net6.0-windows</TargetFrameworks>
-    <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.3.0" />

--- a/test/SeqCli.Tests/SeqCli.Tests.csproj
+++ b/test/SeqCli.Tests/SeqCli.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net6.0-windows</TargetFrameworks>
-    <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />


### PR DESCRIPTION
Part of #227 

We don't really need to be explicit about architectures we support in the csproj files themselves, since there's no native code or conditional compilation involved.

We now also publish Docker containers for both x86 and ARM that can be used by independent Seq apps as a base image.