### PR TITLE
`seqcli app uninstall`

### DIFF
--- a/src/SeqCli/Cli/Commands/App/UninstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/App/UninstallCommand.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Connection;
+using SeqCli.Util;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.App;
+
+[Command("app", "uninstall", "Uninstall an app package",
+    Example = "seqcli app uninstall --package-id 'Seq.App.JsonArchive'")]
+// ReSharper disable once UnusedType.Global
+class UninstallCommand : Command
+{
+    readonly SeqConnectionFactory _connectionFactory;
+
+    string? _packageId, _id;
+    readonly ConnectionFeature _connection;
+
+    public UninstallCommand(SeqConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+
+        Options.Add(
+            "package-id=",
+            "The package id of the app package to uninstall",
+            packageId => _packageId = ArgumentString.Normalize(packageId));
+        
+        Options.Add(
+            "i=|id=",
+            "The id of a single app package to uninstall",
+            t => _id = ArgumentString.Normalize(t));
+
+        _connection = Enable<ConnectionFeature>();
+    }
+
+    protected override async Task<int> Run()
+    {
+        if (_packageId == null && _id == null)
+        {
+            Log.Error("A `package-id` or `id` must be specified");
+            return 1;
+        }
+
+        var connection = _connectionFactory.Connect(_connection);
+
+        var toRemove = _id != null ? [await connection.Apps.FindAsync(_id)]
+            : (await connection.Apps.ListAsync())
+                .Where(app => _packageId == app.Package.PackageId) 
+                .ToArray();
+
+        if (!toRemove.Any())
+        {
+            Log.Error("No matching API key was found");
+            return 1;
+        }
+
+        foreach (var app in toRemove)
+            await connection.Apps.RemoveAsync(app);
+
+        return 0;
+    }
+}

--- a/src/SeqCli/Cli/Features/EntityIdentityFeature.cs
+++ b/src/SeqCli/Cli/Features/EntityIdentityFeature.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using SeqCli.Util;
 
 namespace SeqCli.Cli.Features;
 
@@ -21,8 +22,6 @@ class EntityIdentityFeature : CommandFeature
 {
     readonly string _entityName;
     readonly string _verb;
-
-    string? _title, _id;
 
     public EntityIdentityFeature(string entityName, string verb)
     {
@@ -35,12 +34,12 @@ class EntityIdentityFeature : CommandFeature
         options.Add(
             "t=|title=",
             $"The title of the {_entityName}(s) to {_verb}",
-            t => _title = t);
+            t => Title = ArgumentString.Normalize(t));
 
         options.Add(
             "i=|id=",
             $"The id of a single {_entityName} to {_verb}",
-            t => _id = t);
+            t => Id = ArgumentString.Normalize(t));
     }
 
     public override IEnumerable<string> GetUsageErrors()
@@ -49,7 +48,7 @@ class EntityIdentityFeature : CommandFeature
             yield return "Only one of either `title` or `id` can be specified";
     }
 
-    public string? Title => string.IsNullOrWhiteSpace(_title) ? null : _title.Trim();
+    public string? Title { get; private set; }
 
-    public string? Id => string.IsNullOrWhiteSpace(_id) ? null : _id.Trim();
+    public string? Id { get; private set; }
 }

--- a/test/SeqCli.EndToEnd/App/AppBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/App/AppBasicsTestCase.cs
@@ -23,6 +23,9 @@ public class AppBasicsTestCase: ICliTestCase
         exit = runner.Exec("app update", "--all");
         Assert.Equal(0, exit);
 
+        exit = runner.Exec("app uninstall", "--package-id Seq.App.EmailPlus");
+        Assert.Equal(0, exit);
+
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
```
seqcli app uninstall [<args>]

Uninstall an app package

Example:
  seqcli app uninstall --package-id 'Seq.App.JsonArchive'

Arguments:
      --package-id=VALUE     The package id of the app package to uninstall
  -i, --id=VALUE             The id of a single app package to uninstall
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --verbose              Print verbose output to `STDERR`
```
