### PR TITLE
Tidy up `ForwardingChannel` shut-down logic

### DIFF
--- a/seqcli.sln.DotSettings
+++ b/seqcli.sln.DotSettings
@@ -34,9 +34,11 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=STORAGEPATH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subcommand/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=syslogdt/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=tcpip/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tokenizes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=trailingindent/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unawaited/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unclosable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=urlacl/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=winmgmt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=xmpweb/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/seqcli.sln.DotSettings
+++ b/seqcli.sln.DotSettings
@@ -38,4 +38,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=trailingindent/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unawaited/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unclosable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=urlacl/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=xmpweb/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
@@ -101,7 +101,7 @@ class InstallCommand : Command
         if (netshResult != 0)
             Console.WriteLine($"Could not add URL reservation for {listenUri}: `netsh` returned {netshResult}; ignoring");
 
-        var exePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, Program.BinaryName);
+        var exePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Program.BinaryName);
         var forwarderRunCmdline = $"\"{exePath}\" forwarder run --pre --storage=\"{_storagePath.StorageRootPath}\"";
 
         var binPath = forwarderRunCmdline.Replace("\"", "\\\"");
@@ -117,7 +117,7 @@ class InstallCommand : Command
         var sc = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "sc.exe");
         if (0 != CaptiveProcess.Run(sc, scCmdline, Console.WriteLine, Console.WriteLine))
         {
-            throw new ArgumentException("Service setup failed");
+            throw new ArgumentException("Service setup failed.");
         }
 
         Console.WriteLine("Setting service restart policy...");
