### PR TITLE
Add a --setup flag to sample ingest

### DIFF
--- a/src/SeqCli/Cli/Commands/Sample/SetupCommand.cs
+++ b/src/SeqCli/Cli/Commands/Sample/SetupCommand.cs
@@ -22,6 +22,7 @@ using SeqCli.Connection;
 using SeqCli.Templates.Ast;
 using SeqCli.Templates.Import;
 using SeqCli.Util;
+using Seq.Api;
 
 // ReSharper disable once UnusedType.Global
 
@@ -58,6 +59,11 @@ class SetupCommand : Command
             return 1;
         }
 
+        return await ImportTemplates(connection);
+    }
+
+    internal static async Task<int> ImportTemplates(SeqConnection connection)
+    {
         var templateArgs = new Dictionary<string, JsonTemplate>();
         templateArgs["ownerId"] = new JsonTemplateNull();
 

--- a/test/SeqCli.EndToEnd/Sample/SampleIngestTestCase.cs
+++ b/test/SeqCli.EndToEnd/Sample/SampleIngestTestCase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Seq.Api;

--- a/test/SeqCli.EndToEnd/Sample/SampleIngestTestCase.cs
+++ b/test/SeqCli.EndToEnd/Sample/SampleIngestTestCase.cs
@@ -12,7 +12,17 @@ public class SampleIngestTestCase : ICliTestCase
 {
     public async Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
     {
-        runner.Exec("sample ingest", "--setup --confirm", timeout: TimeSpan.FromSeconds(3));
+        try
+        {
+            runner.Exec("sample ingest", "--setup --confirm", timeout: TimeSpan.FromSeconds(3));
+        }
+        catch
+        {
+            // Ignored
+        }
+
+        var events = await connection.Events.ListAsync();
+        Assert.NotEmpty(events);
 
         var sampleWorkspace = (await connection.Workspaces.ListAsync(shared: true))
             .SingleOrDefault(w => w.Title == "Sample");

--- a/test/SeqCli.EndToEnd/Sample/SampleIngestTestCase.cs
+++ b/test/SeqCli.EndToEnd/Sample/SampleIngestTestCase.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Sample;
+
+public class SampleIngestTestCase : ICliTestCase
+{
+    public async Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+    {
+        runner.Exec("sample ingest", "--setup --confirm", timeout: TimeSpan.FromSeconds(3));
+
+        var sampleWorkspace = (await connection.Workspaces.ListAsync(shared: true))
+            .SingleOrDefault(w => w.Title == "Sample");
+
+        Assert.NotNull(sampleWorkspace);
+    }
+}

--- a/test/SeqCli.EndToEnd/Support/CliCommandRunner.cs
+++ b/test/SeqCli.EndToEnd/Support/CliCommandRunner.cs
@@ -10,10 +10,10 @@ public class CliCommandRunner(TestConfiguration configuration)
         
     public ITestProcess? LastRunProcess { get; private set; }
 
-    public int Exec(string command, string? args = null, bool disconnected = false)
+    public int Exec(string command, string? args = null, bool disconnected = false, TimeSpan? timeout = null)
     {
         using var process = configuration.SpawnCliProcess(command, args, skipServerArg: disconnected);
         LastRunProcess = process;
-        return process.WaitForExit(DefaultExecTimeout);
+        return process.WaitForExit(timeout ?? DefaultExecTimeout);
     }
 }


### PR DESCRIPTION
This PR introduces a `--setup` flag to `seqcli sample ingest` that lets you import the setup templates and run sample ingestion in a single command:

```
seqcli sample ingest --setup -y
```