### PR TITLE
Create a docker manifest for CI builds

### DIFF
--- a/Build.Docker.ps1
+++ b/Build.Docker.ps1
@@ -50,6 +50,20 @@ function Publish-DockerImage($arch)
     $ErrorActionPreference = "Stop"
 }
 
+function Publish-DockerManifest($archs)
+{
+    $images = ""
+    foreach ($arch in $archs) {
+        $images += "$image-ci:$version-$($arch.rid) "
+    }
+
+    invoke-expression "docker manifest create $image-ci:$version $images"
+    if ($LASTEXITCODE) { exit 4 }
+    
+    docker manifest push $image-ci:$version
+    if ($LASTEXITCODE) { exit 4 }
+}
+
 Push-Location $PSScriptRoot
 
 Execute-Tests
@@ -60,6 +74,10 @@ foreach ($arch in $archs) {
     if ($IsPublishedBuild) {
         Publish-DockerImage($arch)
     }
+}
+
+if ($IsPublishedBuild) {
+    Publish-DockerManifest($archs)
 }
 
 Pop-Location


### PR DESCRIPTION
This will publish a cross-platform Docker manifest for the `seqcli-ci` as well as the platform-specific versions to make it easier to consume locally.