### PR TITLE
Add tracing to seqcli sample ingest

### DIFF
--- a/src/Roastery/Data/Database.cs
+++ b/src/Roastery/Data/Database.cs
@@ -152,14 +152,8 @@ class Database
         
         var delay = 10 + (int)(Distribution.Uniform() * Math.Pow(rowCount, 1.6));
         await Task.Delay(delay);
-
-        if (activity?.Activity != null)
-        {
-            if (_logger.BindProperty("RowCount", rowCount, false, out var rowCountProperty))
-            {
-                ActivityInstrumentation.SetLogEventProperty(activity.Activity, rowCountProperty);
-            }
-        }
+        
+        activity.AddProperty("RowCount", rowCount);
     }
 
     static T Clone<T>(T value) where T: IIdentifiable, new()

--- a/src/Roastery/Data/Database.cs
+++ b/src/Roastery/Data/Database.cs
@@ -7,6 +7,9 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Roastery.Util;
 using Serilog;
+using Serilog.Events;
+using SerilogTracing;
+using SerilogTracing.Instrumentation;
 
 namespace Roastery.Data;
 
@@ -134,17 +137,29 @@ class Database
 
     async Task LogExecAsync(string sql, int rowCount)
     {
+        using var activity = _logger.StartActivity("Execution of {Sql}", sql);
+
         if (Distribution.OnceIn(200))
         {
-            throw new OperationCanceledException(
+            var exception = new OperationCanceledException(
                 "A deadlock was detected and the transaction chosen as the deadlock victim.");
-        }
             
-        var sw = Stopwatch.StartNew();
+            activity.Complete(LogEventLevel.Error, exception);
+
+            throw exception;
+        }
+        
+        
         var delay = 10 + (int)(Distribution.Uniform() * Math.Pow(rowCount, 1.6));
         await Task.Delay(delay);
-        _logger.Debug("Execution of {Sql} affected {RowCount} rows in {Elapsed:0.000} ms",
-            sql, rowCount, sw.Elapsed.TotalMilliseconds);
+
+        if (activity?.Activity != null)
+        {
+            if (_logger.BindProperty("RowCount", rowCount, false, out var rowCountProperty))
+            {
+                ActivityInstrumentation.SetLogEventProperty(activity.Activity, rowCountProperty);
+            }
+        }
     }
 
     static T Clone<T>(T value) where T: IIdentifiable, new()

--- a/src/Roastery/Program.cs
+++ b/src/Roastery/Program.cs
@@ -21,7 +21,7 @@ public static class Program
 
         var database = new Database(webApplicationLogger, "roastery");
         DatabaseMigrator.Populate(database);
-            
+
         var client = new HttpClient(
             "https://roastery.datalust.co",
             new NetworkLatencyMiddleware(
@@ -35,13 +35,13 @@ public static class Program
                             }, webApplicationLogger))))));
 
         var agents = new List<Agent>();
-            
+
         for (var i = 0; i < 100; ++i)
             agents.Add(new Customer(client, Person.Generate(), (int)Distribution.Uniform(60000, 180000)));
-            
+
         for (var i = 0; i < 3; ++i)
             agents.Add(new WarehouseStaff(client));
-            
+
         var batchApplicationLogger = logger.ForContext("Application", "Roastery Batch Processing");
         agents.Add(new CatalogBatch(client, batchApplicationLogger));
         agents.Add(new ArchivingBatch(client, batchApplicationLogger));

--- a/src/Roastery/Roastery.csproj
+++ b/src/Roastery/Roastery.csproj
@@ -4,9 +4,10 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="Serilog" Version="3.1.1" />
+        <PackageReference Include="SerilogTracing" Version="1.0.0-dev-00088" />
     </ItemGroup>
 
 </Project>

--- a/src/Roastery/Web/RequestLoggingMiddleware.cs
+++ b/src/Roastery/Web/RequestLoggingMiddleware.cs
@@ -43,24 +43,12 @@ class RequestLoggingMiddleware : HttpServer
         }
     }
 
-    bool LogCompletion(LoggerActivity? activity, Exception? exception, HttpStatusCode statusCode)
+    bool LogCompletion(LoggerActivity activity, Exception? exception, HttpStatusCode statusCode)
     {
         var level = (int)statusCode >= 500 ? LogEventLevel.Error : LogEventLevel.Information;
-        if (activity?.Activity != null)
-        {
-            if (_logger.BindProperty("StatusCode", (int)statusCode, false, out var statusCodeProperty))
-            {
-                ActivityInstrumentation.SetLogEventProperty(activity.Activity,
-                    statusCodeProperty);
-            }
 
-            if (exception != null)
-            {
-                ActivityInstrumentation.TrySetException(activity.Activity, exception);
-            }
-        }
-
-        activity?.Complete(level);
+        activity.AddProperty("StatusCode", (int)statusCode);
+        activity.Complete(level, exception);
         
         return false;
     }

--- a/src/SeqCli/Ingestion/TraceConstants.cs
+++ b/src/SeqCli/Ingestion/TraceConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace SeqCli.Ingestion;
+
+static class TraceConstants
+{
+    internal const string ParentSpanIdProperty = "ParentSpanId";
+
+    internal const string SpanStartTimestampProperty = "SpanStartTimestamp";
+}

--- a/src/SeqCli/Output/OutputFormatter.cs
+++ b/src/SeqCli/Output/OutputFormatter.cs
@@ -1,3 +1,4 @@
+using SeqCli.Ingestion;
 using SeqCli.Levels;
 using Serilog.Formatting;
 using Serilog.Templates;
@@ -7,6 +8,6 @@ namespace SeqCli.Output;
 static class OutputFormatter
 {
     internal static readonly ITextFormatter Json = new ExpressionTemplate(
-        $"{{ {{@t, @mt, @l: coalesce({LevelMapping.SurrogateLevelProperty}, if @l = 'Information' then undefined() else @l), @x, @sp, @tr, @ps, @st, ..rest()}} }}\n"
+        $"{{ {{@t, @mt, @l: coalesce({LevelMapping.SurrogateLevelProperty}, if @l = 'Information' then undefined() else @l), @x, @sp, @tr, @ps: coalesce({TraceConstants.ParentSpanIdProperty}, @ps), @st: coalesce({TraceConstants.SpanStartTimestampProperty}, @st), ..rest()}} }}\n"
     );
 }

--- a/src/SeqCli/Sample/Loader/Simulation.cs
+++ b/src/SeqCli/Sample/Loader/Simulation.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using Seq.Api;
 using SeqCli.Ingestion;
 using Serilog;
+using SerilogTracing;
 
 namespace SeqCli.Sample.Loader;
 
@@ -26,7 +27,7 @@ static class Simulation
     {
         var buffer = new BufferingSink();
 
-        await using var logger = new LoggerConfiguration()
+        var logger = new LoggerConfiguration()
             .MinimumLevel.Debug()
             .Enrich.FromLogContext()
             .Enrich.WithProperty("Origin", "seqcli sample ingest")


### PR DESCRIPTION
This PR makes `seqcli sample ingest` produce spans instead of manually measuring the time operations take. The spans produced are fairly simplistic, but provide enough context to demonstrate various features, and highlight the kinds of issues that tracing is good at surfacing.

![screenshot-header-dark](https://github.com/datalust/seqcli/assets/6721458/0e487764-aff7-4e04-805c-9def5bd60331)
