### PR TITLE
Fix up version computing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   CI_BUILD_NUMBER_BASE: ${{ github.run_number }}
   CI_TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
-  CI_PUBLISH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  CI_PUBLISH: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
 jobs:
   build-windows:

--- a/build/Build.Common.ps1
+++ b/build/Build.Common.ps1
@@ -3,14 +3,12 @@ function Get-SemVer()
     $branch = @{ $true = $env:CI_TARGET_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$NULL -ne $env:CI_TARGET_BRANCH];
     $revision = @{ $true = "{0:00000}" -f $([convert]::ToInt32($env:CI_BUILD_NUMBER_BASE, 10) + 2300); $false = "local" }[$NULL -ne $env:CI_BUILD_NUMBER_BASE]
     $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)) -replace '([^a-zA-Z0-9\-]*)', '')-$revision"}[$branch -eq "main" -and $revision -ne "local"]
-    $commitHash = $(git rev-parse --short HEAD)
-    $buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
     $base = $(Get-Content ./baseversion).Trim()
 
     if ($suffix) {
         $base + "." + $revision + "-" + $suffix
     } else {
-        $revision
+        $base + "." + $revision
     }
 }

--- a/build/Build.Linux.ps1
+++ b/build/Build.Linux.ps1
@@ -2,7 +2,13 @@ Push-Location $PSScriptRoot/../
 
 . ./build/Build.Common.ps1
 
+Write-Host "Run Number: $env:CI_BUILD_NUMBER_BASE"
+Write-Host "Target Branch: $env:CI_TARGET_BRANCH"
+Write-Host "Published: $env:CI_PUBLISH"
+
 $version = Get-SemVer
+
+Write-Output "Building version $version"
 
 $framework = "net9.0"
 $image = "datalust/seqcli"


### PR DESCRIPTION
Follow-up to #390 

This PR fixes up a few issues that came out of the original port to GitHub Actions:

1. We compute the wrong version number when the branch is `main`.
2. We publish releases on pushes to both `dev` and `main`, instead of just `main`.