### PR TITLE
Switch seqcli ingest filtering to use Serilog.Expressions; fix filters over non-Serilog level names

### DIFF
--- a/src/SeqCli/Api/ApiConstants.cs
+++ b/src/SeqCli/Api/ApiConstants.cs
@@ -16,7 +16,7 @@ namespace SeqCli.Api;
 
 static class ApiConstants
 {
-    public const string ClefMediatType = "application/vnd.serilog.clef";
+    public const string ClefMediaType = "application/vnd.serilog.clef";
     public const string IngestionEndpoint = "api/events/raw";
     public const string ApiKeyHeaderName = "X-Seq-ApiKey";
 }

--- a/src/SeqCli/Cli/Commands/LogCommand.cs
+++ b/src/SeqCli/Cli/Commands/LogCommand.cs
@@ -99,7 +99,7 @@ class LogCommand : Command
             payload.WriteTo(jsonWriter);
             jsonWriter.Flush();
             builder.WriteLine();
-            content = new StringContent(builder.ToString(), Encoding.UTF8, ApiConstants.ClefMediatType);
+            content = new StringContent(builder.ToString(), Encoding.UTF8, ApiConstants.ClefMediaType);
         }
 
         var connection = _connectionFactory.Connect(_connection);

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -19,7 +19,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using Seq.Api.Model;
-using Seq.Api.Model.AppInstances;
 using SeqCli.Config;
 using SeqCli.Csv;
 using SeqCli.Levels;
@@ -49,7 +48,7 @@ class OutputFormatFeature : CommandFeature
 
     public bool Json => _json;
 
-    bool ApplyThemeToRedirectedOutput => _noColor == false && _forceColor == true;
+    bool ApplyThemeToRedirectedOutput => _noColor == false && _forceColor;
 
     ConsoleTheme Theme
         => _noColor                     ? ConsoleTheme.None
@@ -61,13 +60,13 @@ class OutputFormatFeature : CommandFeature
         options.Add(
             "json",
             "Print output in newline-delimited JSON (the default is plain text)",
-            v => _json = true);
+            _ => _json = true);
 
-        options.Add("no-color", "Don't colorize text output", v => _noColor = true);
+        options.Add("no-color", "Don't colorize text output", _ => _noColor = true);
 
         options.Add("force-color",
             "Force redirected output to have ANSI color (unless `--no-color` is also specified)",
-            v => _forceColor = true);
+            _ => _forceColor = true);
     }
 
     public Logger CreateOutputLogger()

--- a/src/SeqCli/Ingestion/LogShipper.cs
+++ b/src/SeqCli/Ingestion/LogShipper.cs
@@ -159,7 +159,7 @@ static class LogShipper
             foreach (var evt in batch)
                 Formatter.Format(evt, builder);
 
-            content = new StringContent(builder.ToString(), Encoding.UTF8, ApiConstants.ClefMediatType);
+            content = new StringContent(builder.ToString(), Encoding.UTF8, ApiConstants.ClefMediaType);
         }
 
         var request = new HttpRequestMessage(HttpMethod.Post, ApiConstants.IngestionEndpoint) { Content = content };

--- a/src/SeqCli/Ingestion/SeqBuiltInNameResolver.cs
+++ b/src/SeqCli/Ingestion/SeqBuiltInNameResolver.cs
@@ -1,0 +1,59 @@
+﻿// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using Serilog.Expressions;
+
+#nullable enable
+
+namespace SeqCli.Ingestion;
+
+/// <summary>
+/// Extends Serilog.Expressions with support for commonly-used Seq property names.
+/// </summary>
+/// <remarks>SeqCli ingestion filters previously used Serilog.Filters.Expressions, so this type ensures most
+/// older filters will continue to work.</remarks>
+public class SeqBuiltInNameResolver: NameResolver
+{
+    public override bool TryResolveBuiltInPropertyName(string alias, [NotNullWhen(true)] out string? target)
+    {
+        switch (alias)
+        {
+            case "@Properties":
+                target = "@p";
+                return true;
+            case "@Timestamp":
+                target = "@t";
+                return true;
+            case "@Level":
+                target = "@l";
+                return true;
+            case "@Message":
+                target = "@m";
+                return true;
+            case "@MessageTemplate":
+                target = "@mt";
+                return true;
+            case "@EventType":
+                target = "@i";
+                return true;
+            case "@Exception":
+                target = "@x";
+                return true;
+            default:
+                target = null;
+                return false;
+        }
+    }
+}

--- a/src/SeqCli/PlainText/Extraction/ExtractionPatternInterpreter.cs
+++ b/src/SeqCli/PlainText/Extraction/ExtractionPatternInterpreter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using SeqCli.PlainText.Patterns;
 

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Destructurama.JsonNet" Version="2.0.0" />
     <PackageReference Include="newtonsoft.json" Version="13.0.2" />
     <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="serilog.filters.expressions" Version="2.1.0" />
+    <PackageReference Include="serilog.expressions" Version="3.4.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/test/SeqCli.Tests/PlainText/LogEventBuilderTests.cs
+++ b/test/SeqCli.Tests/PlainText/LogEventBuilderTests.cs
@@ -29,12 +29,12 @@ public class LogEventBuilderTests
 
         Assert.Equal("2018-02-01T13:00:00.1230000+00:00", evt.Timestamp.ToString("o"));
         Assert.Equal("Hello, world", evt.RenderMessage());
-        Assert.Equal(LogEventLevel.Information, evt.Level);
+        Assert.Equal(LogEventLevel.Warning, evt.Level);
         Assert.Equal("WRN", ((ScalarValue)evt.Properties[SurrogateLevelProperty.PropertyName]).Value);
-        Assert.Equal("EverythingFailedException", evt.Exception.ToString());
+        Assert.Equal("EverythingFailedException", evt.Exception?.ToString());
         Assert.Equal(42, ((ScalarValue)evt.Properties["Count"]).Value);
-        Assert.Equal("TP", ((ScalarValue)evt.Properties["MachineName"]).Value.ToString());
-        Assert.Equal("rem", ((ScalarValue)evt.Properties["@unmatched"]).Value.ToString());
+        Assert.Equal("TP", ((ScalarValue)evt.Properties["MachineName"]).Value!.ToString());
+        Assert.Equal("rem", ((ScalarValue)evt.Properties["@unmatched"]).Value!.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
Investigated https://github.com/datalust/seqcli/issues/280 and while chasing down the issue, ported filtering from the deprecated _Serilog.Filters.Expressions_ library to the newer _Serilog.Expressions_ variant. While neither is a perfect match for Seq filtering syntax, the newer implementation is better maintained, produces more intelligible error messages, and does go as far as supporting the Seq-style `ci` modifier.

There's a plug-in name resolver that maps the Seq style names like `@Message` to the CLEF-style ones like `@m`, so existing filters will be reasonably unlikely to break.

The actual bug, in `IngestCommand` is that:

```csharp
var expr = _filter.Replace("@Level", SurrogateLevelProperty.PropertyName);
```

incorrectly results in `@Level` being replaced with `@seqlevel`. Since `@seqlevel` (the surrogate level property) isn't a built-in, it needs to be referred to as `@Properties['@seqlevel']` (or equivalent).

Test coverage for all of this could definitely be improved, but I've eaten up my time budget for it today, so making what improvements I can, for now.

Fixes #280