### PR TITLE
Report the first timing for each benchmarked query

### DIFF
--- a/src/SeqCli/Cli/Commands/Bench/BenchCaseTimings.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCaseTimings.cs
@@ -29,6 +29,7 @@ class BenchCaseTimings
     public double MeanElapsed => _timings.Sum() / _timings.Count;
     public double MinElapsed => _timings.Min();
     public double MaxElapsed => _timings.Max();
+    public double FirstElapsed => _timings.First();
     public double StandardDeviationElapsed => StandardDeviation(_timings); 
     public double RelativeStandardDeviationElapsed => StandardDeviation(_timings) / MeanElapsed;
 

--- a/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
@@ -159,8 +159,8 @@ class BenchCommand : Command
                     using (LogContext.PushProperty("Query", c.Query))
                     {
                         reportingLogger.Information(
-                            "Case {Id,-40} mean {MeanElapsed,5:N0} ms (min {MinElapsed,5:N0} ms, max {MaxElapsed,5:N0} ms, RSD {RelativeStandardDeviationElapsed,4:N2})",
-                            c.Id, timings.MeanElapsed, timings.MinElapsed, timings.MaxElapsed, timings.RelativeStandardDeviationElapsed);
+                            "Case {Id,-40} mean {MeanElapsed,5:N0} ms (first {FirstElapsed:N0} ms, min {MinElapsed,5:N0} ms, max {MaxElapsed,5:N0} ms, RSD {RelativeStandardDeviationElapsed,4:N2})",
+                            c.Id, timings.MeanElapsed, timings.FirstElapsed, timings.MinElapsed, timings.MaxElapsed, timings.RelativeStandardDeviationElapsed);
                     }
                 }
             }


### PR DESCRIPTION
The first ("cold") result for each case is an important measure of UX.