### PR TITLE
Align `seqcli`'s environment override handling with Seq's

### DIFF
--- a/src/SeqCli/Cli/Commands/ConfigCommand.cs
+++ b/src/SeqCli/Cli/Commands/ConfigCommand.cs
@@ -44,24 +44,25 @@ class ConfigCommand : Command
             
         try
         {
-            var config = SeqCliConfig.Read();
-
+            var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.DefaultConfigFilename);
+            
             if (_key != null)
             {
                 if (_clear)
                 {
                     verb = "clear";
-                    Clear(config, _key);
-                    SeqCliConfig.Write(config);
+                    KeyValueSettings.Clear(config, _key);
+                    SeqCliConfig.Write(config, RuntimeConfigurationLoader.DefaultConfigFilename);
                 }
                 else if (_value != null)
                 {
                     verb = "update";
-                    Set(config, _key, _value);
-                    SeqCliConfig.Write(config);
+                    KeyValueSettings.Set(config, _key, _value);
+                    SeqCliConfig.Write(config, RuntimeConfigurationLoader.DefaultConfigFilename);
                 }
                 else
                 {
+                    verb = "print";
                     Print(config, _key);
                 }
             }
@@ -78,114 +79,23 @@ class ConfigCommand : Command
             return Task.FromResult(1);
         }
     }
-
+    
     static void Print(SeqCliConfig config, string key)
     {
         if (config == null) throw new ArgumentNullException(nameof(config));
         if (key == null) throw new ArgumentNullException(nameof(key));
 
-        var pr = ReadPairs(config).SingleOrDefault(p => p.Key == key);
-        if (pr.Key == null)
-            throw new ArgumentException($"Option {key} not found.");
-
-        Console.WriteLine(Format(pr.Value));
-    }
-
-    static void Set(SeqCliConfig config, string key, string? value)
-    {
-        if (config == null) throw new ArgumentNullException(nameof(config));
-        if (key == null) throw new ArgumentNullException(nameof(key));
-
-        var steps = key.Split('.');
-        if (steps.Length != 2)
-            throw new ArgumentException("The format of the key is incorrect; run the command without any arguments to view all keys.");
-
-        var first = config.GetType().GetTypeInfo().DeclaredProperties
-            .Where(p => p.CanRead && p.GetMethod!.IsPublic && !p.GetMethod.IsStatic)
-            .SingleOrDefault(p => Camelize(p.Name) == steps[0]);
-
-        if (first == null)
-            throw new ArgumentException("The key could not be found; run the command without any arguments to view all keys.");
-
-        if (first.PropertyType == typeof(Dictionary<string, SeqCliConnectionConfig>))
-            throw new NotSupportedException("Use `seqcli profile create` to configure connection profiles.");
-
-        var second = first.PropertyType.GetTypeInfo().DeclaredProperties
-            .Where(p => p.CanRead && p.GetMethod!.IsPublic && !p.GetMethod.IsStatic)
-            .SingleOrDefault(p => Camelize(p.Name) == steps[1]);
-
-        if (second == null)
-            throw new ArgumentException("The key could not be found; run the command without any arguments to view all keys.");
+        if (!KeyValueSettings.TryGetValue(config, key, out var value, out _))
+            throw new ArgumentException($"Option {key} not found");
             
-        if (!second.CanWrite || !second.SetMethod!.IsPublic)
-            throw new ArgumentException("The value is not writeable.");
-
-        var targetValue = Convert.ChangeType(value, second.PropertyType, CultureInfo.InvariantCulture);
-        var configItem = first.GetValue(config);
-        second.SetValue(configItem, targetValue);
-    }
-
-    static void Clear(SeqCliConfig config, string key)
-    {
-        Set(config, key, null);
+        Console.WriteLine(value);
     }
 
     static void List(SeqCliConfig config)
     {
-        foreach (var (key, value) in ReadPairs(config))
+        foreach (var (key, value, _) in KeyValueSettings.Inspect(config))
         {
-            Console.WriteLine($"{key}:");
-            Console.WriteLine($"  {Format(value)}");
+            Console.WriteLine($"{key}={value}");
         }
-    }
-
-    static IEnumerable<KeyValuePair<string, object?>> ReadPairs(object config)
-    {
-        foreach (var property in config.GetType().GetTypeInfo().DeclaredProperties
-                     .Where(p => p.CanRead && p.GetMethod!.IsPublic && !p.GetMethod.IsStatic && !p.Name.StartsWith("Encoded"))
-                     .OrderBy(p => p.Name))
-        {
-            var propertyName = Camelize(property.Name);
-            var propertyValue = property.GetValue(config);
-
-            if (propertyValue is IDictionary dict)
-            {
-                foreach (var elementKey in dict.Keys)
-                {
-                    foreach (var elementPair in ReadPairs(dict[elementKey]!))
-                    {
-                        yield return new KeyValuePair<string, object?>(
-                            $"{propertyName}[{elementKey}].{elementPair.Key}",
-                            elementPair.Value);
-                    }
-                }
-            }
-            else if (propertyValue?.GetType().Namespace?.StartsWith("SeqCli.Config") ?? false)
-            {
-                foreach (var childPair in ReadPairs(propertyValue))
-                {
-                    var name = propertyName + "." + childPair.Key;
-                    yield return new KeyValuePair<string, object?>(name, childPair.Value);
-                }
-            }
-            else
-            {
-                yield return new KeyValuePair<string, object?>(propertyName, propertyValue);
-            }
-        }
-    }
-
-    static string Camelize(string s)
-    {
-        if (s.Length < 2)
-            throw new NotSupportedException("No camel-case support for short names");
-        return char.ToLowerInvariant(s[0]) + s.Substring(1);
-    }
-
-    static string Format(object? value)
-    {
-        return value is IFormattable formattable
-            ? formattable.ToString(null, CultureInfo.InvariantCulture)
-            : value?.ToString() ?? "";
     }
 }