@@ -132,8 +132,6 @@ class InstallCommand : Command
 
     void GiveFullControl(string target)
     {
-        if (target == null) throw new ArgumentNullException(nameof(target));
-
         if (!Directory.Exists(target))
             Directory.CreateDirectory(target);
 
@@ -147,7 +145,7 @@ class InstallCommand : Command
     static string MakeListenUriReservationPattern(string uri)
     {
         var listenUri = uri.Replace("localhost", "+");
-        if (!listenUri.EndsWith("/"))
+        if (!listenUri.EndsWith('/'))
             listenUri += "/";
         return listenUri;
     }

--- a/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
@@ -17,9 +17,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Security.AccessControl;
-using System.ServiceProcess;
 using System.Threading.Tasks;
 using SeqCli.Cli.Features;
 using SeqCli.Config;
@@ -29,234 +27,129 @@ using SeqCli.Forwarder.Util;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 
-namespace SeqCli.Cli.Commands.Forwarder
+namespace SeqCli.Cli.Commands.Forwarder;
+
+[Command("forwarder", "install", "Install the forwarder as a Windows service", IsPreview = true)]
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+class InstallCommand : Command
 {
-    [Command("forwarder", "install", "Install the forwarder as a Windows service", IsPreview = true)]
-    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
-    class InstallCommand : Command
+    readonly StoragePathFeature _storagePath;
+    readonly ServiceCredentialsFeature _serviceCredentials;
+    readonly ListenUriFeature _listenUri;
+
+    public InstallCommand()
     {
-        readonly StoragePathFeature _storagePath;
-        readonly ServiceCredentialsFeature _serviceCredentials;
-        readonly ListenUriFeature _listenUri;
+        _storagePath = Enable<StoragePathFeature>();
+        _listenUri = Enable<ListenUriFeature>();
+        _serviceCredentials = Enable<ServiceCredentialsFeature>();
+    }
+
+    string ServiceUsername => _serviceCredentials.IsUsernameSpecified ? _serviceCredentials.Username : "NT AUTHORITY\\LocalService";
+
+    protected override Task<int> Run()
+    {
+        try
+        {
+            Install();
+            return Task.FromResult(0);
+        }
+        catch (DirectoryNotFoundException dex)
+        {
+            Console.WriteLine("Could not install the service, directory not found: " + dex.Message);
+            return Task.FromResult(-1);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Could not install the service: " + ex.Message);
+            return Task.FromResult(-1);
+        }
+    }
+
+    void Install()
+    {
+        Console.WriteLine("Installing service...");
+
+        Console.WriteLine($"Updating the configuration in {_storagePath.ConfigFilePath}...");
+        var config = SeqCliConfig.ReadFromFile(_storagePath.ConfigFilePath);
         
-        bool _setup;
-
-        public InstallCommand()
+        if (!string.IsNullOrEmpty(_listenUri.ListenUri))
         {
-            _storagePath = Enable<StoragePathFeature>();
-            _listenUri = Enable<ListenUriFeature>();
-            _serviceCredentials = Enable<ServiceCredentialsFeature>();
-
-            Options.Add(
-                "setup",
-                "Install and start the service only if it does not exist; otherwise reconfigure the binary location",
-                _ => _setup = true);
+            config.Forwarder.Api.ListenUri = _listenUri.ListenUri;
+            SeqCliConfig.WriteToFile(config, _storagePath.ConfigFilePath);
         }
 
-        string ServiceUsername => _serviceCredentials.IsUsernameSpecified ? _serviceCredentials.Username : "NT AUTHORITY\\LocalService";
-
-        protected override Task<int> Run()
+        if (_serviceCredentials.IsUsernameSpecified)
         {
-            try
-            {
-                if (!_setup)
-                {
-                    Install();
-                    return Task.FromResult(0);
-                }
+            if (!_serviceCredentials.IsPasswordSpecified)
+                throw new ArgumentException(
+                    "If a service user account is specified, a password for the account must also be specified.");
 
-                var exit = Setup();
-                if (exit == 0)
-                {
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine("Setup completed successfully.");
-                    Console.ResetColor();
-                }
-                return Task.FromResult(exit);
-            }
-            catch (DirectoryNotFoundException dex)
-            {
-                Console.WriteLine("Could not install the service, directory not found: " + dex.Message);
-                return Task.FromResult(-1);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("Could not install the service: " + ex.Message);
-                return Task.FromResult(-1);
-            }
-        }
-        
-        int Setup()
-        {
-            ServiceController controller;
-            try
-            {
-                Console.WriteLine($"Checking the status of the {SeqCliForwarderWindowsService.WindowsServiceName} service...");
-
-                controller = new ServiceController(SeqCliForwarderWindowsService.WindowsServiceName);
-                Console.WriteLine("Status is {0}", controller.Status);
-            }
-            catch (InvalidOperationException)
-            {
-                Install();
-                var controller2 = new ServiceController(SeqCliForwarderWindowsService.WindowsServiceName);
-                return Start(controller2);
-            }
-
-            Console.WriteLine("Service is installed; checking path and dependency configuration...");
-            Reconfigure(controller);
-
-            return controller.Status != ServiceControllerStatus.Running ? Start(controller) : 0;
+            // https://technet.microsoft.com/en-us/library/cc794944(v=ws.10).aspx
+            Console.WriteLine($"Ensuring {_serviceCredentials.Username} is granted 'Log on as a Service' rights...");
+            AccountRightsHelper.EnsureServiceLogOnRights(_serviceCredentials.Username);
         }
 
-        static void Reconfigure(ServiceController controller)
+        Console.WriteLine($"Granting {ServiceUsername} rights to {_storagePath.StorageRootPath}...");
+        GiveFullControl(_storagePath.StorageRootPath);
+
+        Console.WriteLine($"Granting {ServiceUsername} rights to {_storagePath.InternalLogPath}...");
+        GiveFullControl(_storagePath.InternalLogPath);
+
+        var listenUri = MakeListenUriReservationPattern(config.Forwarder.Api.ListenUri);
+        Console.WriteLine($"Adding URL reservation at {listenUri} for {ServiceUsername}...");
+        var netshResult = CaptiveProcess.Run("netsh", $"http add urlacl url={listenUri} user=\"{ServiceUsername}\"", Console.WriteLine, Console.WriteLine);
+        if (netshResult != 0)
+            Console.WriteLine($"Could not add URL reservation for {listenUri}: `netsh` returned {netshResult}; ignoring");
+
+        var exePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, Program.BinaryName);
+        var forwarderRunCmdline = $"\"{exePath}\" forwarder run --pre --storage=\"{_storagePath.StorageRootPath}\"";
+
+        var binPath = forwarderRunCmdline.Replace("\"", "\\\"");
+
+        var scCmdline = "create \"" + SeqCliForwarderWindowsService.WindowsServiceName + "\"" +
+                        " binPath= \"" + binPath + "\"" +
+                        " start= auto" +
+                        " depend= Winmgmt/Tcpip/CryptSvc";
+
+        if (_serviceCredentials.IsUsernameSpecified)
+            scCmdline += $" obj= {_serviceCredentials.Username} password= {_serviceCredentials.Password}";
+
+        var sc = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "sc.exe");
+        if (0 != CaptiveProcess.Run(sc, scCmdline, Console.WriteLine, Console.WriteLine))
         {
-            var sc = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "sc.exe");
-            if (0 != CaptiveProcess.Run(sc, "config \"" + controller.ServiceName + "\" depend= Winmgmt/Tcpip/CryptSvc", Console.WriteLine, Console.WriteLine))
-                Console.WriteLine("Could not reconfigure service dependencies; ignoring.");
-
-            if (!ServiceConfiguration.GetServiceBinaryPath(controller, out var path))
-                return;
-
-            var current = "\"" + Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Program.BinaryName) + "\"";
-            if (path.StartsWith(current))
-                return;
-
-            var seqRun = path.IndexOf(Program.BinaryName + "\" run", StringComparison.OrdinalIgnoreCase);
-            if (seqRun == -1)
-            {
-                Console.WriteLine("Current binary path is an unrecognized format.");
-                return;
-            }
-
-            Console.WriteLine("Existing service binary path is: {0}", path);
-
-            var trimmed = path.Substring((seqRun + Program.BinaryName + " ").Length);
-            var newPath = current + trimmed;
-            Console.WriteLine("Updating service binary path configuration to: {0}", newPath);
-
-            var escaped = newPath.Replace("\"", "\\\"");
-            if (0 != CaptiveProcess.Run(sc, "config \"" + controller.ServiceName + "\" binPath= \"" + escaped + "\"", Console.WriteLine, Console.WriteLine))
-            {
-                Console.WriteLine("Could not reconfigure service path; ignoring.");
-                return;
-            }
-
-            Console.WriteLine("Service binary path reconfigured successfully.");
+            throw new ArgumentException("Service setup failed");
         }
 
