### PR TITLE
Bench upgrades

### DIFF
--- a/src/SeqCli/Cli/Commands/Bench/BenchCasesCollection.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCasesCollection.cs
@@ -23,6 +23,6 @@ namespace SeqCli.Cli.Commands;
 class BenchCasesCollection
 {
     // An identifier for the particular cases file
-    public int CasesHash = 0;
+    public string CasesHash = "";
     public IList<BenchCase> Cases = new List<BenchCase>();
 }

--- a/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
@@ -215,7 +215,7 @@ class BenchCommand : Command
         return casesFile;
     }
 
-    public static string HashString(string input)
+    static string HashString(string input)
     {
         using var md5 = MD5.Create();
         var bytes = Encoding.ASCII.GetBytes(input);

--- a/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
@@ -219,7 +219,6 @@ class BenchCommand : Command
     {
         using var md5 = MD5.Create();
         var bytes = Encoding.ASCII.GetBytes(input);
-        var hash = Convert.ToHexString(md5.ComputeHash(bytes));
-        return new string(new [] {hash[4], hash[8], hash[16], hash[24]});
+        return Convert.ToHexString(md5.ComputeHash(bytes));
     }
 }

--- a/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
@@ -17,6 +17,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Seq.Api.Model.Signals;
@@ -188,7 +190,7 @@ class BenchCommand : Command
         var casesFile = JsonConvert.DeserializeObject<BenchCasesCollection>(casesString)
                         ?? new BenchCasesCollection();
 
-        casesFile.CasesHash = casesString.GetHashCode(); // not consistent across framework versions, but that's OK
+        casesFile.CasesHash = HashString(casesString); 
 
         if (casesFile.Cases.Select(c => c.Id).Distinct().Count() != casesFile.Cases.Count)
         {
@@ -201,5 +203,12 @@ class BenchCommand : Command
         }
 
         return casesFile;
+    }
+    
+    static string HashString(string input)
+    {
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hashedBytes = MD5.Create().ComputeHash(bytes);
+        return Encoding.UTF8.GetString(hashedBytes);
     }
 }

--- a/test/SeqCli.EndToEnd/Bench/BenchTestCase.cs
+++ b/test/SeqCli.EndToEnd/Bench/BenchTestCase.cs
@@ -13,7 +13,7 @@ namespace SeqCli.EndToEnd.Bench
             ILogger logger,
             CliCommandRunner runner)
         {
-            var exit = runner.Exec("bench", "");
+            var exit = runner.Exec("bench", "--start=2022-01-01 --end=2022-01-02");
             Assert.Equal(0, exit);
 
             return Task.CompletedTask;


### PR DESCRIPTION
- [x] 'Server' property is wrong
- [x] Add a label arg to describe what the bench run is testing
- [x] Make `start` and `end` required to remove ambiguity
- [x] Make cases hash consistent