### PR TITLE
Specify alert template import ordering

### DIFF
--- a/src/SeqCli/Templates/Import/TemplateSetImporter.cs
+++ b/src/SeqCli/Templates/Import/TemplateSetImporter.cs
@@ -41,7 +41,7 @@ namespace SeqCli.Templates.Import
             bool merge)
         {
             var ordering = new[] {"users", "signals", "apps", "appinstances",
-                "dashboards", "sqlqueries", "workspaces", "retentionpolicies"}.ToList();
+                "dashboards", "sqlqueries", "workspaces", "retentionpolicies", "alerts"}.ToList();
 
             var sorted = templates.OrderBy(t => ordering.IndexOf(t.ResourceGroup));
             


### PR DESCRIPTION
See #248 

Without explicitly specifying the import ordering for alerts, they're imported first and therefore ahead of any signals/app instances they might reference.

Note that alert imports are still rather clunky; those with notification channels require `-g notificationAppInstanceId=...` to be specified on the `template import` command-line, while it'd be nicer to also import/merge app instances in the long run.