-        static int Start(ServiceController controller)
-        {
-            controller.Start();
+        Console.WriteLine("Setting service restart policy...");
+        if (0 != CaptiveProcess.Run(sc, $"failure \"{SeqCliForwarderWindowsService.WindowsServiceName}\" actions= restart/60000/restart/60000/restart/60000// reset= 600000", Console.WriteLine, Console.WriteLine))
+            Console.WriteLine("Could not set service restart policy; ignoring");
+        Console.WriteLine("Setting service description...");
+        if (0 != CaptiveProcess.Run(sc, $"description \"{SeqCliForwarderWindowsService.WindowsServiceName}\" \"Durable storage and forwarding of application log events\"", Console.WriteLine, Console.WriteLine))
+            Console.WriteLine("Could not set service description; ignoring");
 
-            if (controller.Status != ServiceControllerStatus.Running)
-            {
-                Console.WriteLine("Waiting up to 60 seconds for the service to start (currently: " + controller.Status + ")...");
-                controller.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(60));
-            }
+        Console.WriteLine("Service installed successfully.");
+    }
 
-            if (controller.Status == ServiceControllerStatus.Running)
-            {
-                Console.WriteLine("Started.");
-                return 0;
-            }
+    void GiveFullControl(string target)
+    {
+        if (target == null) throw new ArgumentNullException(nameof(target));
 
-            Console.WriteLine("The service hasn't started successfully.");
-            return -1;
-        }
+        if (!Directory.Exists(target))
+            Directory.CreateDirectory(target);
 
-        [DllImport("shlwapi.dll")]
-        static extern bool PathIsNetworkPath(string pszPath);
+        var storageInfo = new DirectoryInfo(target);
+        var storageAccessControl = storageInfo.GetAccessControl();
+        storageAccessControl.AddAccessRule(new FileSystemAccessRule(ServiceUsername,
+            FileSystemRights.FullControl, AccessControlType.Allow));
+        storageInfo.SetAccessControl(storageAccessControl);
+    }
 
