### PR TITLE
`app list`, `appinstance (create|list|remove)`

### DIFF
--- a/src/SeqCli/Cli/Command.cs
+++ b/src/SeqCli/Cli/Command.cs
@@ -91,7 +91,7 @@ abstract class Command
 
     protected virtual Task<int> Run() { return Task.FromResult(0); }
 
-    protected virtual void ShowUsageErrors(IEnumerable<string> errors)
+    protected static void ShowUsageErrors(IEnumerable<string> errors)
     {
         foreach (var error in errors)
         {

--- a/src/SeqCli/Cli/Commands/ApiKey/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/ApiKey/ListCommand.cs
@@ -47,13 +47,9 @@ class ListCommand : Command
         var list = _entityIdentity.Id != null ?
             new[] { await connection.ApiKeys.FindAsync(_entityIdentity.Id) } :
             (await connection.ApiKeys.ListAsync())
-            .Where(ak => _entityIdentity.Title == null || _entityIdentity.Title == ak.Title)
-            .ToArray();
+            .Where(ak => _entityIdentity.Title == null || _entityIdentity.Title == ak.Title);
 
-        foreach (var apiKey in list)
-        {
-            _output.WriteEntity(apiKey);
-        }
+        _output.ListEntities(list);
             
         return 0;
     }

--- a/src/SeqCli/Cli/Commands/App/DefineCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/DefineCommand.cs
@@ -16,7 +16,6 @@ using System;
 using System.Threading.Tasks;
 using SeqCli.Apps;
 using SeqCli.Apps.Definitions;
-using SeqCli.Config;
 using SeqCli.Util;
 
 namespace SeqCli.Cli.Commands.App;

--- a/src/SeqCli/Cli/Commands/App/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/ListCommand.cs
@@ -51,13 +51,9 @@ class ListCommand : Command
         var list = Id != null ?
             new[] { await connection.Apps.FindAsync(Id) } :
             (await connection.Apps.ListAsync())
-            .Where(ak => PackageId == null || PackageId == ak.Name)
-            .ToArray();
+            .Where(ak => PackageId == null || PackageId == ak.Package.PackageId);
 
-        foreach (var app in list)
-        {
-            _output.WriteEntity(app);
-        }
+        _output.ListEntities(list);
             
         return 0;
     }

--- a/src/SeqCli/Cli/Commands/App/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/ListCommand.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+
+namespace SeqCli.Cli.Commands.App;
+
+[Command("app", "list", "List installed app packages", Example="seqcli app list")]
+class ListCommand : Command
+{
+    readonly SeqConnectionFactory _connectionFactory;
+
+    string? _title, _id;
+    readonly ConnectionFeature _connection;
+    readonly OutputFormatFeature _output;
+
+    string? PackageId => string.IsNullOrWhiteSpace(_title) ? null : _title.Trim();
+    string? Id => string.IsNullOrWhiteSpace(_id) ? null : _id.Trim();
+
+    public ListCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+    {
+        if (config == null) throw new ArgumentNullException(nameof(config));
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+        Options.Add(
+            "package-id=",
+            "The package id of the app(s) to list",
+            t => _title = t);
+
+        Options.Add(
+            "i=|id=",
+            "The id of a single app to list",
+            t => _id = t);
+
+        _output = Enable(new OutputFormatFeature(config.Output));
+        _connection = Enable<ConnectionFeature>();
+    }
+    
+    protected override async Task<int> Run()
+    {
+        if (PackageId != null && Id != null)
+        {
+            ShowUsageErrors(new[] {"Only one of either `package-id` or `id` can be specified"});
+            return 1;
+        }
+
+        var connection = _connectionFactory.Connect(_connection);
+
+        var list = Id != null ?
+            new[] { await connection.Apps.FindAsync(Id) } :
+            (await connection.Apps.ListAsync())
+            .Where(ak => PackageId == null || PackageId == ak.Name)
+            .ToArray();
+
+        foreach (var app in list)
+        {
+            _output.WriteEntity(app);
+        }
+            
+        return 0;
+    }
+}

--- a/src/SeqCli/Cli/Commands/AppInstance/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/AppInstance/CreateCommand.cs
@@ -11,7 +11,7 @@ using Serilog;
 
 namespace SeqCli.Cli.Commands.AppInstance;
 
