### PR TITLE
Add `--simulations=N` parameter to seqcli sample ingest

### DIFF
--- a/src/Roastery/Program.cs
+++ b/src/Roastery/Program.cs
@@ -28,11 +28,10 @@ public static class Program
                 new RequestLoggingMiddleware(webApplicationLogger,
                     new SchedulingLatencyMiddleware(
                         new FaultInjectionMiddleware(webApplicationLogger,
-                            new Router(new Controller[]
-                            {
+                            new Router([
                                 new OrdersController(logger, database),
                                 new ProductsController(logger, database)
-                            }, webApplicationLogger))))));
+                            ], webApplicationLogger))))));
 
         var agents = new List<Agent>();
 

--- a/src/SeqCli/Sample/Loader/Simulation.cs
+++ b/src/SeqCli/Sample/Loader/Simulation.cs
@@ -35,7 +35,7 @@ static class Simulation
             .CreateLogger();
 
         var ship = Task.Run(() => LogShipper.ShipEvents(connection, apiKey, buffer,
-            InvalidDataHandling.Fail, SendFailureHandling.Continue, batchSize));
+            InvalidDataHandling.Fail, SendFailureHandling.Continue, batchSize), cancellationToken);
 
         await Roastery.Program.Main(logger, cancellationToken);
         await logger.DisposeAsync();


### PR DESCRIPTION
Adds an option to increase the volume of sample data from `sample ingest`, for use in load testing or when needing more dense sample data.

Usage:

```
seqcli sample ingest -y --quiet --simulations 10
```

