### PR TITLE
Fix up unused level property

### DIFF
--- a/src/SeqCli/Cli/Commands/IngestCommand.cs
+++ b/src/SeqCli/Cli/Commands/IngestCommand.cs
@@ -84,6 +84,10 @@ class IngestCommand : Command
         try
         {
             var enrichers = new List<ILogEventEnricher>();
+            
+            if (_level != null)
+                enrichers.Add(new ScalarPropertyEnricher(LevelMapping.SurrogateLevelProperty, _level));
+            
             foreach (var (name, value) in _properties.Properties)
                 enrichers.Add(new ScalarPropertyEnricher(name, value));
 

--- a/src/SeqCli/PlainText/LogEvents/LogEventBuilder.cs
+++ b/src/SeqCli/PlainText/LogEvents/LogEventBuilder.cs
@@ -35,7 +35,7 @@ static class LogEventBuilder
         var messageTemplate = GetMessageTemplate(properties);
         var traceId = GetTraceId(properties);
         var spanId = GetSpanId(properties);
-        var props = GetLogEventProperties(properties, remainder, level);
+        var props = GetLogEventProperties(properties, remainder);
 
         var fallbackMappedLevel = level != null ? LevelMapping.ToSerilogLevel(level) : LogEventLevel.Information;
         properties[LevelMapping.SurrogateLevelProperty] = level;
@@ -100,7 +100,7 @@ static class LogEventBuilder
         return null;
     }
 
-    static IEnumerable<LogEventProperty> GetLogEventProperties(IDictionary<string, object?> properties, string? remainder, string? level)
+    static IEnumerable<LogEventProperty> GetLogEventProperties(IDictionary<string, object?> properties, string? remainder)
     {
         var payload = properties
             .Where(p => !ReifiedProperties.IsReifiedProperty(p.Key))

--- a/test/SeqCli.EndToEnd/Ingest/OverrideLevelIngestionTestCase.cs
+++ b/test/SeqCli.EndToEnd/Ingest/OverrideLevelIngestionTestCase.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Ingest;
+
+public class OverrideLevelIngestionTestCase : ICliTestCase
+{
+    public async Task ExecuteAsync(
+        SeqConnection connection,
+        ILogger logger,
+        CliCommandRunner runner)
+    {
+        var inputFiles = Path.Combine("Data", "log-*.txt");
+
+        var exit = runner.Exec("ingest", $"-i {inputFiles} -l OK");
+        Assert.Equal(0, exit);
+
+        var events = await connection.Events.ListAsync();
+        Assert.Equal(4, events.Count(e => e.Level == "OK"));
+    }
+}


### PR DESCRIPTION
In #302 we refactored a lot of how events are constructed. One existing piece of functionality that was lost was being able to specify a level to override any in the events with when ingesting. This PR restores that functionality.