### PR TITLE
Fix exception when writing `connection.apiKey` values

### DIFF
--- a/src/SeqCli/Config/EnvironmentOverrides.cs
+++ b/src/SeqCli/Config/EnvironmentOverrides.cs
@@ -1,5 +1,18 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -30,7 +43,7 @@ static class EnvironmentOverrides
         }
     }
 
-    internal static string ToEnvironmentVariableName(string prefix, string key)
+    static string ToEnvironmentVariableName(string prefix, string key)
     {
         return prefix + key.Replace(".", "_").ToUpperInvariant();
     }

--- a/src/SeqCli/Config/KeyValueSettings.cs
+++ b/src/SeqCli/Config/KeyValueSettings.cs
@@ -38,7 +38,7 @@ static class KeyValueSettings
         for (var i = 0; i < steps.Length - 1; ++i)
         {
             var nextStep = receiver.GetType().GetTypeInfo().DeclaredProperties
-                .Where(p => p.CanRead && p.GetMethod!.IsPublic && !p.GetMethod.IsStatic && p.GetCustomAttribute<ObsoleteAttribute>() == null && p.GetCustomAttribute<JsonIgnoreAttribute>() == null)
+                .Where(p => p.CanRead && p.GetMethod!.IsPublic && !p.GetMethod.IsStatic && p.GetCustomAttribute<JsonIgnoreAttribute>() == null)
                 .SingleOrDefault(p => Camelize(GetUserFacingName(p)) == steps[i]);
 
             if (nextStep == null)
@@ -56,8 +56,7 @@ static class KeyValueSettings
         // intercept writes through hidden properties, triggering encoding where supported. A type-based solution
         // would be more robust.
         var targetProperty = receiver.GetType().GetTypeInfo().DeclaredProperties
-            .Where(p => p is { CanRead: true, CanWrite: true } && p.GetMethod!.IsPublic && p.SetMethod!.IsPublic &&
-                        !p.GetMethod.IsStatic && p.GetCustomAttribute<ObsoleteAttribute>() == null)
+            .Where(p => p is { CanRead: true, CanWrite: true } && p.GetMethod!.IsPublic && p.SetMethod!.IsPublic && !p.GetMethod.IsStatic)
             .SingleOrDefault(p => Camelize(p.Name) == steps[^1]);
 
         if (targetProperty == null)

--- a/src/SeqCli/Config/RuntimeConfigurationLoader.cs
+++ b/src/SeqCli/Config/RuntimeConfigurationLoader.cs
@@ -1,3 +1,17 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.IO;
 

--- a/src/SeqCli/Config/SeqCliConfig.cs
+++ b/src/SeqCli/Config/SeqCliConfig.cs
@@ -54,7 +54,7 @@ class SeqCliConfig
     {
         if (!data._exportable)
             throw new InvalidOperationException("The provided configuration is not exportable.");
-
+        
         var content = JsonConvert.SerializeObject(data, Formatting.Indented, SerializerSettings);
         File.WriteAllText(filename, content);
     }

--- a/src/SeqCli/Properties/launchSettings.json
+++ b/src/SeqCli/Properties/launchSettings.json
@@ -3,7 +3,7 @@
   "profiles": {
     "SeqCli": {
       "commandName": "Project",
-      "commandLineArgs": "signal update --json-stdin"
+      "commandLineArgs": "config -k connection.apiKey -v test"
     }
   }
 }


### PR DESCRIPTION
This restores behavior broken in #366 - the `connection.apiKey` value relies on user writes to the property with `seqcli config` going through the `ApiKey` property rather than the user-visible `EncodedApiKey` property.

The behavior change led to an exception rather than exposure of any sensitive info, but this whole mechanism could do with some further hardening and test coverage.