-[Command("appinstance", "create", "Create a signal",
+[Command("appinstance", "create", "Create an instance of an installed app",
     Example = "seqcli appinstance create -t 'Email Ops' --app hostedapp-314159 -p To=ops@example.com")]
 class CreateCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/AppInstance/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/AppInstance/CreateCommand.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Seq.Api.Model.AppInstances;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
+using SeqCli.Util;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.AppInstance;
+
+[Command("appinstance", "create", "Create a signal",
+    Example = "seqcli appinstance create -t 'Email Ops' --app hostedapp-314159 -p To=ops@example.com")]
+class CreateCommand : Command
+{
+    readonly SeqConnectionFactory _connectionFactory;
+
+    readonly ConnectionFeature _connection;
+    readonly OutputFormatFeature _output;
+
+    string? _title, _appId;
+    readonly Dictionary<string, string> _settings = new();
+    readonly List<string> _overridable = new();
+
+    public CreateCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+        Options.Add(
+            "t=|title=",
+            "A title for the app instance",
+            t => _title = ArgumentString.Normalize(t));
+
+        Options.Add(
+            "app=",
+            "The id of the installed app package to instantiate",
+            app => _appId = ArgumentString.Normalize(app));
+
+        Options.Add(
+            "p={=}|property={=}",
+            "Specify name/value settings for the app, e.g. `-p ToAddress=example@example.com -p Subject=\"Alert!\"`",
+            (n, v) =>
+            {
+                var name = n.Trim();
+                var valueText = v?.Trim();
+                _settings.Add(name, valueText ?? "");
+            });
+
+        Options.Add(
+            "overridable=",
+            "Specify setting names that may be overridden by users when invoking the app",
+            s => _overridable.Add(s));
+        
+        // The command doesn't yet implement "Stream incoming events".
+
+        _connection = Enable<ConnectionFeature>();
+        _output = Enable(new OutputFormatFeature(config.Output));
+    }
+
+    protected override async Task<int> Run()
+    {
+        var connection = _connectionFactory.Connect(_connection);
+        
+        AppInstanceEntity instance = await connection.AppInstances.TemplateAsync(_appId)!;
+
+        bool ValidateSettingName(string settingName)
+        {
+            if (!instance.Settings!.ContainsKey(settingName))
+            {
+                Log.Error("The app does not accept a setting with name {SettingName}; available settings are: {AvailableSettings}", settingName, instance.Settings.Keys.ToArray());
+                return false;
+            }
+
+            return true;
+        }
+
+        instance.Title = _title;
+
+        foreach (var setting in _settings)
+        {
+            if (!ValidateSettingName(setting.Key))
+                return 1;
+                
+            instance.Settings![setting.Key] = setting.Value;
+        }
+
+        foreach (var overridable in _overridable)
+        {
+            if (!ValidateSettingName(overridable))
+                return 1;
+            
+            instance.InvocationOverridableSettings!.Add(overridable);
+        }
+        
+        instance = await connection.AppInstances.AddAsync(instance);
+
+        _output.WriteEntity(instance);
+
+        return 0;
+    }
+}

--- a/src/SeqCli/Cli/Commands/AppInstance/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/AppInstance/ListCommand.cs
@@ -1,6 +1,42 @@
-﻿namespace SeqCli.Cli.Commands.AppInstance;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Connection;
 
-public class ListCommand
+namespace SeqCli.Cli.Commands.AppInstance;
+
+[Command("appinstance", "list", "List instances of installed apps", Example="seqcli appinstance list")]
+class ListCommand : Command
 {
+    readonly SeqConnectionFactory _connectionFactory;
+
+    readonly EntityIdentityFeature _entityIdentity;
+    readonly ConnectionFeature _connection;
+    readonly OutputFormatFeature _output;
+
+    public ListCommand(SeqConnectionFactory connectionFactory, SeqCliConfig config)
+    {
+        if (config == null) throw new ArgumentNullException(nameof(config));
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+        _entityIdentity = Enable(new EntityIdentityFeature("app instance", "list"));
+        _output = Enable(new OutputFormatFeature(config.Output));
+        _connection = Enable<ConnectionFeature>();
+    }
     
+    protected override async Task<int> Run()
+    {
+        var connection = _connectionFactory.Connect(_connection);
+
+        var list = _entityIdentity.Id != null ?
+            new[] { await connection.AppInstances.FindAsync(_entityIdentity.Id) } :
+            (await connection.AppInstances.ListAsync())
+            .Where(d => _entityIdentity.Title == null || _entityIdentity.Title == d.Title);
+
+        _output.ListEntities(list);
+
+        return 0;
+    }
 }

--- a/src/SeqCli/Cli/Commands/AppInstance/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/AppInstance/ListCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace SeqCli.Cli.Commands.AppInstance;
+
+public class ListCommand
+{
+    
+}

--- a/src/SeqCli/Cli/Commands/AppInstance/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/AppInstance/RemoveCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace SeqCli.Cli.Commands.AppInstance;
+
+public class RemoveCommand
+{
+    
+}

--- a/src/SeqCli/Cli/Commands/AppInstance/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/AppInstance/RemoveCommand.cs
@@ -1,6 +1,54 @@
-﻿namespace SeqCli.Cli.Commands.AppInstance;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Connection;
+using Serilog;
 
-public class RemoveCommand
+namespace SeqCli.Cli.Commands.AppInstance;
+[Command("appinstance", "remove", "Remove an app instance from the server",
+    Example="seqcli appinstance remove -t 'Email Ops'")]
+
+class RemoveCommand : Command
 {
-    
+    readonly SeqConnectionFactory _connectionFactory;
+
+    readonly EntityIdentityFeature _entityIdentity;
+    readonly ConnectionFeature _connection;
+
+    public RemoveCommand(SeqConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+        _entityIdentity = Enable(new EntityIdentityFeature("app instance", "remove"));
+        _connection = Enable<ConnectionFeature>();
+    }
+
+    protected override async Task<int> Run()
+    {
+        if (_entityIdentity.Title == null && _entityIdentity.Id == null)
+        {
+            Log.Error("A `title` or `id` must be specified");
+            return 1;
+        }
+
+        var connection = _connectionFactory.Connect(_connection);
+
+        var toRemove = _entityIdentity.Id != null ?
+            new[] {await connection.AppInstances.FindAsync(_entityIdentity.Id)} :
+            (await connection.AppInstances.ListAsync())
+            .Where(ak => _entityIdentity.Title == ak.Title) 
+            .ToArray();
+
+        if (!toRemove.Any())
+        {
+            Log.Error("No matching app instance was found");
+            return 1;
+        }
+
+        foreach (var appInstanceEntity in toRemove)
+            await connection.AppInstances.RemoveAsync(appInstanceEntity);
+
+        return 0;
+    }
 }

--- a/src/SeqCli/Cli/Commands/Dashboard/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Dashboard/ListCommand.cs
@@ -49,13 +49,9 @@ class ListCommand : Command
         var list = _entityIdentity.Id != null ?
             new[] { await connection.Dashboards.FindAsync(_entityIdentity.Id) } :
             (await connection.Dashboards.ListAsync(ownerId: _entityOwner.OwnerId, shared: _entityOwner.IncludeShared))
-            .Where(d => _entityIdentity.Title == null || _entityIdentity.Title == d.Title)
-            .ToArray();
+            .Where(d => _entityIdentity.Title == null || _entityIdentity.Title == d.Title);
 
-        foreach (var dashboardEntity in list)
-        {
-            _output.WriteEntity(dashboardEntity);
-        }
+        _output.ListEntities(list);
             
         return 0;
     }

