### PR TITLE
Line up CI and Docker publishing scripts; publish multi-arch manifests

### DIFF
--- a/docker-publish.ps1
+++ b/docker-publish.ps1
@@ -1,26 +1,57 @@
 param (
-  [Parameter(Mandatory=$true)]
+  [Parameter(Mandatory=$True)]
   [string] $version
 )
+
+$ErrorActionPreference = "Stop"
 
 $versionParts = $version.Split('.')
 
 $major = $versionParts[0]
 $minor = $versionParts[1]
+$isPre = $version.endswith("pre")
 
-$baseImage = "datalust/seqcli-ci:$version"
-$publishImages = "datalust/seqcli:latest", "datalust/seqcli:$major", "datalust/seqcli:$major.$minor", "datalust/seqcli:$version"
+$image = "datalust/seqcli"
+$archs = @("x64", "arm64")
+$publishImages = @()
+
+foreach ($arch in $archs) {
+    $ciImage = "$image-ci:$version-$arch"
+    $publishImage = "$image:$version-$arch";
+
+    docker pull $ciImage
+    if ($LASTEXITCODE) { exit 1 }
+
+    docker tag $ciImage $publishImage
+    if ($LASTEXITCODE) { exit 1 }
+
+    docker push $publishImage    
+    if ($LASTEXITCODE) { exit 1 }
+    
+    $publishImages += $publishImage
+}
+
+$publishManifest = "$image:$version"
+
+$pushTags = @($publishManifest)
+
+if ($isPre -eq $True) {
+    $pushTags += "$image:preview"
+} else {
+    $pushTags += "$image:$major", "$image:$major.$minor", "$image:latest"
+}
 
 $choices  = "&Yes", "&No"
-$decision = $Host.UI.PromptForChoice("Publishing ($baseImage) as ($publishImages)", "Does this look right?", $choices, 1)
+$decision = $Host.UI.PromptForChoice("Publishing ($publishManifest) as ($pushTags)", "Does this look right?", $choices, 1)
 if ($decision -eq 0) {
-    foreach ($publishImage in $publishImages) {
-        Write-Host "Publishing $publishImage"
+    foreach ($pushTag in $pushTags) {
+        Write-Host "Publishing $pushTag"
 
-        docker tag $baseImage $publishImage
+        echo "creating manifest $pushTag from $publishImages"
+        iex "docker manifest create $pushTag $publishImages"
         if ($LASTEXITCODE) { exit 1 }
 
-        docker push $publishImage
+        docker manifest push $pushTag
         if ($LASTEXITCODE) { exit 1 }
     }
 } else {


### PR DESCRIPTION
From 2022, we'll publish multi-architecture manifests instead of regular images. To do this:

 * In CI, we'll produce `datalust/seqcli-ci:2022.n.m-x64` and `datalust/seqcli-ci:2022.n.m-arm64`
 * When publishing, these two images will be packaged into `datalust/seqcli:2022.n.m`, along with `:latest` tags etc.