--- a/src/SeqCli/Cli/Commands/ConfigCommand.cs
+++ b/src/SeqCli/Cli/Commands/ConfigCommand.cs
@@ -52,13 +52,13 @@ class ConfigCommand : Command
                 {
                     verb = "clear";
                     KeyValueSettings.Clear(config, _key);
-                    SeqCliConfig.Write(config, RuntimeConfigurationLoader.DefaultConfigFilename);
+                    SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.DefaultConfigFilename);
                 }
                 else if (_value != null)
                 {
                     verb = "update";
                     KeyValueSettings.Set(config, _key, _value);
-                    SeqCliConfig.Write(config, RuntimeConfigurationLoader.DefaultConfigFilename);
+                    SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.DefaultConfigFilename);
                 }
                 else
                 {

--- a/src/SeqCli/Cli/Commands/Profile/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Profile/CreateCommand.cs
@@ -50,7 +50,7 @@ class CreateCommand : Command
         {
             var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.DefaultConfigFilename);
             config.Profiles[_name] = new SeqCliConnectionConfig { ServerUrl = _url, ApiKey = _apiKey };
-            SeqCliConfig.Write(config, RuntimeConfigurationLoader.DefaultConfigFilename);
+            SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.DefaultConfigFilename);
             return 0;
         }
         catch (Exception ex)

--- a/src/SeqCli/Cli/Commands/Profile/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Profile/CreateCommand.cs
@@ -48,9 +48,9 @@ class CreateCommand : Command
             
         try
         {
-            var config = SeqCliConfig.Read();
+            var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.DefaultConfigFilename);
             config.Profiles[_name] = new SeqCliConnectionConfig { ServerUrl = _url, ApiKey = _apiKey };
-            SeqCliConfig.Write(config);
+            SeqCliConfig.Write(config, RuntimeConfigurationLoader.DefaultConfigFilename);
             return 0;
         }
         catch (Exception ex)

--- a/src/SeqCli/Cli/Commands/Profile/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Profile/ListCommand.cs
@@ -11,7 +11,7 @@ class ListCommand : Command
 {
     protected override Task<int> Run()
     {
-        var config = SeqCliConfig.Read();
+        var config = RuntimeConfigurationLoader.Load();
 
         foreach (var profile in config.Profiles.OrderBy(p => p.Key))
         {

--- a/src/SeqCli/Cli/Commands/Profile/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Profile/RemoveCommand.cs
@@ -41,7 +41,7 @@ class RemoveCommand : Command
                 return 1;
             }
 
-            SeqCliConfig.Write(config, RuntimeConfigurationLoader.DefaultConfigFilename);
+            SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.DefaultConfigFilename);
 
             return 0;
         }

--- a/src/SeqCli/Cli/Commands/Profile/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Profile/RemoveCommand.cs
@@ -34,14 +34,14 @@ class RemoveCommand : Command
 
         try
         {
-            var config = SeqCliConfig.Read();
+            var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.DefaultConfigFilename);
             if (!config.Profiles.Remove(_name))
             {
                 Log.Error("No profile with name {ProfileName} was found", _name);
                 return 1;
             }
 
