### PR TITLE
Support signal expressions when creating retention policies

### DIFF
--- a/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
@@ -43,7 +43,7 @@ public class AppInstanceBasicsTestCase : ICliTestCase
         Assert.Equal(0, exit);
 
         var streamSignal = "signal-m33303,(signal-m33301~signal-m33302)";
-        exit = runner.Exec("appinstance create", $"-t {Guid.NewGuid():N} --app {app.Id} --stream \"{streamSignal}\" -p To=example@example.com -p From=example@example.com -p Host=localhost");
+        exit = runner.Exec("appinstance create", $"-t {Guid.NewGuid():N} --app {app.Id} --stream=\"{streamSignal}\" -p To=example@example.com -p From=example@example.com -p Host=localhost");
         Assert.Equal(0, exit);
     }
 }

--- a/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/AppInstance/AppInstanceBasicsTestCase.cs
@@ -43,7 +43,7 @@ public class AppInstanceBasicsTestCase : ICliTestCase
         Assert.Equal(0, exit);
 
         var streamSignal = "signal-m33303,(signal-m33301~signal-m33302)";
-        exit = runner.Exec("appinstance create", $"-t {Guid.NewGuid():N} --app {app.Id} --stream=\"{streamSignal}\" -p To=example@example.com -p From=example@example.com -p Host=localhost");
+        exit = runner.Exec("appinstance create", $"-t {Guid.NewGuid():N} --app {app.Id} --stream \"{streamSignal}\" -p To=example@example.com -p From=example@example.com -p Host=localhost");
         Assert.Equal(0, exit);
     }
 }

--- a/test/SeqCli.EndToEnd/RetentionPolicy/RetentionPolicyBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/RetentionPolicy/RetentionPolicyBasicsTestCase.cs
@@ -35,5 +35,9 @@ public class RetentionPolicyBasicsTestCase : ICliTestCase
             
         exit = runner.Exec("retention list", $"-i {id}");
         Assert.Equal(1, exit);
+        
+        var streamSignal = "signal-m33303,(signal-m33301~signal-m33302)";
+        exit = runner.Exec("retention create", $"--after 10h --delete \"{streamSignal}\"");
+        Assert.Equal(0, exit);
     }
 }

--- a/test/SeqCli.EndToEnd/RetentionPolicy/RetentionPolicyBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/RetentionPolicy/RetentionPolicyBasicsTestCase.cs
@@ -36,8 +36,14 @@ public class RetentionPolicyBasicsTestCase : ICliTestCase
         exit = runner.Exec("retention list", $"-i {id}");
         Assert.Equal(1, exit);
         
-        var streamSignal = "signal-m33303,(signal-m33301~signal-m33302)";
-        exit = runner.Exec("retention create", $"--after 10h --delete \"{streamSignal}\"");
+        var deleteSignal = "signal-m33303,(signal-m33301~signal-m33302)";
+        exit = runner.Exec("retention create", $"--after 10h --delete \"{deleteSignal}\"");
         Assert.Equal(0, exit);
+
+        exit = runner.Exec("retention create", "--after 10h");
+        Assert.Equal(1, exit);
+        
+        exit = runner.Exec("retention create", $"--after 10h --delete-all-events --delete \"{deleteSignal}\"");
+        Assert.Equal(1, exit);
     }
 }


### PR DESCRIPTION
This PR introduces a `--delete` arg to `retention create` that lets you specify a signal expression to remove. It requires that exactly one of `--delete` or `--delete-all-events` is specified so it's clear what your retention policy will do.