### PR TITLE
Add `seqcli setting names|show|set|clear` commands

### DIFF
--- a/src/SeqCli/Apps/Definitions/AppDefinition.cs
+++ b/src/SeqCli/Apps/Definitions/AppDefinition.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/src/SeqCli/Apps/Definitions/AppMetadataReader.cs
+++ b/src/SeqCli/Apps/Definitions/AppMetadataReader.cs
@@ -19,8 +19,6 @@ using System.Linq;
 using System.Reflection;
 using Seq.Apps;
 
-#nullable  enable
-
 namespace SeqCli.Apps.Definitions;
 
 static class AppMetadataReader

--- a/src/SeqCli/Apps/Definitions/AppSettingDefinition.cs
+++ b/src/SeqCli/Apps/Definitions/AppSettingDefinition.cs
@@ -14,8 +14,6 @@
 
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace SeqCli.Apps.Definitions;
 
 // ReSharper disable all

--- a/src/SeqCli/Cli/CommandLineHost.cs
+++ b/src/SeqCli/Cli/CommandLineHost.cs
@@ -21,8 +21,6 @@ using Autofac.Features.Metadata;
 using Serilog.Core;
 using Serilog.Events;
 
-#nullable enable
-
 namespace SeqCli.Cli;
 
 class CommandLineHost

--- a/src/SeqCli/Cli/Commands/App/InstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/InstallCommand.cs
@@ -22,8 +22,6 @@ using SeqCli.Connection;
 using SeqCli.Util;
 using Serilog;
 
