### PR TITLE
Ensure we use buildx for cross-platform docker builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 2022.1.{build}
 skip_tags: true
 image:
 - Visual Studio 2022
-- Ubuntu1804
+- Ubuntu2004
 environment:
   DOCKER_TOKEN:
    secure: QKr2YEuliXdFKe3jN7w97w==

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ for:
 -
   matrix:
     only:
-      - image: Ubuntu1804
+      - image: Ubuntu2004
 
   install:
   - pwsh: ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -14,5 +14,5 @@ chmod +x dotnet-install.sh
 ./dotnet-install.sh --install-dir $HOME/.dotnetcli --no-path --version $RequiredDotnetVersion
 rm dotnet-install.sh
 
-docker run --privileged --rm docker/binfmt: a7996909642ee92942dcd6cff44b9b95f08dad64
+docker run --privileged --rm docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
 service docker restart

--- a/setup.sh
+++ b/setup.sh
@@ -14,5 +14,5 @@ chmod +x dotnet-install.sh
 ./dotnet-install.sh --install-dir $HOME/.dotnetcli --no-path --version $RequiredDotnetVersion
 rm dotnet-install.sh
 
-docker run --privileged --rm docker/binfmt
+docker run --privileged --rm docker/binfmt: a7996909642ee92942dcd6cff44b9b95f08dad64
 service docker restart

--- a/setup.sh
+++ b/setup.sh
@@ -13,3 +13,6 @@ curl https://dot.net/v1/dotnet-install.sh -sSfL --output dotnet-install.sh
 chmod +x dotnet-install.sh
 ./dotnet-install.sh --install-dir $HOME/.dotnetcli --no-path --version $RequiredDotnetVersion
 rm dotnet-install.sh
+
+docker run --privileged --rm docker/binfmt
+service docker restart

--- a/setup.sh
+++ b/setup.sh
@@ -15,4 +15,4 @@ chmod +x dotnet-install.sh
 rm dotnet-install.sh
 
 docker run --privileged --rm docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
-service docker restart
+sudo service docker restart


### PR DESCRIPTION
For #227 

It looks like we're not actually building cross-platform containers for seqcli in CI here. Running the build script locally does seem to do the right thing though, so this PR calls `buildx` directly and specifies a platform explicitly to make sure we're doing what we expect.