### PR TITLE
2023.1 target cases

### DIFF
--- a/src/SeqCli/Cli/Commands/Bench/BenchCase.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCase.cs
@@ -13,13 +13,18 @@
 // limitations under the License.
 
 #nullable enable
-using System.Collections.Generic;
 
-namespace SeqCli.Cli.Commands;
+namespace SeqCli.Cli.Commands.Bench;
+
+// ReSharper disable ClassNeverInstantiated.Global AutoPropertyCanBeMadeGetOnly.Global UnusedAutoPropertyAccessor.Global
 
 class BenchCase
 {
-    public string Id = "";
-    public string Query = "";
-    public string SignalExpression = "";
+    public string Id { get; set; } = null!;
+    public string Query { get; set; } = null!;
+    public string? SignalExpression { get; set; }
+    
+    // Not used programmatically at this time.
+    // ReSharper disable once UnusedMember.Global
+    public string? Notes { get; set; }
 }

--- a/src/SeqCli/Cli/Commands/Bench/BenchCaseTimings.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCaseTimings.cs
@@ -17,31 +17,33 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SeqCli.Cli.Commands;
+namespace SeqCli.Cli.Commands.Bench;
 
 /*
  * Collects benchmarking elapsed time measurements and calculates statistics. 
  */
 class BenchCaseTimings
 {
-    readonly List<double> _elaspseds = new() { };
-    public double MeanElapsed => _elaspseds.Sum() / _elaspseds.Count;
-    public double MinElapsed => _elaspseds.Min();
-    public double MaxElapsed => _elaspseds.Max();
-    public double StandardDeviationElapsed => StandardDeviation(_elaspseds); 
-    public double RelativeStandardDeviationElapsed => StandardDeviation(_elaspseds) / MeanElapsed;
+    readonly List<double> _timings = new();
+    
+    public double MeanElapsed => _timings.Sum() / _timings.Count;
+    public double MinElapsed => _timings.Min();
+    public double MaxElapsed => _timings.Max();
+    public double StandardDeviationElapsed => StandardDeviation(_timings); 
+    public double RelativeStandardDeviationElapsed => StandardDeviation(_timings) / MeanElapsed;
 
     public void PushElapsed(double elapsed)
     {
-        _elaspseds.Add(elapsed);
+        _timings.Add(elapsed);
     }
 
-    double StandardDeviation(IList<double> population)
+    static double StandardDeviation(ICollection<double> population)
     {
         if (population.Count < 2)
         {
             return 0;
         }
+        
         var mean = population.Sum() / population.Count;
         return Math.Sqrt(population.Select(e => Math.Pow(e - mean, 2)).Sum() / (population.Count - 1));
     }

--- a/src/SeqCli/Cli/Commands/Bench/BenchCases.json
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCases.json
@@ -1,20 +1,54 @@
 {
   "cases": [
     {
-      "id": "count-star",
-      "query": "select count(*) from stream"
+      "id": "count-all",
+      "query": "select count(*) from stream where @Timestamp >= now() - 30d",
+      "notes": "Tests page traversal performance only; avoids data copies, serialization, and evaluation."
     },
     {
-      "id": "starts-with",
-      "query": "select count(*) from stream where @Message like '%abcde'"
+      "id": "count-having-request-id",
+      "query": "select count(*) from stream where RequestId is not null and @Timestamp >= now() - 30d",
+      "notes": "Tests sparse deserialization and condition evaluation atop basic page traversal."
     },
     {
-      "id": "without-signal",
-      "query": "select count(*) from stream where @Level = 'Warning'"
+      "id": "count-exception-starts-with-s",
+      "query": "select count(*) from stream where @Exception like 'S%' and @Timestamp >= now() - 30d",
+      "notes": "Text search performance. Chooses 'S' because in .NET data there should be some hits."
     },
     {
-      "id": "property-match",
-      "query": "select count(*) from stream where Action = 'ListAsync'"
+      "id": "count-message-starts-with-e",
+      "query": "select count(*) from stream where @Message like 'E%' and @Timestamp >= now() - 30d",
+      "notes": "Text search performance; worse on @Message than other properties because fragment pre-filtering is not used."
+    },
+    {
+      "id": "count-by-level",
+      "query": "select count(*) from stream where @Timestamp >= now() - 30d group by @Level",
+      "notes": "Grouping performance, strings, small number of groups."
+    },
+    {
+      "id": "count-by-millisecond",
+      "query": "select count(*) from stream where @Timestamp >= now() - 30d group by @Timestamp % 1ms limit 100",
+      "notes": "Grouping performance, numbers, up to 10000 groups."
+    },
+    {
+      "id": "count-by-day",
+      "query": "select count(*) from stream where @Timestamp >= now() - 30d group by time(12h)",
+      "notes": "Time partitioning performance."
+    },
+    {
+      "id": "distinct-exception-20ch-limit-100",
+      "query": "select distinct(substring(@Exception, 0, 20)) from stream where @Exception is not null and @Timestamp >= now() - 30d limit 100",
+      "notes": "Distinct on computed text."
+    },
+    {
+      "id": "order-by-ts-mod-10k",
+      "query": "select @Timestamp from stream where @Timestamp >= now() - 30d order by @Timestamp % 1ms limit 10",
+      "notes": "Tests performance of limited sort."
+    },
+    {
+      "id": "order-by-message-limit-10",
+      "query": "select @Message from stream where @Timestamp >= now() - 30d order by @Message limit 10",
+      "notes": "Adds character collation to limited sort."
     }
   ]
 }

--- a/src/SeqCli/Cli/Commands/Bench/BenchCasesCollection.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCasesCollection.cs
@@ -15,14 +15,13 @@
 #nullable enable
 using System.Collections.Generic;
 
-namespace SeqCli.Cli.Commands;
+namespace SeqCli.Cli.Commands.Bench;
 
 /*
  * A target type for deserialization of bench case files.
  */
 class BenchCasesCollection
 {
-    // An identifier for the particular cases file
-    public string CasesHash = "";
-    public IList<BenchCase> Cases = new List<BenchCase>();
+    // ReSharper disable once CollectionNeverUpdated.Global
+    public IList<BenchCase> Cases { get; } = new List<BenchCase>();
 }

--- a/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
@@ -108,7 +108,7 @@ class BenchCommand : Command
             var seqVersion = (await connection.Client.GetRootAsync()).Version;
 
             var cases = ReadCases(_cases);
-            var runId = Guid.NewGuid().ToString("N");
+            var runId = Guid.NewGuid().ToString("N")[..16];
             
             await using var reportingLogger = BuildReportingLogger();
 

--- a/test/SeqCli.EndToEnd/Bench/BenchTestCase.cs
+++ b/test/SeqCli.EndToEnd/Bench/BenchTestCase.cs
@@ -13,7 +13,7 @@ public class BenchTestCase : ICliTestCase
         ILogger logger,
         CliCommandRunner runner)
     {
-        var exit = runner.Exec("bench", "--start=2022-01-01 --end=2022-01-02");
+        var exit = runner.Exec("bench", "--runs 3");
         Assert.Equal(0, exit);
 
         return Task.CompletedTask;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/342712/211710061-0414e03c-5918-434d-af4c-b40ffa2204fb.png)
 
 * New cases - trying to cover more areas of query perf
 * Dropped off the cases file hash; the queries themselves are enough to distinguish what's being run
 * Log the target server version
 * Compact output
 * Start and end now optional (although imprecise between runs, they can be specified in the query text for casual benchmarking)

I've also included a "notes" field with each benchmark explaining what it's supposed to measure; the code doesn't use this (yet?).