--- a/src/SeqCli/Cli/Commands/Feed/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Feed/ListCommand.cs
@@ -57,13 +57,9 @@ class ListCommand : Command
         var list = _id != null ?
             new[] { await connection.Feeds.FindAsync(_id) } :
             (await connection.Feeds.ListAsync())
-            .Where(f => _name == null || _name == f.Name)
-            .ToArray();
+            .Where(f => _name == null || _name == f.Name);
 
-        foreach (var feed in list)
-        {
-            _output.WriteEntity(feed);
-        }
+        _output.ListEntities(list);
             
         return 0;
     }

--- a/src/SeqCli/Cli/Commands/HelpCommand.cs
+++ b/src/SeqCli/Cli/Commands/HelpCommand.cs
@@ -179,13 +179,13 @@ class HelpCommand : Command
             {
                 if (!printedGroups.Contains(avail.Metadata.Name))
                 {
-                    Printing.Define($"  {avail.Metadata.Name}", "<sub-command>", 13, Console.Out);
+                    Printing.Define($"  {avail.Metadata.Name}", "<sub-command>", Console.Out);
                     printedGroups.Add(avail.Metadata.Name);
                 }
             }
             else
             {
-                Printing.Define($"  {avail.Metadata.Name}", avail.Metadata.HelpText, 13, Console.Out);
+                Printing.Define($"  {avail.Metadata.Name}", avail.Metadata.HelpText, Console.Out);
             }
         }
 