-#nullable enable
-
 namespace SeqCli.Cli.Commands.App;
 
 [Command("app", "install", "Install an app package",

--- a/src/SeqCli/Cli/Commands/App/UpdateCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/UpdateCommand.cs
@@ -21,8 +21,6 @@ using SeqCli.Connection;
 using SeqCli.Util;
 using Serilog;
 
-#nullable enable
-
 namespace SeqCli.Cli.Commands.App;
 
 [Command("app", "update", "Update an installed app package",

--- a/src/SeqCli/Cli/Commands/Bench/BenchCase.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCase.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#nullable enable
-
 namespace SeqCli.Cli.Commands.Bench;
 
 // ReSharper disable ClassNeverInstantiated.Global AutoPropertyCanBeMadeGetOnly.Global UnusedAutoPropertyAccessor.Global

--- a/src/SeqCli/Cli/Commands/Bench/BenchCaseTimings.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCaseTimings.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SeqCli/Cli/Commands/Bench/BenchCasesCollection.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCasesCollection.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#nullable enable
 using System.Collections.Generic;
 
 namespace SeqCli.Cli.Commands.Bench;

--- a/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCommand.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#nullable enable
-
 using System;
 using System.IO;
 using System.Linq;

--- a/src/SeqCli/Cli/Commands/License/ApplyCommand.cs
+++ b/src/SeqCli/Cli/Commands/License/ApplyCommand.cs
@@ -9,8 +9,6 @@ using Serilog;
 
 // ReSharper disable once UnusedType.Global
 
-#nullable enable
-
 namespace  SeqCli.Cli.Commands.License;
 
 [Command("license", "apply", "Apply a license to the Seq server",

--- a/src/SeqCli/Cli/Commands/Node/DemoteCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/DemoteCommand.cs
@@ -1,12 +1,24 @@
-﻿using System;
+﻿// Copyright Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Seq.Api.Model.Cluster;
 using SeqCli.Cli.Features;
 using SeqCli.Connection;
 using Serilog;
-
-#nullable enable
 
 namespace SeqCli.Cli.Commands.Node;
 

--- a/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,8 +20,6 @@ using SeqCli.Cli.Features;
 using SeqCli.Connection;
 using SeqCli.Util;
 using Serilog;
-
-#nullable enable
 
 namespace SeqCli.Cli.Commands.Node;
 

--- a/src/SeqCli/Cli/Commands/SearchCommand.cs
+++ b/src/SeqCli/Cli/Commands/SearchCommand.cs
@@ -28,8 +28,6 @@ using Serilog.Events;
 using Serilog.Parsing;
 // ReSharper disable UnusedType.Global
 
-#nullable enable
-
 namespace SeqCli.Cli.Commands;
 
 [Command("search", "Retrieve log events that match a given filter",

--- a/src/SeqCli/Cli/Commands/Settings/NamesCommand.cs
+++ b/src/SeqCli/Cli/Commands/Settings/NamesCommand.cs
@@ -29,6 +29,6 @@ class NamesCommand: Command
             Console.WriteLine(name);
         }
         
-        return Task.FromResult(1);
+        return Task.FromResult(0);
     }
 }

--- a/src/SeqCli/Cli/Commands/Settings/NamesCommand.cs
+++ b/src/SeqCli/Cli/Commands/Settings/NamesCommand.cs
@@ -1,4 +1,4 @@
-// Copyright 2018 Datalust Pty Ltd
+﻿// Copyright Datalust Pty Ltd and Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,24 +13,22 @@
 // limitations under the License.
 
 using System;
-using System.Reflection;
+using System.Linq;
 using System.Threading.Tasks;
+using Seq.Api.Model.Settings;
 
-namespace SeqCli.Cli.Commands;
+namespace SeqCli.Cli.Commands.Settings;
 
-[Command("version", "Print the current executable version")]
-class VersionCommand : Command
+[Command("setting", "names", "Print the names of all supported settings")]
+class NamesCommand: Command
 {
-    protected override Task<int> Run()
+    protected override Task<int> Run(string[] unrecognized)
     {
-        var version = GetVersion();
-        Console.WriteLine(version);
-        return Task.FromResult(0);
-    }
-
-    public static string GetVersion()
-    {
-        return typeof(VersionCommand).GetTypeInfo().Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+        foreach (var name in Enum.GetNames(typeof(SettingName)).Order())
+        {
+            Console.WriteLine(name);
+        }
+        
+        return Task.FromResult(1);
     }
 }

--- a/src/SeqCli/Cli/Commands/Settings/SetCommand.cs
+++ b/src/SeqCli/Cli/Commands/Settings/SetCommand.cs
@@ -1,0 +1,80 @@
+﻿// Copyright Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Connection;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.Settings;
+
+[Command("setting", "set", "Change a runtime-configurable server setting")]
+class SetCommand: Command
+{
+    readonly SeqConnectionFactory _connectionFactory;
+
+    readonly ConnectionFeature _connection;
+    readonly SettingNameFeature _name;
+    
+    string? _value;
+    bool _valueSpecified, _readValueFromStdin;
+
+    public SetCommand(SeqConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+        _name = Enable<SettingNameFeature>();
+        
+        Options.Add("v|value=",
+            "The setting value, comma-separated if multiple values are accepted",
+            v =>
+            {
+                // Not normalized; some settings might include leading/trailing whitespace.
+                _valueSpecified = true;
+                _value = v;
+            });
+
+        Options.Add("value-stdin",
+            "Read the value from `STDIN`",
+            _ => _readValueFromStdin = true);
+
+        _connection = Enable<ConnectionFeature>();
+    }
+
+    protected override async Task<int> Run()
+    {
+        if (!_valueSpecified && !_readValueFromStdin)
+        {
+            Log.Error("A value must be supplied with either `--value=VALUE` or `--value-stdin`.");
+            return 1;
+        }
+        
+        var connection = _connectionFactory.Connect(_connection);
+
+        var setting = await connection.Settings.FindNamedAsync(_name.Name);
+        setting.Value = ReadValue();
+        await connection.Settings.UpdateAsync(setting);
+
+        return 0;
+    }
+
+    string? ReadValue()
+    {
+        if (_readValueFromStdin)
+            return Console.In.ReadToEnd().TrimEnd('\r', '\n');
+
+        return _value;
+    }
+}

--- a/src/SeqCli/Cli/Commands/Settings/ShowCommand.cs
+++ b/src/SeqCli/Cli/Commands/Settings/ShowCommand.cs
@@ -13,54 +13,40 @@
 // limitations under the License.
 
 using System;
-using System.Linq;
+using System.Globalization;
 using System.Threading.Tasks;
 using SeqCli.Cli.Features;
-using SeqCli.Config;
 using SeqCli.Connection;
 
-namespace SeqCli.Cli.Commands.Node;
+namespace SeqCli.Cli.Commands.Settings;
 
-[Command("node", "list", "List nodes in the Seq cluster",
-    Example = "seqcli node list --json")]
-class ListCommand : Command
+[Command("setting", "show", "Print the current value of a runtime-configurable server setting")]
+class ShowCommand: Command
 {
     readonly SeqConnectionFactory _connectionFactory;
 
     readonly ConnectionFeature _connection;
-    readonly OutputFormatFeature _output;
+    readonly SettingNameFeature _name;
 
-    string? _name, _id;
-        
-    public ListCommand(SeqConnectionFactory connectionFactory, SeqCliOutputConfig outputConfig)
+    public ShowCommand(SeqConnectionFactory connectionFactory)
     {
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
-            
-        Options.Add(
-            "n=|name=",
-            "The name of the cluster node to list",
-            n => _name = n);
 
-        Options.Add(
-            "i=|id=",
-            "The id of a single cluster node to list",
-            id => _id = id);
-            
-        _output = Enable(new OutputFormatFeature(outputConfig));
+        _name = Enable<SettingNameFeature>();
         _connection = Enable<ConnectionFeature>();
     }
-        
+
     protected override async Task<int> Run()
     {
         var connection = _connectionFactory.Connect(_connection);
 
-        var list = _id != null ?
-            new[] { await connection.ClusterNodes.FindAsync(_id) } :
-            (await connection.ClusterNodes.ListAsync())
-            .Where(n => _name == null || _name == n.Name);
+        var setting = await connection.Settings.FindNamedAsync(_name.Name);
 
-        _output.ListEntities(list);
-            
+        if (setting.Value != null)
+        {
+            Console.WriteLine(setting.Value is IFormattable f ? f.ToString(null, CultureInfo.InvariantCulture) : setting.Value.ToString());
+        }
+
         return 0;
     }
 }

--- a/src/SeqCli/Cli/Commands/Settings/ShowCommand.cs
+++ b/src/SeqCli/Cli/Commands/Settings/ShowCommand.cs
@@ -44,7 +44,7 @@ class ShowCommand: Command
 
         if (setting.Value != null)
         {
-            Console.WriteLine(setting.Value is IFormattable f ? f.ToString(null, CultureInfo.InvariantCulture) : setting.Value.ToString());
+            Console.Write(setting.Value is IFormattable f ? f.ToString(null, CultureInfo.InvariantCulture) : setting.Value.ToString());
         }
 
         return 0;

--- a/src/SeqCli/Cli/Commands/Template/ExportCommand.cs
+++ b/src/SeqCli/Cli/Commands/Template/ExportCommand.cs
@@ -10,8 +10,6 @@ using Serilog;
 
 // ReSharper disable once UnusedType.Global
 
-#nullable enable
-
 namespace SeqCli.Cli.Commands.Template;
 
 [Command("template", "export", "Export entities into template files",

--- a/src/SeqCli/Cli/Commands/Template/ImportCommand.cs
+++ b/src/SeqCli/Cli/Commands/Template/ImportCommand.cs
@@ -13,8 +13,6 @@ using Serilog;
 
 // ReSharper disable once UnusedType.Global
 
-#nullable enable
-
 namespace SeqCli.Cli.Commands.Template;
 
 // Uses an import directory rather than individual files, so that name resolution

--- a/src/SeqCli/Cli/Features/ConnectionFeature.cs
+++ b/src/SeqCli/Cli/Features/ConnectionFeature.cs
@@ -14,8 +14,6 @@
 
 using SeqCli.Util;
 
-#nullable enable
-
 namespace SeqCli.Cli.Features;
 
 class ConnectionFeature : CommandFeature

--- a/src/SeqCli/Cli/Features/PropertiesFeature.cs
+++ b/src/SeqCli/Cli/Features/PropertiesFeature.cs
@@ -14,8 +14,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace SeqCli.Cli.Features;
 
 class PropertiesFeature : CommandFeature

--- a/src/SeqCli/Cli/Features/SettingNameFeature.cs
+++ b/src/SeqCli/Cli/Features/SettingNameFeature.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2018 Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Seq.Api.Model.Settings;
+using SeqCli.Util;
+using Serilog;
+
+namespace SeqCli.Cli.Features;
+
+class SettingNameFeature: CommandFeature
+{
+    string? _name;
+
+    public SettingName Name => Enum.Parse<SettingName>(_name!, ignoreCase: true);
+
+    public override void Enable(OptionSet options)
+    {
+        options.Add("n|name=", "The setting name, for example `OpenIdConnectClientSecret`", k => _name = ArgumentString.Normalize(k));
+    }
+
+    public override IEnumerable<string> GetUsageErrors()
+    {
+        if (string.IsNullOrEmpty(_name))
+        {
+            yield return "A setting must be specified with `--name=NAME`.";
+        }
+        
+        if (!Enum.TryParse(_name, ignoreCase: true, out SettingName _))
+        {
+            yield return $"The setting name {_name} was not recognized; run the `seqcli setting names` command to see supported settings.";
+        }
+    }
+}

--- a/src/SeqCli/Connection/SeqConnectionFactory.cs
+++ b/src/SeqCli/Connection/SeqConnectionFactory.cs
@@ -17,8 +17,6 @@ using Seq.Api;
 using SeqCli.Cli.Features;
 using SeqCli.Config;
 
-#nullable enable
-
 namespace SeqCli.Connection;
 
 class SeqConnectionFactory

--- a/src/SeqCli/Templates/Export/EntityName.cs
+++ b/src/SeqCli/Templates/Export/EntityName.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Seq.Api.Model;
 
-#nullable enable
-
 namespace SeqCli.Templates.Export;
 
 static class EntityName

--- a/src/SeqCli/Templates/Export/TemplateSetExporter.cs
+++ b/src/SeqCli/Templates/Export/TemplateSetExporter.cs
@@ -14,8 +14,6 @@ using Seq.Api.Model.SqlQueries;
 using Seq.Api.Model.Workspaces;
 using Serilog;
 
-#nullable enable
-
 namespace SeqCli.Templates.Export;
 
 class TemplateSetExporter

--- a/src/SeqCli/Templates/Export/TemplateValueMap.cs
+++ b/src/SeqCli/Templates/Export/TemplateValueMap.cs
@@ -4,8 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace SeqCli.Templates.Export;
 
 class TemplateValueMap

--- a/src/SeqCli/Templates/Export/TemplateWriter.cs
+++ b/src/SeqCli/Templates/Export/TemplateWriter.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Seq.Api.Model;
 
-#nullable enable
-
 namespace SeqCli.Templates.Export;
 
 static class TemplateWriter

--- a/src/SeqCli/Templates/Import/EntityTemplateFileLoader.cs
+++ b/src/SeqCli/Templates/Import/EntityTemplateFileLoader.cs
@@ -18,8 +18,6 @@ using SeqCli.Templates.Ast;
 using SeqCli.Templates.Export;
 using SeqCli.Templates.Parser;
 
-#nullable enable
-
 namespace SeqCli.Templates.Import;
 
 static class EntityTemplateLoader

--- a/src/SeqCli/Templates/Import/EntityTemplateFunctions.cs
+++ b/src/SeqCli/Templates/Import/EntityTemplateFunctions.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using SeqCli.Templates.Ast;
 using SeqCli.Templates.Evaluator;
 
-#nullable enable
-
 namespace SeqCli.Templates.Import;
 
 class EntityTemplateFunctions

--- a/src/SeqCli/Templates/Import/GenericEntity.cs
+++ b/src/SeqCli/Templates/Import/GenericEntity.cs
@@ -14,8 +14,6 @@
 
 using Seq.Api.Model;
 
-#nullable enable
-
 namespace SeqCli.Templates.Import;
 
 // ReSharper disable once ClassNeverInstantiated.Global

--- a/src/SeqCli/Templates/Import/TemplateImportState.cs
+++ b/src/SeqCli/Templates/Import/TemplateImportState.cs
@@ -5,8 +5,6 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace SeqCli.Templates.Import;
 
 class TemplateImportState

--- a/src/SeqCli/Templates/Import/TemplateSetImporter.cs
+++ b/src/SeqCli/Templates/Import/TemplateSetImporter.cs
@@ -27,8 +27,6 @@ using Serilog;
 
 // ReSharper disable SuggestBaseTypeForParameter, CommentTypo
 
-#nullable enable
-
 namespace SeqCli.Templates.Import;
 
 static class TemplateSetImporter

--- a/src/SeqCli/Util/ArgumentString.cs
+++ b/src/SeqCli/Util/ArgumentString.cs
@@ -14,8 +14,6 @@
 
 using System.Linq;
 
-#nullable enable
-
 namespace SeqCli.Util;
 
 static class ArgumentString

--- a/src/SeqCli/Util/Presentation.cs
+++ b/src/SeqCli/Util/Presentation.cs
@@ -16,8 +16,6 @@ using System;
 using System.Reflection;
 using System.Text;
 
-#nullable enable
-
 namespace SeqCli.Util;
 
 static class Presentation

--- a/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
+++ b/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
@@ -5,9 +5,7 @@
     <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="7.1.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0-dev-00266" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Data\*">

--- a/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Settings;
+
+public class SettingBasicsTestCase : ICliTestCase
+{
+    public Task ExecuteAsync(
+        SeqConnection connection,
+        ILogger logger,
+        CliCommandRunner runner)
+    {
+        var exit = runner.Exec("setting names");
+        Assert.Equal(0, exit);
+        Assert.Contains("InstanceTitle", runner.LastRunProcess!.Output);
+
+        exit = runner.Exec("setting show", "-n instancetitle");
+        Assert.Equal(0, exit);
+        Assert.Empty(runner.LastRunProcess.Output);
+
+        exit = runner.Exec("setting set", "-n instancetitle -v 'Hello, world!'");
+        Assert.Equal(0, exit);
+
+        exit = runner.Exec("setting show", "-n instancetitle");
+        Assert.Equal(0, exit);
+        Assert.Equal("Hello, world!", runner.LastRunProcess.Output);
+
+        exit = runner.Exec("setting clear", "-n instancetitle");
+        Assert.Equal(0, exit);
+
+        exit = runner.Exec("setting show", "-n instancetitle");
+        Assert.Equal(0, exit);
+        Assert.Empty(runner.LastRunProcess.Output);
+
+        return Task.CompletedTask;
+    }
+}

--- a/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
@@ -21,7 +21,7 @@ public class SettingBasicsTestCase : ICliTestCase
         Assert.Equal(0, exit);
         Assert.Empty(runner.LastRunProcess.Output);
 
-        exit = runner.Exec("setting set", "-n instancetitle -v 'Hello, world!'");
+        exit = runner.Exec("setting set", "-n instancetitle -v \"Hello, world!\"");
         Assert.Equal(0, exit);
 
         exit = runner.Exec("setting show", "-n instancetitle");

--- a/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
@@ -27,7 +27,7 @@ public class SettingBasicsTestCase : ICliTestCase
 
         exit = runner.Exec("setting show", "-n instancetitle");
         Assert.Equal(0, exit);
-        Assert.Equal("Hello, world!" + Environment.NewLine, runner.LastRunProcess.Output);
+        Assert.Equal("Hello, world!", runner.LastRunProcess.Output);
 
         exit = runner.Exec("setting clear", "-n instancetitle");
         Assert.Equal(0, exit);

--- a/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Seq.Api;
 using SeqCli.EndToEnd.Support;
 using Serilog;
@@ -26,7 +27,7 @@ public class SettingBasicsTestCase : ICliTestCase
 
         exit = runner.Exec("setting show", "-n instancetitle");
         Assert.Equal(0, exit);
-        Assert.Equal("Hello, world!", runner.LastRunProcess.Output);
+        Assert.Equal("Hello, world!" + Environment.NewLine, runner.LastRunProcess.Output);
 
         exit = runner.Exec("setting clear", "-n instancetitle");
         Assert.Equal(0, exit);

--- a/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Settings/SettingBasicsTestCase.cs
@@ -27,7 +27,7 @@ public class SettingBasicsTestCase : ICliTestCase
 
         exit = runner.Exec("setting show", "-n instancetitle");
         Assert.Equal(0, exit);
-        Assert.Equal("Hello, world!", runner.LastRunProcess.Output);
+        Assert.Equal("Hello, world!", runner.LastRunProcess.Output.Trim());
 
         exit = runner.Exec("setting clear", "-n instancetitle");
         Assert.Equal(0, exit);


### PR DESCRIPTION
_Seq.Api_ needs an update to make all settings available (we'll do that in the near future :-)) but the primary utility of this command group right now is the rotation of Azure AD and OIDC client secrets, which can be set using:

```
echo "some secret" | seqcli setting set -n AzureADClientKey --value-stdin
```

and similarly for `OpenIdConnectClientSecret`.