-            SeqCliConfig.Write(config);
+            SeqCliConfig.Write(config, RuntimeConfigurationLoader.DefaultConfigFilename);
 
             return 0;
         }

--- a/src/SeqCli/Cli/Options.cs
+++ b/src/SeqCli/Cli/Options.cs
@@ -239,7 +239,7 @@ namespace SeqCli.Cli
 
 	class OptionValueCollection : IList, IList<string> {
 
-		List<string> values = new List<string> ();
+		List<string> values = new();
 		OptionContext c;
 
 		internal OptionValueCollection (OptionContext c)
@@ -694,7 +694,7 @@ namespace SeqCli.Cli
 			get {return localizer;}
 		}
 
-		List<ArgumentSource> sources = new List<ArgumentSource> ();
+		List<ArgumentSource> sources = new();
 		ReadOnlyCollection<ArgumentSource> roSources;
 
 		public ReadOnlyCollection<ArgumentSource> ArgumentSources {
@@ -960,7 +960,7 @@ namespace SeqCli.Cli
 		}
 
 		class ArgumentEnumerator : IEnumerable<string> {
-			List<IEnumerator<string>> sources = new List<IEnumerator<string>> ();
+			List<IEnumerator<string>> sources = new();
 
 			public ArgumentEnumerator (IEnumerable<string> arguments)
 			{
@@ -1015,7 +1015,7 @@ namespace SeqCli.Cli
 			return false;
 		}
 
-		private readonly Regex ValueOption = new Regex (
+		private readonly Regex ValueOption = new(
 			@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
 
 		protected bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value)

--- a/src/SeqCli/Config/EnvironmentOverrides.cs
+++ b/src/SeqCli/Config/EnvironmentOverrides.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SeqCli.Config;
+
+static class EnvironmentOverrides
+{
+    public static void Apply(string prefix, SeqCliConfig config)
+    {
+        var environment = Environment.GetEnvironmentVariables();
+        Apply(prefix, config, environment.Keys.Cast<string>().ToDictionary(k => k, k => (string?)environment[k]));
+    }
+
+    internal static void Apply(string prefix, SeqCliConfig config, Dictionary<string, string?> environment)
+    {
+        if (config == null) throw new ArgumentNullException(nameof(config));
+        if (environment == null) throw new ArgumentNullException(nameof(environment));
+
+        config.DisallowExport();
+
+        foreach (var (key, _, _) in KeyValueSettings.Inspect(config))
+        {
+            var envVar = ToEnvironmentVariableName(prefix, key);
+            if (environment.TryGetValue(envVar, out var value))
+            {
+                KeyValueSettings.Set(config, key, value ?? "");
+            }
+        }
+    }
+
+    internal static string ToEnvironmentVariableName(string prefix, string key)
+    {
+        return prefix + key.Replace(".", "_").ToUpperInvariant();
+    }
+}

--- a/src/SeqCli/Config/KeyValueSettings.cs
+++ b/src/SeqCli/Config/KeyValueSettings.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace SeqCli.Config;
+
+static class KeyValueSettings
+{
+    public static void Set(SeqCliConfig config, string key, string? value)
+    {
+        if (config == null) throw new ArgumentNullException(nameof(config));
+        if (key == null) throw new ArgumentNullException(nameof(key));
+
+        var steps = key.Split('.');
+        if (steps.Length < 2)
+            throw new ArgumentException("The format of the key is incorrect; run `seqcli config list` to view all keys.");
+
+        object? receiver = config;
+        for (var i = 0; i < steps.Length - 1; ++i)
+        {
+            var nextStep = receiver.GetType().GetTypeInfo().DeclaredProperties
+                .Where(p => p.CanRead && p.GetMethod!.IsPublic && !p.GetMethod.IsStatic && p.GetCustomAttribute<ObsoleteAttribute>() == null)
+                .SingleOrDefault(p => Camelize(GetUserFacingName(p)) == steps[i]);
+
+            if (nextStep == null)
+                throw new ArgumentException("The key could not be found; run `seqcli config list` to view all keys.");
+
+            if (nextStep.PropertyType == typeof(Dictionary<string, SeqCliConnectionConfig>))
+                throw new NotSupportedException("Use `seqcli profile create` to configure connection profiles.");
+            
+            receiver = nextStep.GetValue(receiver);
+            if (receiver == null)
+                throw new InvalidOperationException("Intermediate configuration object is null.");
+        }
+
+        var targetProperty = receiver.GetType().GetTypeInfo().DeclaredProperties
+            .Where(p => p is { CanRead: true, CanWrite: true } && p.GetMethod!.IsPublic && p.SetMethod!.IsPublic &&
+                        !p.GetMethod.IsStatic && p.GetCustomAttribute<ObsoleteAttribute>() == null)
+            .SingleOrDefault(p => Camelize(GetUserFacingName(p)) == steps[^1]);
+
+        if (targetProperty == null)
+            throw new ArgumentException("The key could not be found; run `seqcli config list` to view all keys.");
+
+        var targetValue = ChangeType(value, targetProperty.PropertyType);
+        targetProperty.SetValue(receiver, targetValue);
+    }
+
+    static object? ChangeType(string? value, Type propertyType)
+    {
+        if (propertyType == typeof(string[]))
+            return value?.Split(',').Select(e => e.Trim()).ToArray() ?? [];
+
+        if (propertyType == typeof(int[]))
+            return value?.Split(',').Select(e => int.Parse(e.Trim(), CultureInfo.InvariantCulture)).ToArray() ?? Array.Empty<int>();
+
+        if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+        {
+            return string.IsNullOrWhiteSpace(value) ? null : ChangeType(value, propertyType.GetGenericArguments().Single());
+        }
+
+        if (propertyType.IsEnum)
+            return Enum.Parse(propertyType, value ?? throw new ArgumentException("The setting format is incorrect."));
+
+        return Convert.ChangeType(value, propertyType, CultureInfo.InvariantCulture);
+    }
+
+    public static void Clear(SeqCliConfig config, string key)
+    {
+        Set(config, key, null);
+    }
+
+    public static bool TryGetValue(object config, string key, out string? value, [NotNullWhen(true)] out PropertyInfo? metadata)
+    {
+        var (readKey, readValue, m) = Inspect(config).SingleOrDefault(p => p.Item1 == key);
+        if (readKey == null)
+        {
+            value = null;
+            metadata = null;
+            return false;
+        }
+
+        value = readValue;
+        metadata = m;
+        return true;
+    }
+    
+    public static IEnumerable<(string, string, PropertyInfo)> Inspect(object config)
+    {
+        return Inspect(config, null);
+    }
+
+    static IEnumerable<(string, string, PropertyInfo)> Inspect(object receiver, string? receiverName)
+    {
+        foreach (var nextStep in receiver.GetType().GetTypeInfo().DeclaredProperties
+            .Where(p => p.CanRead && p.GetMethod!.IsPublic && 
+                        !p.GetMethod.IsStatic && p.GetCustomAttribute<ObsoleteAttribute>() == null)
+            .OrderBy(GetUserFacingName))
+        {
+            var camel = Camelize(GetUserFacingName(nextStep));
+            var valuePath = receiverName == null ? camel : $"{receiverName}.{camel}";
+
+            if (nextStep.PropertyType.IsAssignableTo(typeof(IDictionary)))
+            {
+                var dict = (IDictionary)nextStep.GetValue(receiver)!;
+                foreach (var elementKey in dict.Keys)
+                {
+                    foreach (var elementPair in Inspect(dict[elementKey]!))
+                    {
+                        yield return (
+                            $"{valuePath}[{elementKey}].{elementPair.Item1}",
+                            elementPair.Item2,
+                            elementPair.Item3);
+                    }
+                }
+            }
+            // I.e. all of our nested config types
+            else if (nextStep.PropertyType.Name.StartsWith("SeqCli", StringComparison.Ordinal))
+            {
+                var subConfig = nextStep.GetValue(receiver);
+                if (subConfig != null)
+                {
+                    foreach (var keyValuePair in Inspect(subConfig, valuePath))
+                        yield return keyValuePair;
+                }
+            }
+            else if (nextStep.CanRead && nextStep.GetMethod!.IsPublic && 
+                     nextStep.CanWrite && nextStep.SetMethod!.IsPublic && 
+                     !nextStep.SetMethod.IsStatic &&
+                     nextStep.GetCustomAttribute<JsonIgnoreAttribute>() == null)
+            {
+                var value = nextStep.GetValue(receiver);
+                yield return (valuePath, FormatConfigValue(value), nextStep);
+            }
+        }
+    }
+
+    static string FormatConfigValue(object? value)
+    {
+        if (value is string[] strings)
+            return string.Join(",", strings);
+
+        if (value is int[] ints)
+            return string.Join(",", ints.Select(i => i.ToString(CultureInfo.InvariantCulture)));
+
+        if (value is decimal dec)
+        {
+            var floor = decimal.Floor(dec);
+            if (dec == floor)
+                value = floor; // JSON.NET adds a trailing zero, which System.Decimal preserves
+        }
+
+        return value is IFormattable formattable ?
+                formattable.ToString(null, CultureInfo.InvariantCulture) :
+                value?.ToString() ?? "";
+    }
+
+    static string Camelize(string s)
+    {
+        if (s.Length < 2)
+            throw new NotImplementedException("No camel-case support for short names");
+
+        if (s.StartsWith("MS", StringComparison.Ordinal))
+            return "ms" + s[2..];
+        
+        return char.ToLowerInvariant(s[0]) + s[1..];
+    }
+    
+    static string GetUserFacingName(PropertyInfo pi)
+    {
+        return pi.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName ?? pi.Name;
+    }
+}

--- a/src/SeqCli/Config/RuntimeConfigurationLoader.cs
+++ b/src/SeqCli/Config/RuntimeConfigurationLoader.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+
+namespace SeqCli.Config;
+
+static class RuntimeConfigurationLoader
+{
+    public static readonly string DefaultConfigFilename =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "SeqCli.json");
+
+    const string DefaultEnvironmentVariablePrefix = "SEQCLI_";
+    
+    /// <summary>
+    /// This is the method to use when loading configuration for runtime use. It will apply overrides from the
+    /// secret store and environment, and validate the configuration.
+    /// </summary>
+    public static SeqCliConfig Load()
+    {
+        var config = File.Exists(DefaultConfigFilename) ?
+            SeqCliConfig.ReadFromFile(DefaultConfigFilename) :
+            new SeqCliConfig();
+        
+        EnvironmentOverrides.Apply(DefaultEnvironmentVariablePrefix, config);
+            
+        return config;
+    }    
+}

--- a/src/SeqCli/Config/RuntimeConfigurationLoader.cs
+++ b/src/SeqCli/Config/RuntimeConfigurationLoader.cs
@@ -11,8 +11,8 @@ static class RuntimeConfigurationLoader
     const string DefaultEnvironmentVariablePrefix = "SEQCLI_";
     
     /// <summary>
-    /// This is the method to use when loading configuration for runtime use. It will apply overrides from the
-    /// secret store and environment, and validate the configuration.
+    /// This is the method to use when loading configuration for runtime use. It will read the default configuration
+    /// file, if any, and apply overrides from the environment.
     /// </summary>
     public static SeqCliConfig Load()
     {

--- a/src/SeqCli/Config/RuntimeConfigurationLoader.cs
+++ b/src/SeqCli/Config/RuntimeConfigurationLoader.cs
@@ -16,9 +16,7 @@ static class RuntimeConfigurationLoader
     /// </summary>
     public static SeqCliConfig Load()
     {
-        var config = File.Exists(DefaultConfigFilename) ?
-            SeqCliConfig.ReadFromFile(DefaultConfigFilename) :
-            new SeqCliConfig();
+        var config = SeqCliConfig.ReadFromFile(DefaultConfigFilename);
         
         EnvironmentOverrides.Apply(DefaultEnvironmentVariablePrefix, config);
             

--- a/src/SeqCli/Config/SeqCliConfig.cs
+++ b/src/SeqCli/Config/SeqCliConfig.cs
@@ -35,6 +35,11 @@ class SeqCliConfig
         }
     };
 
+    /// <summary>
+    /// Loads <paramref name="filename"/> without considering any environment overrides, nor performing any validation.
+    /// This method is typically used when editing/manipulating the configuration file itself. To read and use the
+    /// configuration at runtime, see <see cref="RuntimeConfigurationLoader.Load"/>.
+    /// </summary>
     public static SeqCliConfig ReadFromFile(string filename)
     {
         var content = File.ReadAllText(filename);

--- a/src/SeqCli/Config/SeqCliConfig.cs
+++ b/src/SeqCli/Config/SeqCliConfig.cs
@@ -40,15 +40,18 @@ class SeqCliConfig
     /// This method is typically used when editing/manipulating the configuration file itself. To read and use the
     /// configuration at runtime, see <see cref="RuntimeConfigurationLoader.Load"/>.
     /// </summary>
+    /// <remarks>If <paramref name="filename"/> does not exist, a new default configuration will be returned.</remarks>
     public static SeqCliConfig ReadFromFile(string filename)
     {
+        if (!File.Exists(filename))
+            return new SeqCliConfig();
+
         var content = File.ReadAllText(filename);
         return JsonConvert.DeserializeObject<SeqCliConfig>(content, SerializerSettings)!;
     }
 
-    public static void Write(SeqCliConfig data, string filename)
+    public static void WriteToFile(SeqCliConfig data, string filename)
     {
-        if (data == null) throw new ArgumentNullException(nameof(data));
         if (!data._exportable)
             throw new InvalidOperationException("The provided configuration is not exportable.");
 

--- a/src/SeqCli/SeqCliModule.cs
+++ b/src/SeqCli/SeqCliModule.cs
@@ -29,7 +29,7 @@ class SeqCliModule : Autofac.Module
             .As<Command>()
             .WithMetadataFrom<CommandAttribute>();
         builder.RegisterType<SeqConnectionFactory>();
-        builder.Register(c => SeqCliConfig.Read()).SingleInstance();
+        builder.Register(c => RuntimeConfigurationLoader.Load()).SingleInstance();
         builder.Register(c => c.Resolve<SeqCliConfig>().Connection).SingleInstance();
         builder.Register(c => c.Resolve<SeqCliConfig>().Output).SingleInstance();
     }

--- a/src/SeqCli/Syntax/QueryBuilder.cs
+++ b/src/SeqCli/Syntax/QueryBuilder.cs
@@ -21,10 +21,10 @@ namespace SeqCli.Syntax;
 
 class QueryBuilder
 {
-    readonly List<(string, string)> _columns = new List<(string, string)>();
-    readonly List<string> _where = new List<string>();
-    readonly List<string> _groupBy = new List<string>();
-    readonly List<string> _having = new List<string>();
+    readonly List<(string, string)> _columns = new();
+    readonly List<string> _where = new();
+    readonly List<string> _groupBy = new();
+    readonly List<string> _having = new();
 
     public void Select(string value, string label)
     {

--- a/test/SeqCli.Tests/Config/EnvironmentOverridesTests.cs
+++ b/test/SeqCli.Tests/Config/EnvironmentOverridesTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using SeqCli.Config;
+using Xunit;
+
+namespace SeqCli.Tests.Config;
+
+public class EnvironmentOverridesTests
+{
+    [Fact]
+    public void EnvironmentVariableOverridesAreApplied()
+    {
+        const string initialUrl = "https://old.example.com";
+
+        var config = new SeqCliConfig
+        {
+            Connection =
+            {
+                ServerUrl = initialUrl
+            }
+        };
+
+        var environment = new Dictionary<string, string>();
+        EnvironmentOverrides.Apply("SEQCLI_", config, environment);
+
+        Assert.Equal(initialUrl, config.Connection.ServerUrl);
+
+        const string updatedUrl = "https://new.example.com";
+        environment["SEQCLI_CONNECTION_SERVERURL"] = updatedUrl;
+        EnvironmentOverrides.Apply("SEQCLI_", config, environment);
+
+        Assert.Equal(updatedUrl, config.Connection.ServerUrl);
+    }
+}

--- a/test/SeqCli.Tests/PlainText/NameValueExtractorTests.cs
+++ b/test/SeqCli.Tests/PlainText/NameValueExtractorTests.cs
@@ -35,7 +35,7 @@ public class NameValueExtractorTests
         Assert.Equal(frame, remainder);
     }
 
-    static NameValueExtractor ClassMethodPattern { get; } = new NameValueExtractor(new[]
+    static NameValueExtractor ClassMethodPattern { get; } = new(new[]
     {
         new SimplePatternElement(Matchers.Identifier, "class"),
         new SimplePatternElement(Matchers.LiteralText(".")),


### PR DESCRIPTION
Fixes #365 

The README shows how environment variable setting overrides _should_ work, but this was committed in error, the README updates should have gone to Seq Forwarder, which was the project that gained environment override support at that time.

Instead of fixing the README, I've lined up `seqcli`'s configuration handling with Seq's - this should help us along towards a fully-consistent experience across client and server in the future.

`SEQCLI_CONNECTION_SERVERURL` now works:

```
seqcli> SEQCLI_CONNECTION_SERVERURL=https://test.example.com seqcli log -m test 
The command failed: nodename nor servname provided, or not known (test.example.com:443) nodename nor servname provided, or not known
seqcli> seqcli log -m test
The command failed: Connection refused (localhost:5341) Connection refused
```

Sorry about the confusing experience, @richard-stafflink - my mistake, here :-)