### PR TITLE
Append branch name as a suffix when build is not main

### DIFF
--- a/Build.Common.ps1
+++ b/Build.Common.ps1
@@ -1,0 +1,12 @@
+function Get-SemVer($shortver)
+{
+    # This script originally (c) 2016 Serilog Contributors - license Apache 2.0
+    $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
+    $suffix = @{ $true = ""; $false = ($branch.Substring(0, [math]::Min(10,$branch.Length)) -replace '[\/\+]','-').Trim("-")}[$branch -eq "main"]
+
+    if ($suffix) {
+        $shortver + "-" + $suffix
+    } else {
+        $shortver
+    }
+}

--- a/Build.Docker.ps1
+++ b/Build.Docker.ps1
@@ -1,7 +1,9 @@
+Push-Location $PSScriptRoot
+
 $IsCIBuild = $null -ne $env:APPVEYOR_BUILD_NUMBER
 $IsPublishedBuild = ($env:APPVEYOR_REPO_BRANCH -eq "main" -or $env:APPVEYOR_REPO_BRANCH -eq "dev") -and $null -eq $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
 
-$version = @{ $true = $env:APPVEYOR_BUILD_VERSION; $false = "99.99.99" }[$env:APPVEYOR_BUILD_VERSION -ne $NULL];
+$version = Get-SemVer(@{ $true = $env:APPVEYOR_BUILD_VERSION; $false = "99.99.99" }[$env:APPVEYOR_BUILD_VERSION -ne $NULL])
 $framework = "net7.0"
 $image = "datalust/seqcli"
 $archs = @(
@@ -64,8 +66,6 @@ function Publish-DockerManifest($archs)
     docker manifest push $image-ci:$version
     if ($LASTEXITCODE) { exit 4 }
 }
-
-Push-Location $PSScriptRoot
 
 Execute-Tests
 

--- a/Build.Docker.ps1
+++ b/Build.Docker.ps1
@@ -1,5 +1,7 @@
 Push-Location $PSScriptRoot
 
+. ./Build.Common.ps1
+
 $IsCIBuild = $null -ne $env:APPVEYOR_BUILD_NUMBER
 $IsPublishedBuild = ($env:APPVEYOR_REPO_BRANCH -eq "main" -or $env:APPVEYOR_REPO_BRANCH -eq "dev") -and $null -eq $env:APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -1,5 +1,10 @@
+Push-Location $PSScriptRoot
+
+. ./Build.Common.ps1
+
 $ErrorActionPreference = 'Stop'
 
+$version = Get-SemVer(@{ $true = $env:APPVEYOR_BUILD_VERSION; $false = "99.99.99" }[$env:APPVEYOR_BUILD_VERSION -ne $NULL])
 $framework = 'net7.0'
 $windowsTfmSuffix = '-windows'
 
@@ -73,9 +78,6 @@ function Publish-Docs($version)
     if($LASTEXITCODE -ne 0) { throw "Build failed" }
 }
 
-Push-Location $PSScriptRoot
-
-$version = @{ $true = $env:APPVEYOR_BUILD_VERSION; $false = "99.99.99" }[$env:APPVEYOR_BUILD_VERSION -ne $NULL];
 Write-Output "Building version $version"
 
 $env:Path = "$pwd/.dotnetcli;$env:Path"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ for:
   - pwsh: ./Setup.ps1
 
   build_script:
-    - pwsh: ./Build.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)"
+    - pwsh: ./Build.ps1
       
   deploy:
   
@@ -53,4 +53,4 @@ for:
   - pwsh: ./setup.sh
 
   build_script:
-  - pwsh: $env:PATH = "$env:HOME/.dotnetcli:$env:PATH"; ./Build.Docker.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)"
+  - pwsh: $env:PATH = "$env:HOME/.dotnetcli:$env:PATH"; ./Build.Docker.ps1


### PR DESCRIPTION
This PR appends the branch name as a suffix to builds unless the branch is `main` so that we can more easily identify builds from `dev` as being pre-releases.