### PR TITLE
Allow the `-i <FILENAME>` argument to be specified multiple times

### DIFF
--- a/src/SeqCli/Cli/Commands/IngestCommand.cs
+++ b/src/SeqCli/Cli/Commands/IngestCommand.cs
@@ -47,7 +47,7 @@ class IngestCommand : Command
     public IngestCommand(SeqConnectionFactory connectionFactory)
     {
         _connectionFactory = connectionFactory;
-        _fileInputFeature = Enable(new FileInputFeature("File(s) to ingest", supportsWildcard: true));
+        _fileInputFeature = Enable(new FileInputFeature("File(s) to ingest", allowMultiple: true));
         _invalidDataHandlingFeature = Enable<InvalidDataHandlingFeature>();
         _properties = Enable<PropertiesFeature>();
 

--- a/src/SeqCli/Cli/Commands/PrintCommand.cs
+++ b/src/SeqCli/Cli/Commands/PrintCommand.cs
@@ -44,7 +44,7 @@ class PrintCommand : Command
         _noColor = outputConfig.DisableColor;
         _forceColor = outputConfig.ForceColor;
 
-        _fileInputFeature = Enable(new FileInputFeature("CLEF file to read", supportsWildcard: true));
+        _fileInputFeature = Enable(new FileInputFeature("CLEF file to read", allowMultiple: true));
 
         Options.Add("f=|filter=",
             "Filter expression to select a subset of events",

--- a/src/SeqCli/Cli/Commands/Signal/ImportCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/ImportCommand.cs
@@ -59,7 +59,7 @@ class ImportCommand : Command
     {
         var connection = _connectionFactory.Connect(_connection);
 
-        using var input = _fileInputFeature.OpenInput();
+        using var input = _fileInputFeature.OpenSingleInput();
         var line = await input.ReadLineAsync();
         while (line != null)
         {


### PR DESCRIPTION
Commands like `print` and `ingest` that support wildcard file input seem to imply in their help text that multiple files can be specified on the command line. However, all but the last specified file is ignored.

This is a quick fix that enables:

```
seqcli ingest .... -i foo.clef -i bar.clef -i *-logs.clef
```
