### PR TITLE
Don't set owner on `seqcli sample setup` template items.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+Contributing to seqcli
+================
+
+Testing
+------
+
+`seqcli` has two test projects: `SeqCli.EndToEnd` and `SeqCli.Tests`.
+
+### SeqCli.EndToEnd 
+
+`/test/SeqCli.EndToEnd` is a console app that implements integration tests. It uses a custom testing framework and xunit for assertions. 
+
+Each test within the EndToEnd project (an implementation of the `ICliTestCase` interface) spans one child process for the Seq server and one child process for the seqcli command. 
+
+The Seq server can be run via the `seq` executable (windows only) or as a `datalust/seq:latest` docker container. Which to use is controlled via the `--docker-server` argument. 
+
+Some tests require a Seq license. These tests are run if a valid license is supplied via stdin and the `--license-certificate-stdin` argument is supplied. 
+
+#### Adding Tests
+
+The typical pattern is to execute a seqcli command, then make an assertion on the output of the command. E.g.
+
+```c#
+var exit = runner.Exec("apikey list", "-t Test --json --no-color");
+Assert.Equal(0, exit);
+
+var output = runner.LastRunProcess!.Output;
+Assert.Contains("\"AssignedPermissions\": [\"Ingest\"]", output);
+```
+
+#### Running Tests
+
+```shell
+/SeqCli.EndToEnd$ dotnet run -- --docker-server
+```
+
+The `--docker-server` is optional if you have a `seq` executable in your path.
+
+To run the multi user tests as well, save a valid license into a file and:
+
+```shell
+/SeqCli.EndToEnd$ cat license.txt | dotnet run -- --docker-server --license-certificate-stdin
+```
+
+To run a specific set of tests pass regular expressions matching the tests to run:
+
+```shell
+/SeqCli.EndToEnd$ dotnet run -- --docker-server *TestCase.cs Command*
+```
+
+### SeqCli.Tests
+
+`/test/SeqCli.Tests` is a regular xunit testing project. To run: 
+
+```shell
+/SeqCli.Tests$ dotnet test
+```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ $token = (
 )
 ```
 
+## Contributing
+
+See `CONTRIBUTING.md`.
+
 ## Commands
 
 Usage:

--- a/seqcli.sln
+++ b/seqcli.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sln", "sln", "{2EA56595-519
 		Build.Docker.ps1 = Build.Docker.ps1
 		docker-publish.ps1 = docker-publish.ps1
 		Setup.ps1 = Setup.ps1
+		CONTRIBUTING.md = CONTRIBUTING.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{3587B633-0C03-4235-8903-6226900328F1}"

--- a/src/SeqCli/Cli/Commands/Sample/SetupCommand.cs
+++ b/src/SeqCli/Cli/Commands/Sample/SetupCommand.cs
@@ -59,11 +59,7 @@ namespace SeqCli.Cli.Commands.Sample
             }
 
             var templateArgs = new Dictionary<string, JsonTemplate>();
-            var users = await connection.Users.ListAsync();
-            if (users.Count == 1)
-                templateArgs["ownerId"] = new JsonTemplateString(users.Single().Id);
-            else
-                templateArgs["ownerId"] = new JsonTemplateNull();
+            templateArgs["ownerId"] = new JsonTemplateNull();
 
             var templatesPath = Content.GetPath(Path.Combine("Sample", "Templates"));
             var templateFiles = Directory.GetFiles(templatesPath);

--- a/test/SeqCli.EndToEnd/Sample/SampleSetupTestCase.cs
+++ b/test/SeqCli.EndToEnd/Sample/SampleSetupTestCase.cs
@@ -13,11 +13,8 @@ namespace SeqCli.EndToEnd.Sample
         {
             var exit = runner.Exec("sample setup", "--confirm");
             Assert.Equal(0, exit);
-
-            var currentUserId = (await connection.Users.FindCurrentAsync()).Id;
-
-            // Depends on the most other entities, so is a pretty good proxy for success.
-            var sampleWorkspace = (await connection.Workspaces.ListAsync(ownerId: currentUserId))
+            
+            var sampleWorkspace = (await connection.Workspaces.ListAsync(shared: true))
                 .SingleOrDefault(w => w.Title == "Sample");
 
             Assert.NotNull(sampleWorkspace);

--- a/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
+++ b/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
@@ -43,7 +43,8 @@ namespace SeqCli.EndToEnd.Support
             var commandWithArgs = $"run --listen=\"{ServerListenUrl}\" --storage=\"{storagePath}\"";
             if (_args.UseDockerSeq())
             {
-                return new CaptiveProcess("docker", $"run --name seq -it --rm -e ACCEPT_EULA=Y -p {ServerListenPort}:80 datalust/seq:latest", stopCommandFullExePath: "docker", stopCommandArgs: "stop seq");
+                var containerName = Guid.NewGuid().ToString("n");
+                return new CaptiveProcess("docker", $"run --name {containerName} -it --rm -e ACCEPT_EULA=Y -p {ServerListenPort}:80 datalust/seq:latest", stopCommandFullExePath: "docker", stopCommandArgs: $"stop {containerName}");
             }
             return new CaptiveProcess("seq", commandWithArgs);
         }


### PR DESCRIPTION
Fixes a bug (https://github.com/datalust/seqcli/issues/200) that stops `seqcli sample ingest` from working if authentication is enabled and there is exactly one user. 