### PR TITLE
Add `--properties` option to `seqcli ingest` and `seqcli log`

### DIFF
--- a/src/SeqCli/Cli/Features/PropertiesExpressionFeature.cs
+++ b/src/SeqCli/Cli/Features/PropertiesExpressionFeature.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using Seq.Syntax.Expressions;
+using SeqCli.Syntax;
+using SeqCli.Util;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SeqCli.Cli.Features;
+
+class PropertiesExpressionFeature : CommandFeature
+{
+    string? _expression;
+
+    public override void Enable(OptionSet options)
+    {
+        options.Add(
+            "properties=",
+            "A Seq syntax object expression describing additional event properties",
+            v => _expression = ArgumentString.Normalize(v));
+    }
+
+    public override IEnumerable<string> GetUsageErrors()
+    {
+        if (_expression == null) yield break;
+
+        if (!SerilogExpression.TryCompile(_expression, null, new SeqCliNameResolver(), out _, out var error))
+            yield return error;
+    }
+
+    public ILogEventEnricher? GetEnricher()
+    {
+        if (_expression == null) return null;
+
+        // Spread enables the expression to overwrite existing property values, use them to compute new properties, and
+        // remove them with `x: undefined()`.
+        var fullExpr = $"{{..@p, ..{_expression}}}";
+        var expr = SerilogExpression.Compile(fullExpr, null, new SeqCliNameResolver());
+        return new PropertiesExpressionEnricher(expr);
+    }
+
+    class PropertiesExpressionEnricher : ILogEventEnricher
+    {
+        readonly CompiledExpression _expr;
+
+        public PropertiesExpressionEnricher(CompiledExpression expr)
+        {
+            _expr = expr;
+        }
+
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            var newProps = _expr(logEvent) as StructureValue ??
+                           throw new InvalidOperationException("Properties expression did not evaluate to an object value.");
+            
+            var missing = new HashSet<string>(logEvent.Properties.Keys);
+            foreach (var prop in newProps.Properties)
+            {
+                missing.Remove(prop.Name);
+                logEvent.AddOrUpdateProperty(prop);
+            }
+
+            foreach (var propName in missing)
+            {
+                logEvent.RemovePropertyIfPresent(propName);
+            }
+        }
+    }
+}

--- a/src/SeqCli/Cli/Features/PropertiesFeature.cs
+++ b/src/SeqCli/Cli/Features/PropertiesFeature.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SeqCli.Cli.Features;
 

--- a/src/SeqCli/Properties/launchSettings.json
+++ b/src/SeqCli/Properties/launchSettings.json
@@ -3,7 +3,7 @@
   "profiles": {
     "SeqCli": {
       "commandName": "Project",
-      "commandLineArgs": "signal update --json-stdin"
+      "commandLineArgs": "log -m test -p Name=World"
     }
   }
 }


### PR DESCRIPTION
Currently, `seqcli log` and `seqcli ingest` allow additional properties to be specified in `-p Name=Value` format:

```
seqcli log -m "Hello, {Name}" -p Name=User
```

This relies on sniffing the type of the property value to construct string, numeric, or Boolean property values in a reasonably intuitive manner.

However, there's no way to override the type used for the representation of a value, and no way to specify complex values such as `service: {name: 'Test'}` or `tags: [1, 2, 3]`.

This PR is a proof-of-concept showing how we could use _Seq.Syntax_ to construct strongly-typed property values:

```
seqcli log -m "Hello, {Name}" --properties="{Name: 'User', Tags: [1, 2, 3]}"
```

Each member in the result of evaluating `--properties` is added to the log event. A tricky "object spread" is used behind the scenes so that in the `seqcli ingest` case, properties on the original event being ingested can be removed with `{someProperty: undefined()}`.

Posting this here as a spike; some more work is needed on tests, and there's a bit of an unpleasant split in `seqcli log` due to the current implementation no longer relying on `LogEvent` behind the scenes.