### PR TITLE
Enable .NET tool major-version roll-forward, update dependencies

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -86,8 +86,7 @@ Clean-Output
 Create-ArtifactDir
 Restore-Packages
 Publish-Archives($version)
-# Temporarily disabled while SerilogTracing is in pre-release
-# Publish-DotNetTool($version)
+Publish-DotNetTool($version)
 Execute-Tests($version)
 Publish-Docs($version)
 

--- a/src/Roastery/Roastery.csproj
+++ b/src/Roastery/Roastery.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Serilog" Version="3.1.1" />
-        <PackageReference Include="SerilogTracing" Version="1.0.0-dev-00088" />
+        <PackageReference Include="SerilogTracing" Version="1.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -21,7 +21,6 @@ using Newtonsoft.Json.Linq;
 using Seq.Api.Model;
 using SeqCli.Config;
 using SeqCli.Csv;
-using SeqCli.Levels;
 using SeqCli.Output;
 using Serilog;
 using Serilog.Core;

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -10,7 +10,8 @@
     <TreatSpecificWarningsAsErrors />
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>seqcli</ToolCommandName>
-    <LangVersion>default</LangVersion>
+    <RollForward>Major</RollForward>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
@@ -34,7 +35,7 @@
     <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Autofac" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="7.0.0" />
     <PackageReference Include="Superpower" Version="3.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />

--- a/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
+++ b/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
@@ -5,9 +5,7 @@
     <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="8.0.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Data\*">

--- a/test/SeqCli.Tests/SeqCli.Tests.csproj
+++ b/test/SeqCli.Tests/SeqCli.Tests.csproj
@@ -3,9 +3,9 @@
     <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This re-enables .NET tool publishing.

Fixes #315 