### PR TITLE
Only include detailed HTTP diagnostics in `node health` output when `--verbose` is set

### DIFF
--- a/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
@@ -54,13 +54,16 @@ class HealthCommand : Command
         try
         {
             var response = await connection.Client.HttpClient.GetAsync("health");
-            Console.WriteLine($"HTTP {response.Version} {((int)response.StatusCode).ToString(CultureInfo.InvariantCulture)} {response.ReasonPhrase}");
+            Log.Information("HTTP {HttpVersion} {StatusCode} {ReasonPhrase}", response.Version, (int)response.StatusCode, response.ReasonPhrase);
+            
             foreach (var (key, values) in response.Headers.Concat(response.Content.Headers))
             foreach (var value in values)
             {
-                Console.WriteLine($"{key}: {value}");
+                Log.Information("{HeaderName}: {HeaderValue}", key, value);
             }
+            
             Console.WriteLine(await response.Content.ReadAsStringAsync());
+            
             return response.IsSuccessStatusCode ? 0 : 1;
         }
         catch (Exception ex)

--- a/test/SeqCli.EndToEnd/Node/NodeDemoteTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeDemoteTestCase.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace SeqCli.EndToEnd.Node;
 
-[CliTestCase(MinimumApiVersion = "2021.3.6410")]
+[CliTestCase]
 public class NodeDemoteTestCase: ICliTestCase
 {
     public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)

--- a/test/SeqCli.EndToEnd/Node/NodeHealthTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeHealthTestCase.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace SeqCli.EndToEnd.Node;
 
-[CliTestCase(MinimumApiVersion = "2021.3.6410")]
+[CliTestCase]
 public class NodeHealthTestCase: ICliTestCase
 {
     public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
     {
         var exit = runner.Exec("node health");
         Assert.Equal(0, exit);
-        Assert.StartsWith("HTTP 1.1 200 OK", runner.LastRunProcess!.Output);
+        Assert.StartsWith("{\"status\":", runner.LastRunProcess!.Output);
         return Task.CompletedTask;
     }
 }

--- a/test/SeqCli.EndToEnd/Node/NodeListTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeListTestCase.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace SeqCli.EndToEnd.Node;
 
-[CliTestCase(MinimumApiVersion = "2021.3.6410")]
+[CliTestCase]
 public class NodeListTestCase: ICliTestCase
 {
     public Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)


### PR DESCRIPTION
No `--verbose` flag - parseable JSON:

```
> seqcli -- node health
{"status":"The Seq node is in service."}
```

With the flag (similar output to today):

```
> seqcli node health --verbose
HTTP 1.1 200 OK
Date: Mon, 08 Jul 2024 04:16:13 GMT
Transfer-Encoding: chunked
Connection: keep-alive
Vary: Accept-Encoding
...
{"status":"The Seq node is in service."}
```

No `--json` flag is currently required - the output is always the literal response from the server, for easy diagnostics (e.g. when the actual response is some random HTML page from a proxy/gateway). Could reevaluate this down the track.