@@ -201,7 +201,7 @@ class HelpCommand : Command
 
         foreach (var avail in _orderedCommands.Where(c => c.Metadata.Name == topLevelCommand))
         {
-            Printing.Define($"  {avail.Metadata.SubCommand}", avail.Metadata.HelpText, 13, Console.Out);
+            Printing.Define($"  {avail.Metadata.SubCommand}", avail.Metadata.HelpText, Console.Out);
         }
 
         Console.WriteLine();

--- a/src/SeqCli/Cli/Commands/Node/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/ListCommand.cs
@@ -59,13 +59,9 @@ class ListCommand : Command
         var list = _id != null ?
             new[] { await connection.ClusterNodes.FindAsync(_id) } :
             (await connection.ClusterNodes.ListAsync())
-            .Where(n => _name == null || _name == n.Name)
-            .ToArray();
+            .Where(n => _name == null || _name == n.Name);
 
-        foreach (var clusterNode in list)
-        {
-            _output.WriteEntity(clusterNode);
-        }
+        _output.ListEntities(list);
             
         return 0;
     }

--- a/src/SeqCli/Cli/Commands/RetentionPolicy/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/RetentionPolicy/ListCommand.cs
@@ -54,13 +54,7 @@ class ListCommand : Command
             (await connection.RetentionPolicies.ListAsync())
             .ToArray();
 
-        foreach (var policy in list)
-        {
-            if (_output.Json)
-                _output.WriteEntity(policy);
-            else
-                Console.WriteLine(policy.Id);
-        }
+        _output.ListEntities(list);
             
         return 0;
     }

--- a/src/SeqCli/Cli/Commands/Signal/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/ListCommand.cs
@@ -49,13 +49,9 @@ class ListCommand : Command
         var list = _entityIdentity.Id != null ?
             new[] { await connection.Signals.FindAsync(_entityIdentity.Id) } :
             (await connection.Signals.ListAsync(ownerId: _entityOwner.OwnerId, shared: _entityOwner.IncludeShared))
-            .Where(signal => _entityIdentity.Title == null || _entityIdentity.Title == signal.Title)
-            .ToArray();
+            .Where(signal => _entityIdentity.Title == null || _entityIdentity.Title == signal.Title);
 
-        foreach (var signal in list)
-        {
-            _output.WriteEntity(signal);
-        }
+        _output.ListEntities(list);
 
         return 0;
     }

--- a/src/SeqCli/Cli/Commands/User/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/User/ListCommand.cs
@@ -47,13 +47,9 @@ class ListCommand : Command
         var list = _userIdentity.Id != null ?
             new[] { await connection.Users.FindAsync(_userIdentity.Id) } :
             (await connection.Users.ListAsync())
-            .Where(u => _userIdentity.Name == null || _userIdentity.Name == u.Username)
-            .ToArray();
+            .Where(u => _userIdentity.Name == null || _userIdentity.Name == u.Username);
 
-        foreach (var user in list)
-        {
-            _output.WriteEntity(user);
-        }
+        _output.ListEntities(list);
             
         return 0;
     }

--- a/src/SeqCli/Cli/Commands/Workspace/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/ListCommand.cs
@@ -35,13 +35,9 @@ class ListCommand : Command
         var list = _entityIdentity.Id != null ?
             new[] { await connection.Workspaces.FindAsync(_entityIdentity.Id) } :
             (await connection.Workspaces.ListAsync(ownerId: _entityOwner.OwnerId, shared: _entityOwner.IncludeShared))
-            .Where(workspace => _entityIdentity.Title == null || _entityIdentity.Title == workspace.Title)
-            .ToArray();
+            .Where(workspace => _entityIdentity.Title == null || _entityIdentity.Title == workspace.Title);
 