-        void Install()
-        {
-            Console.WriteLine("Installing service...");
-
-            if (PathIsNetworkPath(_storagePath.StorageRootPath))
-                throw new ArgumentException("Seq requires a local (or SAN) storage location; network shares are not supported.");
-
-            Console.WriteLine($"Updating the configuration in {_storagePath.ConfigFilePath}...");
-            var config = SeqCliConfig.ReadFromFile(_storagePath.ConfigFilePath);
-            
-            if (!string.IsNullOrEmpty(_listenUri.ListenUri))
-            {
-                config.Forwarder.Api.ListenUri = _listenUri.ListenUri;
-                SeqCliConfig.WriteToFile(config, _storagePath.ConfigFilePath);
-            }
-
-            if (_serviceCredentials.IsUsernameSpecified)
-            {
-                if (!_serviceCredentials.IsPasswordSpecified)
-                    throw new ArgumentException(
-                        "If a service user account is specified, a password for the account must also be specified.");
-
-                // https://technet.microsoft.com/en-us/library/cc794944(v=ws.10).aspx
-                Console.WriteLine($"Ensuring {_serviceCredentials.Username} is granted 'Log on as a Service' rights...");
-                AccountRightsHelper.EnsureServiceLogOnRights(_serviceCredentials.Username);
-            }
-
-            Console.WriteLine($"Granting {ServiceUsername} rights to {_storagePath.StorageRootPath}...");
-            GiveFullControl(_storagePath.StorageRootPath);
-
-            Console.WriteLine($"Granting {ServiceUsername} rights to {_storagePath.InternalLogPath}...");
-            GiveFullControl(_storagePath.InternalLogPath);
-
-            var listenUri = MakeListenUriReservationPattern(config.Forwarder.Api.ListenUri);
-            Console.WriteLine($"Adding URL reservation at {listenUri} for {ServiceUsername}...");
-            var netshResult = CaptiveProcess.Run("netsh", $"http add urlacl url={listenUri} user=\"{ServiceUsername}\"", Console.WriteLine, Console.WriteLine);
-            if (netshResult != 0)
-                Console.WriteLine($"Could not add URL reservation for {listenUri}: `netsh` returned {netshResult}; ignoring");
-
-            var exePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory!, Program.BinaryName);
-            var forwarderRunCmdline = $"\"{exePath}\" run --storage=\"{_storagePath.StorageRootPath}\"";
-
-            var binPath = forwarderRunCmdline.Replace("\"", "\\\"");
-
-            var scCmdline = "create \"" + SeqCliForwarderWindowsService.WindowsServiceName + "\"" +
-                            " binPath= \"" + binPath + "\"" +
-                            " start= auto" +
-                            " depend= Winmgmt/Tcpip/CryptSvc";
-
-            if (_serviceCredentials.IsUsernameSpecified)
-                scCmdline += $" obj= {_serviceCredentials.Username} password= {_serviceCredentials.Password}";
-
-            var sc = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "sc.exe");
-            if (0 != CaptiveProcess.Run(sc, scCmdline, Console.WriteLine, Console.WriteLine))
-            {
-                throw new ArgumentException("Service setup failed");
-            }
-
-            Console.WriteLine("Setting service restart policy...");
-            if (0 != CaptiveProcess.Run(sc, $"failure \"{SeqCliForwarderWindowsService.WindowsServiceName}\" actions= restart/60000/restart/60000/restart/60000// reset= 600000", Console.WriteLine, Console.WriteLine))
-                Console.WriteLine("Could not set service restart policy; ignoring");
-            Console.WriteLine("Setting service description...");
-            if (0 != CaptiveProcess.Run(sc, $"description \"{SeqCliForwarderWindowsService.WindowsServiceName}\" \"Durable storage and forwarding of application log events\"", Console.WriteLine, Console.WriteLine))
-                Console.WriteLine("Could not set service description; ignoring");
-
-            Console.WriteLine("Service installed successfully.");
-        }
-
-        void GiveFullControl(string target)
-        {
-            if (target == null) throw new ArgumentNullException(nameof(target));
-
-            if (!Directory.Exists(target))
-                Directory.CreateDirectory(target);
-
-            var storageInfo = new DirectoryInfo(target);
-            var storageAccessControl = storageInfo.GetAccessControl();
-            storageAccessControl.AddAccessRule(new FileSystemAccessRule(ServiceUsername,
-                FileSystemRights.FullControl, AccessControlType.Allow));
-            storageInfo.SetAccessControl(storageAccessControl);
-        }
-
-        static string MakeListenUriReservationPattern(string uri)
-        {
-            var listenUri = uri.Replace("localhost", "+");
-            if (!listenUri.EndsWith("/"))
-                listenUri += "/";
-            return listenUri;
-        }
+    static string MakeListenUriReservationPattern(string uri)
+    {
+        var listenUri = uri.Replace("localhost", "+");
+        if (!listenUri.EndsWith("/"))
+            listenUri += "/";
+        return listenUri;
     }
 }
 

