### PR TITLE
feat: Add environment variable SEQCLI_CONFIG_FILE for custom config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ seqcli config -k connection.serverUrl -v https://your-seq-server
 seqcli config -k connection.apiKey -v your-api-key
 ```
 
-The API key will be stored in your `SeqCli.json` configuration file; on Windows, this is encrypted using DPAPI; on Mac/Linux the key is currently stored in plain text. As an alternative to storing the API key in configuration, it can be passed to each command via the `--apikey=` argument.
+The API key will be stored in your `SeqCli.json` (or `SEQCLI_CONFIG_FILE`) configuration file; on Windows, this is encrypted using DPAPI; on Mac/Linux the key is currently stored in plain text. As an alternative to storing the API key in configuration, it can be passed to each command via the `--apikey=` argument.
 
 `seqcli` is also available as a Docker container under [`datalust/seqcli`](https://store.docker.com/community/images/datalust/seqcli):
 
@@ -113,7 +113,7 @@ seqcli help apikey
   - [`appinstance remove`](#appinstance-remove) &mdash; Remove an app instance from the server.
   - [`appinstance update`](#appinstance-update) &mdash; Update an existing app instance.
 - [`bench`](#bench) &mdash; Measure query performance.
-- [`config`](#config) &mdash; View and set fields in the `SeqCli.json` file; run with no arguments to list all fields.
+- [`config`](#config) &mdash; View and set fields in the `SeqCli.json` (or `SEQCLI_CONFIG_PATH`) file; run with no arguments to list all fields.
 - `dashboard`
   - [`dashboard list`](#dashboard-list) &mdash; List dashboards.
   - [`dashboard remove`](#dashboard-remove) &mdash; Remove a dashboard from the server.
@@ -491,7 +491,7 @@ Measure query performance.
 
 ### `config`
 
-View and set fields in the `SeqCli.json` file; run with no arguments to list all fields.
+View and set fields in the default `SeqCli.json` or environment-specified `SEQCLI_CONFIG_FILE` file; run with no arguments to list all fields.
 
 | Option | Description |
 | ------ | ----------- |

--- a/src/SeqCli/Cli/Commands/ConfigCommand.cs
+++ b/src/SeqCli/Cli/Commands/ConfigCommand.cs
@@ -25,7 +25,7 @@ using Serilog;
 
 namespace SeqCli.Cli.Commands;
 
-[Command("config", "View and set fields in the `SeqCli.json` file; run with no arguments to list all fields")]
+[Command("config", "View and set fields in the default `SeqCli.json` or environment-specified `SEQCLI_CONFIG_FILE` file; run with no arguments to list all fields")]
 class ConfigCommand : Command
 {
     string? _key, _value;
@@ -44,7 +44,7 @@ class ConfigCommand : Command
             
         try
         {
-            var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.DefaultConfigFilename);
+            var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.SeqCliConfigFilename());
             
             if (_key != null)
             {
@@ -52,13 +52,13 @@ class ConfigCommand : Command
                 {
                     verb = "clear";
                     KeyValueSettings.Clear(config, _key);
-                    SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.DefaultConfigFilename);
+                    SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.SeqCliConfigFilename());
                 }
                 else if (_value != null)
                 {
                     verb = "update";
                     KeyValueSettings.Set(config, _key, _value);
-                    SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.DefaultConfigFilename);
+                    SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.SeqCliConfigFilename());
                 }
                 else
                 {

--- a/src/SeqCli/Cli/Commands/Profile/CreateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Profile/CreateCommand.cs
@@ -48,9 +48,9 @@ class CreateCommand : Command
             
         try
         {
-            var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.DefaultConfigFilename);
+            var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.SeqCliConfigFilename());
             config.Profiles[_name] = new SeqCliConnectionConfig { ServerUrl = _url, ApiKey = _apiKey };
-            SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.DefaultConfigFilename);
+            SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.SeqCliConfigFilename());
             return 0;
         }
         catch (Exception ex)

--- a/src/SeqCli/Cli/Commands/Profile/RemoveCommand.cs
+++ b/src/SeqCli/Cli/Commands/Profile/RemoveCommand.cs
@@ -34,14 +34,14 @@ class RemoveCommand : Command
 
         try
         {
-            var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.DefaultConfigFilename);
+            var config = SeqCliConfig.ReadFromFile(RuntimeConfigurationLoader.SeqCliConfigFilename());
             if (!config.Profiles.Remove(_name))
             {
                 Log.Error("No profile with name {ProfileName} was found", _name);
                 return 1;
             }
 
-            SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.DefaultConfigFilename);
+            SeqCliConfig.WriteToFile(config, RuntimeConfigurationLoader.SeqCliConfigFilename());
 
             return 0;
         }

--- a/src/SeqCli/Config/RuntimeConfigurationLoader.cs
+++ b/src/SeqCli/Config/RuntimeConfigurationLoader.cs
@@ -23,17 +23,28 @@ static class RuntimeConfigurationLoader
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "SeqCli.json");
 
     const string DefaultEnvironmentVariablePrefix = "SEQCLI_";
-    
+
     /// <summary>
     /// This is the method to use when loading configuration for runtime use. It will read the default configuration
     /// file, if any, and apply overrides from the environment.
     /// </summary>
     public static SeqCliConfig Load()
     {
-        var config = SeqCliConfig.ReadFromFile(DefaultConfigFilename);
-        
+        var config = SeqCliConfig.ReadFromFile(SeqCliConfigFilename());
+
         EnvironmentOverrides.Apply(DefaultEnvironmentVariablePrefix, config);
-            
+
         return config;
-    }    
+    }
+
+    public static string SeqCliConfigFilename()
+    {
+        var customConfigFilename = Environment.GetEnvironmentVariable("SEQCLI_CONFIG_FILE");
+        if (File.Exists(customConfigFilename))
+        {
+            return customConfigFilename;
+        }
+
+        return DefaultConfigFilename;
+    }
 }

--- a/test/SeqCli.Tests/Config/ConfigFileLocationTests.cs
+++ b/test/SeqCli.Tests/Config/ConfigFileLocationTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using SeqCli.Config;
+using Xunit;
+
+namespace SeqCli.Tests.Config;
+
+public class ConfigFileLocationTests
+{
+    [Fact]
+    public void DefaultConfigFilename()
+    {
+        var configFile = RuntimeConfigurationLoader.SeqCliConfigFilename();
+
+        Assert.Equal(configFile, RuntimeConfigurationLoader.DefaultConfigFilename);
+    }
+
+    [Fact]
+    public void EnvironmentOverridenConfigFilename()
+    {
+        var tempConfigFile = Path.GetTempFileName();
+        Environment.SetEnvironmentVariable("SEQCLI_CONFIG_FILE", tempConfigFile);
+        var configFile = RuntimeConfigurationLoader.SeqCliConfigFilename();
+        // Clean up immediately to avoid affecting environment for other tests
+        // TODO: Or better move to public void Dispose() ?
+        Environment.SetEnvironmentVariable("SEQCLI_CONFIG_FILE", null);
+
+        Assert.Equal(tempConfigFile, configFile);
+    }
+}


### PR DESCRIPTION
This allows users to specify custom location of config file.

For example

  SEQCLI_CONFIG_PATH=~/.config/seq/config.json
  seqcli config
  seqcli apikey list

Closes #399

Signed-off-by: Mateusz Łoskot <mateusz@loskot.net>
