### PR TITLE
Fix up ARM publishing for Docker

### DIFF
--- a/dockerfiles/seqcli/linux-arm64.Dockerfile
+++ b/dockerfiles/seqcli/linux-arm64.Dockerfile
@@ -1,6 +1,6 @@
 # based on: https://github.com/dotnet/dotnet-docker/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile
 
-FROM --platform=linux/arm64 ubuntu:20.04
+FROM --platform=linux/arm/v8 ubuntu:20.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
It looks like we missed updating the Dockerfile itself when fixing up our ARM Docker support in #246