-        foreach (var workspace in list)
-        {
-            _output.WriteEntity(workspace);
-        }
+        _output.ListEntities(list);
 
         return 0;
     }

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using Destructurama;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using Seq.Api.Model;
+using Seq.Api.Model.AppInstances;
 using SeqCli.Config;
 using SeqCli.Csv;
 using SeqCli.Levels;
@@ -136,6 +138,14 @@ class OutputFormatFeature : CommandFeature
         {
             var dyn = (dynamic) jo;
             Console.WriteLine($"{entity.Id} {dyn.Title ?? dyn.Name ?? dyn.Username}");
+        }
+    }
+
+    public void ListEntities(IEnumerable<Entity> list)
+    {
+        foreach (var entity in list)
+        {
+            WriteEntity(entity);
         }
     }
 }

--- a/src/SeqCli/Cli/Printing.cs
+++ b/src/SeqCli/Cli/Printing.cs
@@ -19,11 +19,11 @@ namespace SeqCli.Cli;
 
 static class Printing
 {
-    const int ConsoleWidth = 80;
+    const int ConsoleWidth = 82, TermColumnWidth = 14;
 
-    public static void Define(string term, string definition, int termColumnWidth, TextWriter output)
+    public static void Define(string term, string definition, TextWriter output)
     {
-        var header = term.PadRight(termColumnWidth);
+        var header = term.PadRight(TermColumnWidth);
         var right = ConsoleWidth - header.Length;
 
         var rest = definition.ToCharArray();

--- a/test/SeqCli.EndToEnd/App/AppBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/App/AppBasicsTestCase.cs
@@ -17,6 +17,9 @@ public class AppBasicsTestCase: ICliTestCase
         exit = runner.Exec("app install", "--package-id Seq.App.EmailPlus");
         Assert.Equal(0, exit);
 
+        exit = runner.Exec("app list", "--package-id Seq.App.EmailPlus");
+        Assert.Equal(0, exit);
+
         exit = runner.Exec("app update", "--all");
         Assert.Equal(0, exit);
 

--- a/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
@@ -21,7 +21,7 @@ public class AppInstanceBasicsTestCase : ICliTestCase
         var app = (await connection.Apps.ListAsync()).Single();
 
         var title = Guid.NewGuid().ToString("N");
-        exit = runner.Exec("appinstance create", $"-t {title} --app {app.Id} -p To=");
+        exit = runner.Exec("appinstance create", $"-t {title} --app {app.Id} -p To=example@example.com -p From=example@example.com");
         Assert.Equal(0, exit);
 
         var appInstance = (await connection.AppInstances.ListAsync()).Single();

--- a/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
@@ -21,7 +21,7 @@ public class AppInstanceBasicsTestCase : ICliTestCase
         var app = (await connection.Apps.ListAsync()).Single();
 
         var title = Guid.NewGuid().ToString("N");
-        exit = runner.Exec("appinstance create", $"-t {title} --app {app.Id} -p To=example@example.com -p From=example@example.com");
+        exit = runner.Exec("appinstance create", $"-t {title} --app {app.Id} -p To=example@example.com -p From=example@example.com -p Host=localhost");
         Assert.Equal(0, exit);
 
         var appInstance = (await connection.AppInstances.ListAsync()).Single();

--- a/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
@@ -30,8 +30,8 @@ public class AppInstanceBasicsTestCase : ICliTestCase
         Assert.Equal(0, exit);
 
         var output = runner.LastRunProcess?.Output;
-        Assert.Equal(appInstance.Id, output?.Trim());
-        Assert.Equal(appInstance.Title, output?.Trim());
+        Assert.StartsWith(appInstance.Id, output?.Trim());
+        Assert.EndsWith(appInstance.Title, output?.Trim());
 
         exit = runner.Exec("appinstance remove", $"-t {title}");
         Assert.Equal(0, exit);

--- a/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.AppInstance;
+
+public class AppInstanceBasicsTestCase : ICliTestCase
+{
+    public async Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+    {
+        var exit = runner.Exec("appinstance list", "-i appinstance-none");
+        Assert.Equal(1, exit);
+
+        exit = runner.Exec("app install", "--package-id Seq.App.EmailPlus");
+        Assert.Equal(0, exit);
+
+        var app = (await connection.Apps.ListAsync()).Single();
+
+        var title = Guid.NewGuid().ToString("N");
+        exit = runner.Exec("appinstance create", $"-t {title} --app {app.Id} -p To=");
+        Assert.Equal(0, exit);
+
+        var appInstance = (await connection.AppInstances.ListAsync()).Single();
+        
+        exit = runner.Exec("appinstance list", $"-t {title}");
+        Assert.Equal(0, exit);
+
+        var output = runner.LastRunProcess?.Output;
+        Assert.Equal(appInstance.Id, output?.Trim());
+        Assert.Equal(appInstance.Title, output?.Trim());
+
+        exit = runner.Exec("appinstance remove", $"-t {title}");
+        Assert.Equal(0, exit);
+
+        exit = runner.Exec("appinstance list", $"-i {appInstance.Id}");
+        Assert.Equal(1, exit);
+
+        exit = runner.Exec("appinstance list", $"-t {title}");
+        Assert.Equal(0, exit);
+    }
+}

--- a/test/SeqCli.EndToEnd/Signal/SignalBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Signal/SignalBasicsTestCase.cs
@@ -19,8 +19,8 @@ public class SignalBasicsTestCase : ICliTestCase
         exit = runner.Exec("signal list", "-t Warnings");
         Assert.Equal(0, exit);
 
-        var output = runner.LastRunProcess.Output;
-        Assert.Equal("signal-m33302 Warnings", output.Trim());
+        var output = runner.LastRunProcess?.Output;
+        Assert.Equal("signal-m33302 Warnings", output?.Trim());
 
         exit = runner.Exec("signal remove", "-t Warnings");
         Assert.Equal(0, exit);

--- a/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
+++ b/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
@@ -12,10 +12,12 @@ public class TestConfiguration
     {
         _args = args;
     }
-        
-    public int ServerListenPort { get; } = 9989;
 
+    static int ServerListenPort => 9989;
+
+#pragma warning disable CA1822
     public string ServerListenUrl => $"http://localhost:{ServerListenPort}";
+#pragma warning restore CA1822
 
     string EquivalentBaseDirectory { get; } = AppDomain.CurrentDomain.BaseDirectory
         .Replace(Path.Combine("test", "SeqCli.EndToEnd"), Path.Combine("src", "SeqCli"));


### PR DESCRIPTION
## `app list`

```
seqcli app list [<args>]

List installed app packages

Example:
  seqcli app list

Arguments:
      --package-id=VALUE     The package id of the app(s) to list
  -i, --id=VALUE             The id of a single app to list
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --no-color             Don't colorize text output
      --force-color          Force redirected output to have ANSI color (
                               unless `--no-color` is also specified)
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --verbose              Print verbose output to `STDERR`
```

## `appinstance create`

```
seqcli appinstance create [<args>]

Create an instance of an installed app

Example:
  seqcli appinstance create -t 'Email Ops' --app hostedapp-314159 -p To=ops@example.com

Arguments:
  -t, --title=VALUE          A title for the app instance
      --app=VALUE            The id of the installed app package to instantiate
  -p, --property=NAME=VALUE  Specify name/value settings for the app, e.g. `-p
                               ToAddress=example@example.com -p Subject="
                               Alert!"`
      --overridable=VALUE    Specify setting names that may be overridden by
                               users when invoking the app
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --no-color             Don't colorize text output
      --force-color          Force redirected output to have ANSI color (
                               unless `--no-color` is also specified)
      --verbose              Print verbose output to `STDERR`
```

## `appinstance list`

```
seqcli appinstance list [<args>]

List instances of installed apps

Example:
  seqcli appinstance list

Arguments:
  -t, --title=VALUE          The title of the app instance(s) to list
  -i, --id=VALUE             The id of a single app instance to list
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --no-color             Don't colorize text output
      --force-color          Force redirected output to have ANSI color (
                               unless `--no-color` is also specified)
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --verbose              Print verbose output to `STDERR`
```

## `appinstance remove`

```
seqcli appinstance remove [<args>]

Remove an app instance from the server

Example:
  seqcli appinstance remove -t 'Email Ops'

Arguments:
  -t, --title=VALUE          The title of the app instance(s) to remove
  -i, --id=VALUE             The id of a single app instance to remove
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --verbose              Print verbose output to `STDERR`
```
