### PR TITLE
Fall back to paged searching automatically when WebSockets are not supported

### DIFF
--- a/seqcli.sln
+++ b/seqcli.sln
@@ -8,14 +8,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sln", "sln", "{2EA56595-519F-4DD5-9E94-CCC43E3DF624}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
-		appveyor.yml = appveyor.yml
-		Build.ps1 = Build.ps1
 		LICENSE = LICENSE
 		README.md = README.md
-		setup.sh = setup.sh
-		Build.Docker.ps1 = Build.Docker.ps1
-		docker-publish.ps1 = docker-publish.ps1
-		Setup.ps1 = Setup.ps1
 		CONTRIBUTING.md = CONTRIBUTING.md
 		ci.global.json = ci.global.json
 	EndProjectSection

--- a/src/SeqCli/Cli/Features/OutputFormatFeature.cs
+++ b/src/SeqCli/Cli/Features/OutputFormatFeature.cs
@@ -35,9 +35,9 @@ class OutputFormatFeature : CommandFeature
     public const string DefaultOutputTemplate =
         "[{Timestamp:o} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}";
 
-    public static readonly ConsoleTheme DefaultTheme     = SystemConsoleTheme.Literate;
     public static readonly ConsoleTheme DefaultAnsiTheme = AnsiConsoleTheme.Code;
-    static readonly TemplateTheme DefaultTemplateTheme = TemplateTheme.Literate;
+    public static readonly ConsoleTheme DefaultTheme     = OperatingSystem.IsWindows() ? SystemConsoleTheme.Literate : DefaultAnsiTheme;
+    static readonly TemplateTheme DefaultTemplateTheme = TemplateTheme.Code;
 
     bool _json, _noColor, _forceColor;
 


### PR DESCRIPTION
This widens `search` command compatibility with older Seq versions.