### PR TITLE
Add `no_cache` directive to bench queries.

### DIFF
--- a/src/SeqCli/Cli/Commands/Bench/BenchCases.json
+++ b/src/SeqCli/Cli/Commands/Bench/BenchCases.json
@@ -2,47 +2,47 @@
   "cases": [
     {
       "id": "count-all",
-      "query": "select count(*) from stream where @Timestamp >= now() - 30d",
+      "query": "select count(*) from stream where @Timestamp >= now() - 30d for no_cache",
       "notes": "Tests page traversal performance only; avoids data copies, serialization, and evaluation."
     },
     {
       "id": "multiple-reductions",
-      "query": "select count(*), sum(A), min(B), max(C) from stream where @Timestamp >= now() - 30d",
+      "query": "select count(*), sum(A), min(B), max(C) from stream where @Timestamp >= now() - 30d for no_cache",
       "notes": "Reducer performance. Percentile is excluded because it prevents parallelization unless time-grouped."
     },
     {
       "id": "percentile-by-12h",
-      "query": "select percentile(@Timestamp % 1ms, 90) from stream where @Timestamp >= now() - 30d group by @Level, time(12h)",
+      "query": "select percentile(@Timestamp % 1ms, 90) from stream where @Timestamp >= now() - 30d group by @Level, time(12h) for no_cache",
       "notes": "Common reducer/grouping combination used when monitoring performance."
     },
     {
       "id": "count-with-request-id",
-      "query": "select count(*) from stream where RequestId is not null and @Timestamp >= now() - 30d",
+      "query": "select count(*) from stream where RequestId is not null and @Timestamp >= now() - 30d for no_cache",
       "notes": "Tests sparse deserialization and condition evaluation atop basic page traversal."
     },
     {
       "id": "count-exception-starts-with-sys",
-      "query": "select count(*) from stream where @Exception like 'Sys%' and @Timestamp >= now() - 30d",
+      "query": "select count(*) from stream where @Exception like 'Sys%' and @Timestamp >= now() - 30d for no_cache",
       "notes": "Text search performance. Chooses 'Sys' because in .NET data there should be some hits."
     },
     {
       "id": "count-message-starts-with-fai",
-      "query": "select count(*) from stream where @Message like 'Fai%' and @Timestamp >= now() - 30d",
+      "query": "select count(*) from stream where @Message like 'Fai%' and @Timestamp >= now() - 30d for no_cache",
       "notes": "Text search performance; worse on @Message than other properties because fragment pre-filtering is not used."
     },
     {
       "id": "group-by-level",
-      "query": "select count(*) from stream where @Timestamp >= now() - 30d group by @Level",
+      "query": "select count(*) from stream where @Timestamp >= now() - 30d group by @Level for no_cache",
       "notes": "Grouping performance, strings, small number of groups."
     },
     {
       "id": "group-by-millisecond",
-      "query": "select count(*) from stream where @Timestamp >= now() - 30d group by @Timestamp % 1ms limit 100",
+      "query": "select count(*) from stream where @Timestamp >= now() - 30d group by @Timestamp % 1ms limit 100 for no_cache",
       "notes": "Grouping performance, numbers, up to 10000 groups."
     },
     {
       "id": "group-by-12h",
-      "query": "select count(*) from stream where @Timestamp >= now() - 30d group by time(12h)",
+      "query": "select count(*) from stream where @Timestamp >= now() - 30d group by time(12h) for no_cache",
       "notes": "Time partitioning performance."
     },
     {
@@ -62,7 +62,7 @@
     },
     {
       "id": "count-where-heavy-predicate",
-      "query": "select count(*) from stream where (A = 1 or B = '2' or C or D <> null or length(E) > 5 or F = {f: 6} or G = '7' or H like '8%' or I > 9 or J % 10 = 0) and @Timestamp >= now() - 30d",
+      "query": "select count(*) from stream where (A = 1 or B = '2' or C or D <> null or length(E) > 5 or F = {f: 6} or G = '7' or H like '8%' or I > 9 or J % 10 = 0) and @Timestamp >= now() - 30d for no_cache",
       "notes": "Tests expression evaluation performance."
     }
   ]


### PR DESCRIPTION
Aggregate query caching breaks the statistics generated from bench results, hence it is better to opt out of aggregate query caching for query benchmarking.  