### PR TITLE
Colourise Redirected Output

### DIFF
--- a/src/SeqCli/Cli/Commands/PrintCommand.cs
+++ b/src/SeqCli/Cli/Commands/PrintCommand.cs
@@ -57,7 +57,7 @@ namespace SeqCli.Cli.Commands
 
             Options.Add("no-color", "Don't colorize text output", v => _noColor = true);
 
-            Options.Add("c|force-color",
+            Options.Add("force-color",
                 "Force redirected output to have ANSI color (unless `--no-color` is also specified)",
                 v => _forceColor = true);
         }

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -35,7 +35,7 @@ namespace SeqCli.Cli.Features
             "[{Timestamp:o} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}";
 
         public static readonly ConsoleTheme DefaultTheme     = SystemConsoleTheme.Literate;
-        public static readonly ConsoleTheme DefaultAnsiTheme = AnsiConsoleTheme.Literate;
+        public static readonly ConsoleTheme DefaultAnsiTheme = AnsiConsoleTheme.Code;
 
         bool _json, _noColor, _forceColor;
 

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -63,7 +63,7 @@ namespace SeqCli.Cli.Features
 
             options.Add("no-color", "Don't colorize text output", v => _noColor = true);
 
-            options.Add("c|force-color",
+            options.Add("force-color",
                 "Force redirected output to have ANSI color (unless `--no-color` is also specified)",
                 v => _forceColor = true);
         }

--- a/src/SeqCli/Config/SeqCliOutputConfig.cs
+++ b/src/SeqCli/Config/SeqCliOutputConfig.cs
@@ -17,5 +17,6 @@ namespace SeqCli.Config
     class SeqCliOutputConfig
     {
         public bool DisableColor { get; set; }
+        public bool ForceColor   { get; set; }
     }
 }


### PR DESCRIPTION
Allow redirected output to be colourised using ANSI control codes. Option is enabled by the `--force-color` command line switch, or by setting `output.forceColor` to `True` in `SeqCli.json`. Addresses issue #239.

In PowerShell, the following should produce colorised output (if your console supports it) where previously it would not:

    gc logfile.clef | seqcli print --force-color | %{ $_ }

The value of the `--no-color` switch (or `output.disableColor` setting) will take precedence. If either one is specified, `--force-color` will be ignored.

Initially used the ANSI version of the `Literate` theme but it looked horrible so I switched to the `Code` theme.