### PR TITLE
target arm64/v8 rather than arm/v8

### DIFF
--- a/Build.Docker.ps1
+++ b/Build.Docker.ps1
@@ -6,7 +6,7 @@ $framework = "net6.0"
 $image = "datalust/seqcli"
 $archs = @(
     @{ rid = "x64"; platform = "linux/amd64" },
-    @{ rid = "arm64"; platform = "linux/arm/v8" }
+    @{ rid = "arm64"; platform = "linux/arm64/v8" }
 )
 
 function Execute-Tests


### PR DESCRIPTION
For #227 

It looks like we're bundling for `arm/v8` rather than `arm64/v8`. The former does appear to work, but can cause platform mismatches when attempting to actually pull on ARM hosts.