### PR TITLE
Update the `node health` command to be roughly comparable with `cluster health`

### DIFF
--- a/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
@@ -22,7 +22,6 @@ using Seq.Api;
 using SeqCli.Cli.Features;
 using SeqCli.Config;
 using SeqCli.Connection;
-using SeqCli.Util;
 using Serilog;
 
 namespace SeqCli.Cli.Commands.Node;
@@ -77,16 +76,9 @@ class HealthCommand : Command
             {
                 while (true)
                 {
-                    try
+                    if (await RunOnce(connection) == 0)
                     {
-                        if (await RunOnce(connection) == 0)
-                        {
-                            return 0;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error("{UnhandledExceptionMessage}", Presentation.FormattedMessage(ex));
+                        return 0;
                     }
 
                     await Task.Delay(tick, ct.Token);

--- a/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 using System;
-using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Seq.Api;
 using SeqCli.Cli.Features;
+using SeqCli.Config;
 using SeqCli.Connection;
 using SeqCli.Util;
 using Serilog;
@@ -24,33 +28,79 @@ using Serilog;
 namespace SeqCli.Cli.Commands.Node;
 
 [Command("node", "health",
-    "Probe a Seq node's `/health` endpoint, and print the returned HTTP status code, or 'Unreachable' if the endpoint could not be queried",
+    "Probe a Seq node's `/health` endpoint, and print the returned HTTP status code, or 'Unreachable' if the endpoint could not be queried; note that no API key is required",
     Example = "seqcli node health -s https://seq-2.example.com")]
 class HealthCommand : Command
 {
     readonly SeqConnectionFactory _connectionFactory;
 
-    string? _profileName, _serverUrl;
+    readonly ConnectionFeature _connection;
+    readonly WaitUntilHealthyFeature _waitUntilHealthy;
+    readonly TimeoutFeature _timeout;
+    readonly OutputFormatFeature _output;
 
-    public HealthCommand(SeqConnectionFactory connectionFactory)
+    public HealthCommand(SeqConnectionFactory connectionFactory, SeqCliOutputConfig outputConfig)
     {
         _connectionFactory = connectionFactory;
-            
-        Options.Add("s=|server=",
-            "The URL of the Seq server; by default the `connection.serverUrl` config value will be used",
-            v => _serverUrl = ArgumentString.Normalize(v));
 
-        Options.Add("profile=",
-            "A connection profile to use; by default the `connection.serverUrl` and `connection.apiKey` config values will be used",
-            v => _profileName = ArgumentString.Normalize(v));
+        _waitUntilHealthy = Enable(new WaitUntilHealthyFeature("node"));
+        _timeout = Enable(new TimeoutFeature());
+        _connection = Enable<ConnectionFeature>();
+        _output = Enable(new OutputFormatFeature(outputConfig));
     }
 
     protected override async Task<int> Run()
     {
-        // An API key is not accepted; we don't want to imply that /health requires authentication.
-        var surrogateConnectionFeature = new ConnectionFeature { ProfileName = _profileName, Url = _serverUrl };
-        var connection = _connectionFactory.Connect(surrogateConnectionFeature);
+        var connection = _connectionFactory.Connect(_connection);
 
+        var timeout = _timeout.ApplyTimeout(connection.Client.HttpClient);
+
+        if (_waitUntilHealthy.ShouldWait)
+        {
+            return await RunUntilHealthy(connection, timeout ?? TimeSpan.FromSeconds(30));
+        }
+
+        return await RunOnce(connection);
+    }
+
+    async Task<int> RunUntilHealthy(SeqConnection connection, TimeSpan timeout)
+    {
+        using var ct = new CancellationTokenSource(timeout);
+        
+        var tick = TimeSpan.FromSeconds(1);
+
+        connection.Client.HttpClient.Timeout = tick;
+
+        try
+        {
+            return await Task.Run(async () =>
+            {
+                while (true)
+                {
+                    try
+                    {
+                        if (await RunOnce(connection) == 0)
+                        {
+                            return 0;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error("{UnhandledExceptionMessage}", Presentation.FormattedMessage(ex));
+                    }
+
+                    await Task.Delay(tick, ct.Token);
+                }
+            }, ct.Token);
+        }
+        catch (TaskCanceledException)
+        {
+            return 1;
+        }
+    }
+
+    async Task<int> RunOnce(SeqConnection connection)
+    {
         try
         {
             var response = await connection.Client.HttpClient.GetAsync("health");
@@ -61,17 +111,32 @@ class HealthCommand : Command
             {
                 Log.Information("{HeaderName}: {HeaderValue}", key, value);
             }
-            
-            Console.WriteLine(await response.Content.ReadAsStringAsync());
+
+            if (_output.Json)
+            {
+                var shouldBeJson = await response.Content.ReadAsStringAsync();
+                try
+                {
+                    var obj = JsonConvert.DeserializeObject(shouldBeJson) ?? throw new InvalidDataException();
+                    _output.WriteObject(obj);
+                }
+                catch
+                {
+                    _output.WriteObject(new { Response = shouldBeJson });
+                }
+            }
+            else
+            {
+                Console.WriteLine((int)response.StatusCode);
+            }
             
             return response.IsSuccessStatusCode ? 0 : 1;
         }
         catch (Exception ex)
         {
             Log.Information(ex, "Exception thrown when calling health endpoint");
-                
+
             Console.WriteLine("Unreachable");
-            Console.WriteLine(Presentation.FormattedMessage(ex));
             return 1;
         }
     }

--- a/src/SeqCli/Cli/Features/WaitUntilHealthyFeature.cs
+++ b/src/SeqCli/Cli/Features/WaitUntilHealthyFeature.cs
@@ -1,0 +1,28 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace SeqCli.Cli.Features;
+
+class WaitUntilHealthyFeature(string targetName): CommandFeature
+{
+    public bool ShouldWait { get; private set; }
+    
+    public override void Enable(OptionSet options)
+    {
+        options.Add("wait-until-healthy", $"Wait until the {targetName} returns a status of healthy", _ =>
+        {
+            ShouldWait = true;
+        });
+    }
+}

--- a/test/SeqCli.EndToEnd/Node/NodeHealthTestCase.cs
+++ b/test/SeqCli.EndToEnd/Node/NodeHealthTestCase.cs
@@ -13,7 +13,12 @@ public class NodeHealthTestCase: ICliTestCase
     {
         var exit = runner.Exec("node health");
         Assert.Equal(0, exit);
+        Assert.Equal("200", runner.LastRunProcess!.Output.Trim());
+        
+        exit = runner.Exec("node health --no-color --json");
+        Assert.Equal(0, exit);
         Assert.StartsWith("{\"status\":", runner.LastRunProcess!.Output);
+        
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Makes output consistent with the command's help text, showing status code unless `--json` is specified, in which case we use regular JSON output.

Adds `--wait-until-healthy` and `--timeout` to assist with deployment automation scenarios.

There are some subtle differences between the semantics of `/health` and `/health/cluster` that make further convergence tricky, but there's still room to revisit and improve this command in the future.