--- a/src/SeqCli/Forwarder/Channel/ForwardingChannel.cs
+++ b/src/SeqCli/Forwarder/Channel/ForwardingChannel.cs
@@ -51,7 +51,9 @@ class ForwardingChannel
                 reader.AdvanceTo(bookmarkValue.Value);
             }
             
-            while (true)
+            // Stopping shipping is a priority during shut-down, the work represented by the persistent buffer is unbounded
+            // so leaving it un-shipped avoids messier hard cancellation if we can't complete the work in time.
+            while (!_stop.IsCancellationRequested)
             {
                 if (_hardCancel.IsCancellationRequested) return;
 

--- a/src/SeqCli/Forwarder/Channel/ForwardingChannelMap.cs
+++ b/src/SeqCli/Forwarder/Channel/ForwardingChannelMap.cs
@@ -35,7 +35,7 @@ class ForwardingChannelMap
         
         var storePath = Path.Combine(_bufferPath, name);
         var store = new SystemStoreDirectory(storePath);
-        Log.Information("Opening local buffer in {StorePath}", storePath);
+        Log.ForContext<ForwardingChannelMap>().Information("Opening local buffer in {StorePath}", storePath);
         
         return new ForwardingChannel(
             BufferAppender.Open(store),
@@ -71,7 +71,7 @@ class ForwardingChannelMap
 
     public async Task StopAsync()
     {
-        Log.Information("Flushing log buffers");
+        Log.ForContext<ForwardingChannelMap>().Information("Flushing log buffers");
         
         _shutdownTokenSource.CancelAfter(TimeSpan.FromSeconds(30));
 

--- a/src/SeqCli/Forwarder/ForwarderModule.cs
+++ b/src/SeqCli/Forwarder/ForwarderModule.cs
@@ -23,7 +23,6 @@ using SeqCli.Forwarder.Web.Api;
 using SeqCli.Forwarder.Web.Host;
 using Serilog;
 using Serilog.Formatting;
-using Serilog.Formatting.Display;
 using Serilog.Templates;
 
 namespace SeqCli.Forwarder;
@@ -52,13 +51,13 @@ class ForwarderModule : Module
 
         if (_config.Forwarder.Diagnostics.ExposeIngestionLog)
         {
-            Log.Warning("Configured to expose ingestion log via HTTP API");
+            Log.ForContext<ForwarderModule>().Warning("Configured to expose ingestion log via HTTP API");
             builder.RegisterType<IngestionLogEndpoints>().As<IMapEndpoints>();
 
             var ingestionLogTemplate = "[{@t:o} {@l:u3}] {@m}\n";
             if (_config.Forwarder.Diagnostics.IngestionLogShowDetail)
             {
-                Log.Warning("Including full client, payload, and error detail in the ingestion log");
+                Log.ForContext<ForwarderModule>().Warning("Including full client, payload, and error detail in the ingestion log");
                 ingestionLogTemplate +=
                     "{#if ClientHostIP is not null}Client IP address: {ClientHostIP}\n{#end}" +
                     "{#if DocumentStart is not null}First {StartToLog} characters of payload: {DocumentStart:l}\n{#end}" +


### PR DESCRIPTION
Just a minor tweak to bail out of the shipper as early in the process as possible.

Spotted some holes in exception handling in the process. It would be nice now to extract some real functions for the `ForwardingChannel` pump tasks, but skipping for now to avoid conflicts.

Also spotted some holes in `forwarder install` and gave that a quick once-over on the way through :-)

Getting close to a usable preview forwarder now! 😁 ... Or, closer, anyway!