### PR TITLE
Update to Serilog 3.1 to allow hosting apps that depend on it

### DIFF
--- a/src/Roastery/Roastery.csproj
+++ b/src/Roastery/Roastery.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="3.1.0-dev-02078" />
+        <PackageReference Include="Serilog" Version="3.1.1" />
     </ItemGroup>
 
 </Project>

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -26,18 +26,18 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Destructurama.JsonNet" Version="2.0.0" />
+    <PackageReference Include="Destructurama.JsonNet" Version="2.0.1" />
     <PackageReference Include="newtonsoft.json" Version="13.0.3" />
-    <PackageReference Include="Serilog" Version="3.1.0-dev-02078" />
-    <PackageReference Include="serilog.expressions" Version="4.0.0-dev-00139" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0-dev-00961" />
-    <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="3.0.0-dev-00063" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0-dev-00923" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="serilog.expressions" Version="4.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Autofac" Version="7.1.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0-dev-00266" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
     <PackageReference Include="Superpower" Version="3.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="Seq.Api" Version="2023.4.0" />
     <PackageReference Include="Seq.Apps" Version="2023.4.0" />
     <PackageReference Include="Tavis.UriTemplates" Version="2.0.0" />

--- a/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
+++ b/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="7.1.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0-dev-00266" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Data\*">

--- a/test/SeqCli.Tests/SeqCli.Tests.csproj
+++ b/test/SeqCli.Tests/SeqCli.Tests.csproj
@@ -3,9 +3,9 @@
     <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Discovered via an update to _Seq.App.Mail_ that we haven't updated `seqcli` yet with recent Serilog changes.

I think once this is merged we should publish a preview release and pull that into the upcoming Seq 2024.1 preview.