### PR TITLE
Don't burn CPU when there's no log shipping to do

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,5 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestMinor"
+    "version": "6.0.301"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.301"
+    "version": "6.0.400",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
`LogShipper` is lacking a delay or throttling mechanism when there's no work to do, so it busy-waits, continually checking the queue and posting empty batches to Seq, which burns resources all-round.

This is noticeable when running `seqcli sample ingest`, but will also be impacting `seqcli ingest`, which is used elsewhere including `datalust/seq-input-gelf` and `datalust/seq-input-syslog`.
