### PR TITLE
Fix past participles of command verbs. e.g. removd => removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,27 +74,38 @@ Available commands:
   - [`apikey create`](#apikey-create) &mdash; Create an API key for automation or ingestion.
   - [`apikey list`](#apikey-list) &mdash; List available API keys.
   - [`apikey remove`](#apikey-remove) &mdash; Remove an API key from the server.
+  - [`apikey update`](#apikey-update) &mdash; Update an existing API key.
 - `app`
   - [`app define`](#app-define) &mdash; Generate an app definition for a .NET `[SeqApp]` plug-in.
   - [`app install`](#app-install) &mdash; Install an app package.
   - [`app list`](#app-list) &mdash; List installed app packages.
   - [`app run`](#app-run) &mdash; Host a .NET `[SeqApp]` plug-in.
+  - [`app uninstall`](#app-uninstall) &mdash; Uninstall an app package.
   - [`app update`](#app-update) &mdash; Update an installed app package.
 - `appinstance`
   - [`appinstance create`](#appinstance-create) &mdash; Create an instance of an installed app.
   - [`appinstance list`](#appinstance-list) &mdash; List instances of installed apps.
   - [`appinstance remove`](#appinstance-remove) &mdash; Remove an app instance from the server.
+  - [`appinstance update`](#appinstance-update) &mdash; Update an existing app instance.
 - [`bench`](#bench) &mdash; Measure query performance.
 - [`config`](#config) &mdash; View and set fields in the `SeqCli.json` file; run with no arguments to list all fields.
 - `dashboard`
   - [`dashboard list`](#dashboard-list) &mdash; List dashboards.
   - [`dashboard remove`](#dashboard-remove) &mdash; Remove a dashboard from the server.
   - [`dashboard render`](#dashboard-render) &mdash; Produce a CSV or JSON result set from a dashboard chart.
+- `expressionindex`
+  - [`expressionindex create`](#expressionindex-create) &mdash; Create an expression index.
+  - [`expressionindex list`](#expressionindex-list) &mdash; List expression indexes.
+  - [`expressionindex remove`](#expressionindex-remove) &mdash; Remove an expression index from the server.
 - `feed`
   - [`feed create`](#feed-create) &mdash; Create a NuGet feed.
   - [`feed list`](#feed-list) &mdash; List NuGet feeds.
   - [`feed remove`](#feed-remove) &mdash; Remove a NuGet feed from the server.
+  - [`feed update`](#feed-update) &mdash; Update an existing NuGet feed.
 - [`help`](#help) &mdash; Show information about available commands.
+- `index`
+  - [`index list`](#index-list) &mdash; List indexes.
+  - [`index suppress`](#index-suppress) &mdash; Suppress an index.
 - [`ingest`](#ingest) &mdash; Send log events from a file or `STDIN`.
 - [`license apply`](#license-apply) &mdash; Apply a license to the Seq server.
 - [`log`](#log) &mdash; Send a structured log event to the server.
@@ -112,6 +123,7 @@ Available commands:
   - [`retention create`](#retention-create) &mdash; Create a retention policy.
   - [`retention list`](#retention-list) &mdash; List retention policies.
   - [`retention remove`](#retention-remove) &mdash; Remove a retention policy from the server.
+  - [`retention update`](#retention-update) &mdash; Update an existing retention policy.
 - `sample`
   - [`sample ingest`](#sample-ingest) &mdash; Log sample events into a Seq instance.
   - [`sample setup`](#sample-setup) &mdash; Configure a Seq instance with sample dashboards, signals, users, and so on.
@@ -126,6 +138,7 @@ Available commands:
   - [`signal import`](#signal-import) &mdash; Import signals in newline-delimited JSON format.
   - [`signal list`](#signal-list) &mdash; List available signals.
   - [`signal remove`](#signal-remove) &mdash; Remove a signal from the server.
+  - [`signal update`](#signal-update) &mdash; Update an existing signal.
 - [`tail`](#tail) &mdash; Stream log events matching a filter.
 - `template`
   - [`template export`](#template-export) &mdash; Export entities into template files.
@@ -134,11 +147,13 @@ Available commands:
   - [`user create`](#user-create) &mdash; Create a user.
   - [`user list`](#user-list) &mdash; List users.
   - [`user remove`](#user-remove) &mdash; Remove a user from the server.
+  - [`user update`](#user-update) &mdash; Update an existing user.
 - [`version`](#version) &mdash; Print the current executable version.
 - `workspace`
   - [`workspace create`](#workspace-create) &mdash; Create a workspace.
   - [`workspace list`](#workspace-list) &mdash; List available workspaces.
   - [`workspace remove`](#workspace-remove) &mdash; Remove a workspace from the server.
+  - [`workspace update`](#workspace-update) &mdash; Update an existing workspace.
 
 ### `apikey create`
 
@@ -159,7 +174,7 @@ seqcli apikey create -t 'Test API Key' -p Environment=Test
 |       `--minimum-level=VALUE` | The minimum event level/severity to accept; the default is to accept all events |
 |       `--use-server-timestamps` | Discard client-supplied timestamps and use server clock values |
 |       `--permissions=VALUE` | A comma-separated list of permissions to delegate to the API key; valid permissions are `Ingest` (default), `Read`, `Write`, `Project` and `System` |
-|       `--connect-username=VALUE` | A username to connect with, useful primarily when setting up the first API key |
+|       `--connect-username=VALUE` | A username to connect with, useful primarily when setting up the first API key; servers with an 'Individual' subscription only allow one simultaneous request with this option |
 |       `--connect-password=VALUE` | When `connect-username` is specified, a corresponding password |
 |       `--connect-password-stdin` | When `connect-username` is specified, read the corresponding password from `STDIN` |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
@@ -204,6 +219,24 @@ seqcli apikey remove -t 'Test API Key'
 | ------ | ----------- |
 | `-t`, `--title=VALUE` | The title of the API key(s) to remove |
 | `-i`, `--id=VALUE` | The id of a single API key to remove |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
+### `apikey update`
+
+Update an existing API key.
+
+Example:
+
+```
+seqcli apikey update --json '{...}'
+```
+
+| Option | Description |
+| ------ | ----------- |
+|       `--json=VALUE` | The updated API key in JSON format; this can be produced using `seqcli apikey list --json` |
+|       `--json-stdin` | Read the updated API key as JSON from `STDIN` |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
@@ -289,6 +322,24 @@ seqcli tail --json | seqcli app run -d "./bin/Debug/netstandard2.2" -p ToAddress
 |       `--id=VALUE` | The app instance id, used only for app configuration; defaults to a placeholder id. |
 |       `--read-env` | Read app configuration and settings from environment variables, as specified in https://docs.datalust.co/docs/seq-apps-in-other-languages; ignores all options except --directory and --type |
 
+### `app uninstall`
+
+Uninstall an app package.
+
+Example:
+
+```
+seqcli app uninstall --package-id 'Seq.App.JsonArchive'
+```
+
+| Option | Description |
+| ------ | ----------- |
+|       `--package-id=VALUE` | The package id of the app package to uninstall |
+| `-i`, `--id=VALUE` | The id of a single app package to uninstall |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
 ### `app update`
 
 Update an installed app package.
@@ -328,7 +379,7 @@ seqcli appinstance create -t 'Email Ops' --app hostedapp-314159 -p To=ops@exampl
 | `-t`, `--title=VALUE` | A title for the app instance |
 |       `--app=VALUE` | The id of the installed app package to instantiate |
 | `-p`, `--property=NAME=VALUE` | Specify name/value settings for the app, e.g. `-p ToAddress=example@example.com -p Subject="Alert!"` |
-|       `--stream[=VALUE]` | Stream incoming events to this app instance as they're ingested; optionally accepts a signal expression limiting which events should be streamed |
+|       `--stream[=VALUE]` | Stream incoming events to this app instance as they're ingested; optionally accepts a signal expression limiting which events should be streamed, for example `signal-1,signal-2` |
 |       `--overridable=VALUE` | Specify setting names that may be overridden by users when invoking the app |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
@@ -376,6 +427,24 @@ seqcli appinstance remove -t 'Email Ops'
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
 
+### `appinstance update`
+
+Update an existing app instance.
+
+Example:
+
+```
+seqcli appinstance update --json '{...}'
+```
+
+| Option | Description |
+| ------ | ----------- |
+|       `--json=VALUE` | The updated app instance in JSON format; this can be produced using `seqcli appinstance list --json` |
+|       `--json-stdin` | Read the updated app instance as JSON from `STDIN` |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
 ### `bench`
 
 Measure query performance.
@@ -419,7 +488,7 @@ seqcli dashboard list
 | ------ | ----------- |
 | `-t`, `--title=VALUE` | The title of the dashboard(s) to list |
 | `-i`, `--id=VALUE` | The id of a single dashboard to list |
-| `-o`, `--owner=VALUE` | The id of the user to list dashboards for; by default, shared dashboards are listd |
+| `-o`, `--owner=VALUE` | The id of the user to list dashboards for; by default, shared dashboards are listed |
 |       `--json` | Print output in newline-delimited JSON (the default is plain text) |
 |       `--no-color` | Don't colorize text output |
 |       `--force-color` | Force redirected output to have ANSI color (unless `--no-color` is also specified) |
@@ -441,7 +510,7 @@ seqcli dashboard remove -i dashboard-159
 | ------ | ----------- |
 | `-t`, `--title=VALUE` | The title of the dashboard(s) to remove |
 | `-i`, `--id=VALUE` | The id of a single dashboard to remove |
-| `-o`, `--owner=VALUE` | The id of the user to remove dashboards for; by default, shared dashboards are removd |
+| `-o`, `--owner=VALUE` | The id of the user to remove dashboards for; by default, shared dashboards are removed |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
@@ -469,6 +538,63 @@ seqcli dashboard render -i dashboard-159 -c 'Response Time (ms)' --last 7d --by 
 |       `--json` | Print output in newline-delimited JSON (the default is plain text) |
 |       `--no-color` | Don't colorize text output |
 |       `--force-color` | Force redirected output to have ANSI color (unless `--no-color` is also specified) |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
+### `expressionindex create`
+
+Create an expression index.
+
+Example:
+
+```
+seqcli expressionindex create --expression "ServerName"
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-e`, `--expression=VALUE` | The expression to index |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+|       `--json` | Print output in newline-delimited JSON (the default is plain text) |
+|       `--no-color` | Don't colorize text output |
+|       `--force-color` | Force redirected output to have ANSI color (unless `--no-color` is also specified) |
+
+### `expressionindex list`
+
+List expression indexes.
+
+Example:
+
+```
+seqcli expressionindex list
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-i`, `--id=VALUE` | The id of a single expression index to list |
+|       `--json` | Print output in newline-delimited JSON (the default is plain text) |
+|       `--no-color` | Don't colorize text output |
+|       `--force-color` | Force redirected output to have ANSI color (unless `--no-color` is also specified) |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
+### `expressionindex remove`
+
+Remove an expression index from the server.
+
+Example:
+
+```
+seqcli expressionindex -i expressionindex-2529
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-i`, `--id=VALUE` | The id of an expression index to remove |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
@@ -536,6 +662,24 @@ seqcli feed remove -n CI
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
 
+### `feed update`
+
+Update an existing NuGet feed.
+
+Example:
+
+```
+seqcli feed update --json '{...}'
+```
+
+| Option | Description |
+| ------ | ----------- |
+|       `--json=VALUE` | The updated NuGet feed in JSON format; this can be produced using `seqcli feed list --json` |
+|       `--json-stdin` | Read the updated NuGet feed as JSON from `STDIN` |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
 ### `help`
 
 Show information about available commands.
@@ -549,6 +693,43 @@ seqcli help search
 | Option | Description |
 | ------ | ----------- |
 | `-m`, `--markdown` | Generate markdown for use in documentation |
+
+### `index list`
+
+List indexes.
+
+Example:
+
+```
+seqcli index list
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-i`, `--id=VALUE` | The id of a single index to list |
+|       `--json` | Print output in newline-delimited JSON (the default is plain text) |
+|       `--no-color` | Don't colorize text output |
+|       `--force-color` | Force redirected output to have ANSI color (unless `--no-color` is also specified) |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
+### `index suppress`
+
+Suppress an index.
+
+Example:
+
+```
+seqcli index suppress -i index-2191448f1d9b4f22bd32c6edef752748
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-i`, `--id=VALUE` | The id of an index to suppress |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
 
 ### `ingest`
 
@@ -812,6 +993,24 @@ seqcli retention remove -i retentionpolicy-17
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
 
+### `retention update`
+
+Update an existing retention policy.
+
+Example:
+
+```
+seqcli retention update --json '{...}'
+```
+
+| Option | Description |
+| ------ | ----------- |
+|       `--json=VALUE` | The updated retention policy in JSON format; this can be produced using `seqcli retention list --json` |
+|       `--json-stdin` | Read the updated retention policy as JSON from `STDIN` |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
 ### `sample ingest`
 
 Log sample events into a Seq instance.
@@ -952,7 +1151,7 @@ seqcli signal import -i ./Exceptions.json
 | ------ | ----------- |
 |       `--merge` | Update signals that have ids matching those in the imported data; the default is to always create new signals |
 | `-i`, `--input=VALUE` | File to import; if not specified, `STDIN` will be used |
-| `-o`, `--owner=VALUE` | The id of the user to import signals for; by default, shared signals are importd |
+| `-o`, `--owner=VALUE` | The id of the user to import signals for; by default, shared signals are imported |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
@@ -971,7 +1170,7 @@ seqcli signal list
 | ------ | ----------- |
 | `-t`, `--title=VALUE` | The title of the signal(s) to list |
 | `-i`, `--id=VALUE` | The id of a single signal to list |
-| `-o`, `--owner=VALUE` | The id of the user to list signals for; by default, shared signals are listd |
+| `-o`, `--owner=VALUE` | The id of the user to list signals for; by default, shared signals are listed |
 |       `--json` | Print output in newline-delimited JSON (the default is plain text) |
 |       `--no-color` | Don't colorize text output |
 |       `--force-color` | Force redirected output to have ANSI color (unless `--no-color` is also specified) |
@@ -993,7 +1192,25 @@ seqcli signal remove -t 'Test Signal'
 | ------ | ----------- |
 | `-t`, `--title=VALUE` | The title of the signal(s) to remove |
 | `-i`, `--id=VALUE` | The id of a single signal to remove |
-| `-o`, `--owner=VALUE` | The id of the user to remove signals for; by default, shared signals are removd |
+| `-o`, `--owner=VALUE` | The id of the user to remove signals for; by default, shared signals are removed |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
+### `signal update`
+
+Update an existing signal.
+
+Example:
+
+```
+seqcli signal update --json '{...}'
+```
+
+| Option | Description |
+| ------ | ----------- |
+|       `--json=VALUE` | The updated signal in JSON format; this can be produced using `seqcli signal list --json` |
+|       `--json-stdin` | Read the updated signal as JSON from `STDIN` |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
@@ -1117,6 +1334,24 @@ seqcli user remove -n alice
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
 
+### `user update`
+
+Update an existing user.
+
+Example:
+
+```
+seqcli user update --json '{...}'
+```
+
+| Option | Description |
+| ------ | ----------- |
+|       `--json=VALUE` | The updated user in JSON format; this can be produced using `seqcli user list --json` |
+|       `--json-stdin` | Read the updated user as JSON from `STDIN` |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
 ### `version`
 
 Print the current executable version.
@@ -1158,7 +1393,7 @@ seqcli workspace list
 | ------ | ----------- |
 | `-t`, `--title=VALUE` | The title of the workspace(s) to list |
 | `-i`, `--id=VALUE` | The id of a single workspace to list |
-| `-o`, `--owner=VALUE` | The id of the user to list workspaces for; by default, shared workspaces are listd |
+| `-o`, `--owner=VALUE` | The id of the user to list workspaces for; by default, shared workspaces are listed |
 |       `--json` | Print output in newline-delimited JSON (the default is plain text) |
 |       `--no-color` | Don't colorize text output |
 |       `--force-color` | Force redirected output to have ANSI color (unless `--no-color` is also specified) |
@@ -1180,7 +1415,25 @@ seqcli workspace remove -t 'My Workspace'
 | ------ | ----------- |
 | `-t`, `--title=VALUE` | The title of the workspace(s) to remove |
 | `-i`, `--id=VALUE` | The id of a single workspace to remove |
-| `-o`, `--owner=VALUE` | The id of the user to remove workspaces for; by default, shared workspaces are removd |
+| `-o`, `--owner=VALUE` | The id of the user to remove workspaces for; by default, shared workspaces are removed |
+| `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
+| `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
+|       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |
+
+### `workspace update`
+
+Update an existing workspace.
+
+Example:
+
+```
+seqcli workspace update --json '{...}'
+```
+
+| Option | Description |
+| ------ | ----------- |
+|       `--json=VALUE` | The updated workspace in JSON format; this can be produced using `seqcli workspace list --json` |
+|       `--json-stdin` | Read the updated workspace as JSON from `STDIN` |
 | `-s`, `--server=VALUE` | The URL of the Seq server; by default the `connection.serverUrl` config value will be used |
 | `-a`, `--apikey=VALUE` | The API key to use when connecting to the server; by default the `connection.apiKey` config value will be used |
 |       `--profile=VALUE` | A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used |

--- a/src/SeqCli/Cli/Commands/Dashboard/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Dashboard/ListCommand.cs
@@ -37,7 +37,7 @@ class ListCommand : Command
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
         _entityIdentity = Enable(new EntityIdentityFeature("dashboard", "list"));
-        _entityOwner = Enable(new EntityOwnerFeature("dashboard", "list", _entityIdentity));
+        _entityOwner = Enable(new EntityOwnerFeature("dashboard", "list", "listed", _entityIdentity));
         _output = Enable(new OutputFormatFeature(config.Output));
         _connection = Enable<ConnectionFeature>();
     }

--- a/src/SeqCli/Cli/Commands/Dashboard/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Dashboard/RemoveCommand.cs
@@ -36,7 +36,7 @@ class RemoveCommand : Command
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
         _entityIdentity = Enable(new EntityIdentityFeature("dashboard", "remove"));
-        _entityOwner = Enable(new EntityOwnerFeature("dashboard", "remove", _entityIdentity));
+        _entityOwner = Enable(new EntityOwnerFeature("dashboard", "remove", "removed", _entityIdentity));
         _connection = Enable<ConnectionFeature>();
     }
 

--- a/src/SeqCli/Cli/Commands/Signal/ImportCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/ImportCommand.cs
@@ -51,7 +51,7 @@ class ImportCommand : Command
             _ => _merge = true);
 
         _fileInputFeature = Enable(new FileInputFeature("File to import"));
-        _entityOwner = Enable(new EntityOwnerFeature("signal", "import"));
+        _entityOwner = Enable(new EntityOwnerFeature("signal", "import", "imported"));
         _connection = Enable<ConnectionFeature>();
     }
 

--- a/src/SeqCli/Cli/Commands/Signal/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/ListCommand.cs
@@ -37,7 +37,7 @@ class ListCommand : Command
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
         _entityIdentity = Enable(new EntityIdentityFeature("signal", "list"));
-        _entityOwner = Enable(new EntityOwnerFeature("signal", "list", _entityIdentity));
+        _entityOwner = Enable(new EntityOwnerFeature("signal", "list", "listed", _entityIdentity));
         _output = Enable(new OutputFormatFeature(config.Output));
         _connection = Enable<ConnectionFeature>();
     }

--- a/src/SeqCli/Cli/Commands/Signal/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Signal/RemoveCommand.cs
@@ -36,7 +36,7 @@ class RemoveCommand : Command
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
         _entityIdentity = Enable(new EntityIdentityFeature("signal", "remove"));
-        _entityOwner = Enable(new EntityOwnerFeature("signal", "remove", _entityIdentity));
+        _entityOwner = Enable(new EntityOwnerFeature("signal", "remove", "removed", _entityIdentity));
         _connection = Enable<ConnectionFeature>();
     }
 

--- a/src/SeqCli/Cli/Commands/Workspace/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/ListCommand.cs
@@ -23,7 +23,7 @@ class ListCommand : Command
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
         _entityIdentity = Enable(new EntityIdentityFeature("workspace", "list"));
-        _entityOwner = Enable(new EntityOwnerFeature("workspace", "list", _entityIdentity));
+        _entityOwner = Enable(new EntityOwnerFeature("workspace", "list", "listed", _entityIdentity));
         _output = Enable(new OutputFormatFeature(config.Output));
         _connection = Enable<ConnectionFeature>();
     }

--- a/src/SeqCli/Cli/Commands/Workspace/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Workspace/RemoveCommand.cs
@@ -22,7 +22,7 @@ class RemoveCommand : Command
         _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
 
         _entityIdentity = Enable(new EntityIdentityFeature("workspace", "remove"));
-        _entityOwner = Enable(new EntityOwnerFeature("workspace", "remove", _entityIdentity));
+        _entityOwner = Enable(new EntityOwnerFeature("workspace", "remove", "removed", _entityIdentity));
         _connection = Enable<ConnectionFeature>();
     }
 

--- a/src/SeqCli/Cli/Features/EntityOwnerFeature.cs
+++ b/src/SeqCli/Cli/Features/EntityOwnerFeature.cs
@@ -21,12 +21,14 @@ class EntityOwnerFeature : CommandFeature
 {
     readonly string _entityName;
     readonly string _verb;
+    private readonly string _verbPastParticiple;
     readonly EntityIdentityFeature? _identityFeature;
 
-    public EntityOwnerFeature(string entityName, string verb, EntityIdentityFeature? identityFeature = null)
+    public EntityOwnerFeature(string entityName, string verb, string verbPastParticiple, EntityIdentityFeature? identityFeature = null)
     {
         _entityName = entityName ?? throw new ArgumentNullException(nameof(entityName));
         _verb = verb ?? throw new ArgumentNullException(nameof(verb));
+        _verbPastParticiple = verbPastParticiple ?? throw new ArgumentNullException(nameof(verbPastParticiple));
         _identityFeature = identityFeature;
     }
 
@@ -34,7 +36,7 @@ class EntityOwnerFeature : CommandFeature
     {
         options.Add(
             "o=|owner=",
-            $"The id of the user to {_verb} {_entityName}s for; by default, shared {_entityName}s are {_verb.TrimEnd('e')}d",
+            $"The id of the user to {_verb} {_entityName}s for; by default, shared {_entityName}s are {_verbPastParticiple}",
             o =>
             {
                 OwnerId = StringNormalizationExtensions.Normalize(o);
@@ -55,4 +57,5 @@ class EntityOwnerFeature : CommandFeature
     public string? OwnerId { get; private set; }
 
     public bool IncludeShared { get; private set; } = true;
+
 }


### PR DESCRIPTION
Fixes API documentation misspellings. 

https://github.com/datalust/seq-tickets/issues/2384