### PR TITLE
Switch `config` command to a command group, including `clear`, `get`, `set`, and `list` to match Seq's CLI

### DIFF
--- a/src/SeqCli/Cli/CommandAttribute.cs
+++ b/src/SeqCli/Cli/CommandAttribute.cs
@@ -23,12 +23,13 @@ public class CommandAttribute : Attribute, ICommandMetadata
     public string? SubCommand { get; }
     public string HelpText { get; }
     public string? Example { get; set; }
-    public bool IsPreview { get; set; }
+    public FeatureVisibility Visibility { get; set; }
 
     public CommandAttribute(string name, string helpText)
     {
         Name = name;
         HelpText = helpText;
+        Visibility = FeatureVisibility.Visible;
     }
 
     public CommandAttribute(string name, string subCommand, string helpText) : this(name, helpText)

--- a/src/SeqCli/Cli/CommandMetadata.cs
+++ b/src/SeqCli/Cli/CommandMetadata.cs
@@ -20,5 +20,5 @@ public class CommandMetadata : ICommandMetadata
     public string? SubCommand { get; set; }
     public required string HelpText { get; set; }
     public string? Example { get; set; }
-    public bool IsPreview { get; set; }
+    public FeatureVisibility Visibility { get; set; }
 }

--- a/src/SeqCli/Cli/Commands/Config/ClearCommand.cs
+++ b/src/SeqCli/Cli/Commands/Config/ClearCommand.cs
@@ -1,0 +1,43 @@
+﻿// Copyright © Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+
+// ReSharper disable once UnusedType.Global
+
+namespace SeqCli.Cli.Commands.Config;
+
+[Command("config", "clear", "Clear fields in the `SeqCli.json` file")]
+class ClearCommand : Command
+{
+    readonly StoragePathFeature _storagePath;
+    readonly ConfigKeyFeature _key;
+
+    public ClearCommand()
+    {
+        _storagePath = Enable<StoragePathFeature>();
+        _key = Enable<ConfigKeyFeature>();
+    }
+
+    protected override Task<int> Run()
+    {
+        var config = SeqCliConfig.ReadFromFile(_storagePath.ConfigFilePath);
+            
+        KeyValueSettings.Clear(config, _key.GetKey());
+        SeqCliConfig.WriteToFile(config, _storagePath.ConfigFilePath);
+        return Task.FromResult(0);
+    }
+}

--- a/src/SeqCli/Cli/Commands/Config/GetCommand.cs
+++ b/src/SeqCli/Cli/Commands/Config/GetCommand.cs
@@ -1,0 +1,45 @@
+﻿// Copyright © Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+
+// ReSharper disable once UnusedType.Global
+
+namespace SeqCli.Cli.Commands.Config;
+
+[Command("config", "get", "View a field from the `SeqCli.json` file")]
+class GetCommand : Command
+{
+    readonly StoragePathFeature _storagePath;
+    readonly ConfigKeyFeature _key;
+
+    public GetCommand()
+    {
+        _storagePath = Enable<StoragePathFeature>();
+        _key = Enable<ConfigKeyFeature>();
+    }
+
+    protected override Task<int> Run()
+    {
+        var config = SeqCliConfig.ReadFromFile(_storagePath.ConfigFilePath);
+        if (!KeyValueSettings.TryGetValue(config, _key.GetKey(), out var value, out _))
+            throw new ArgumentException($"Field `{_key.GetKey()}` not found.");
+        
+        Console.WriteLine(value);
+        return Task.FromResult(0);
+    }
+}

--- a/src/SeqCli/Cli/Commands/Config/LegacyCommand.cs
+++ b/src/SeqCli/Cli/Commands/Config/LegacyCommand.cs
@@ -19,16 +19,16 @@ using SeqCli.Config;
 using SeqCli.Util;
 using Serilog;
 
-namespace SeqCli.Cli.Commands;
+namespace SeqCli.Cli.Commands.Config;
 
-[Command("config", "View and set fields in `SeqCli.json`; run with no arguments to list all fields")]
-class ConfigCommand : Command
+[Command("config", "legacy", "View and set fields in `SeqCli.json`; run with no arguments to list all fields", Visibility = FeatureVisibility.Hidden)]
+class LegacyCommand : Command
 {
     string? _key, _value;
     bool _clear;
     readonly StoragePathFeature _storagePath;
 
-    public ConfigCommand()
+    public LegacyCommand()
     {
         Options.Add("k|key=", "The field, for example `connection.serverUrl`", k => _key = k);
         Options.Add("v|value=", "The field value; if not specified, the command will print the current value", v => _value = v);

--- a/src/SeqCli/Cli/Commands/Config/ListCommand.cs
+++ b/src/SeqCli/Cli/Commands/Config/ListCommand.cs
@@ -1,0 +1,43 @@
+﻿// Copyright © Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+
+// ReSharper disable once UnusedType.Global
+
+namespace SeqCli.Cli.Commands.Config;
+
+[Command("config", "list", "View all fields in the `SeqCli.json` file")]
+class ListCommand : Command
+{
+    readonly StoragePathFeature _storagePath;
+
+    public ListCommand()
+    {
+        _storagePath = Enable<StoragePathFeature>();
+    }
+
+    protected override Task<int> Run()
+    {
+        var config = SeqCliConfig.ReadFromFile(_storagePath.ConfigFilePath);
+        foreach (var (key, value, _) in KeyValueSettings.Inspect(config))
+        {
+            Console.WriteLine($"{key}={value}");
+        }
+        return Task.FromResult(0);
+    }
+}

--- a/src/SeqCli/Cli/Commands/Config/SetCommand.cs
+++ b/src/SeqCli/Cli/Commands/Config/SetCommand.cs
@@ -1,0 +1,48 @@
+﻿// Copyright © Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using Serilog;
+
+// ReSharper disable once UnusedType.Global
+
+namespace SeqCli.Cli.Commands.Config;
+
+[Command("config", "set", "Set a field in the `SeqCli.json` file")]
+class SetCommand : Command
+{
+    readonly StoragePathFeature _storagePath;
+    readonly ConfigKeyFeature _key;
+    readonly ConfigValueFeature _value;
+        
+    public SetCommand()
+    {
+        _storagePath = Enable<StoragePathFeature>();
+        _key = Enable<ConfigKeyFeature>();
+        _value = Enable<ConfigValueFeature>();
+    }
+
+    protected override Task<int> Run()
+    {
+        var config = SeqCliConfig.ReadFromFile(_storagePath.ConfigFilePath);
+            
+        KeyValueSettings.Set(config, _key.GetKey(), _value.ReadValue());
+        SeqCliConfig.WriteToFile(config, _storagePath.ConfigFilePath);
+        return Task.FromResult(0);
+    }
+}

--- a/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
@@ -31,7 +31,7 @@ using SeqCli.Forwarder.Util;
 
 namespace SeqCli.Cli.Commands.Forwarder
 {
-    [Command("forwarder", "install", "Install the forwarder as a Windows service", IsPreview = true)]
+    [Command("forwarder", "install", "Install the forwarder as a Windows service", Visibility = FeatureVisibility.Preview)]
     [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     class InstallCommand : Command
     {

--- a/src/SeqCli/Cli/Commands/Forwarder/RestartCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/RestartCommand.cs
@@ -24,7 +24,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "restart", "Restart the forwarder Windows service", IsPreview = true)]
+[Command("forwarder", "restart", "Restart the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class RestartCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/RunCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/RunCommand.cs
@@ -45,7 +45,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "run", "Listen on an HTTP endpoint and forward ingested logs to Seq", IsPreview = true)]
+[Command("forwarder", "run", "Listen on an HTTP endpoint and forward ingested logs to Seq", Visibility = FeatureVisibility.Preview)]
 class RunCommand : Command
 {
     readonly StoragePathFeature _storagePath;

--- a/src/SeqCli/Cli/Commands/Forwarder/StartCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StartCommand.cs
@@ -22,7 +22,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "start", "Start the forwarder Windows service", IsPreview = true)]
+[Command("forwarder", "start", "Start the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class StartCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/StatusCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StatusCommand.cs
@@ -22,7 +22,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "status", "Show the status of the forwarder Windows service", IsPreview = true)]
+[Command("forwarder", "status", "Show the status of the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class StatusCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/StopCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StopCommand.cs
@@ -22,7 +22,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "stop", "Stop the forwarder Windows service", IsPreview = true)]
+[Command("forwarder", "stop", "Stop the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class StopCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/TruncateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/TruncateCommand.cs
@@ -20,7 +20,7 @@ using Serilog;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "truncate", "Empty the forwarder's persistent log buffer", IsPreview = true)]
+[Command("forwarder", "truncate", "Empty the forwarder's persistent log buffer", Visibility = FeatureVisibility.Preview)]
 class TruncateCommand : Command
 {
     readonly StoragePathFeature _storagePath;

--- a/src/SeqCli/Cli/Commands/Forwarder/UninstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/UninstallCommand.cs
@@ -22,7 +22,7 @@ using SeqCli.Forwarder.Util;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "uninstall", "Uninstall the forwarder Windows service", IsPreview = true)]
+[Command("forwarder", "uninstall", "Uninstall the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
 class UninstallCommand : Command
 {
     protected override Task<int> Run()

--- a/src/SeqCli/Cli/FeatureVisibility.cs
+++ b/src/SeqCli/Cli/FeatureVisibility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Datalust Pty Ltd
+// Copyright © Datalust Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
+using System;
 
 namespace SeqCli.Cli;
 
-abstract class CommandFeature
+[Flags]
+public enum FeatureVisibility
 {
-    public abstract void Enable(OptionSet options);
-
-    public virtual IEnumerable<string> GetUsageErrors() => [];
+    None = 0,
+    Visible   = 1,
+    Preview   = 1 << 1,
+    Hidden    = 1 << 2
 }

--- a/src/SeqCli/Cli/Features/ConfigKeyFeature.cs
+++ b/src/SeqCli/Cli/Features/ConfigKeyFeature.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using SeqCli.Util;
+
+namespace SeqCli.Cli.Features;
+
+class ConfigKeyFeature: CommandFeature
+{
+    string? _key;
+    
+    public override void Enable(OptionSet options)
+    {
+        options.Add("k|key=", "The field, for example `connection.serverUrl`", k => _key = ArgumentString.Normalize(k));
+    }
+        
+    public string GetKey()
+    {
+        if (string.IsNullOrEmpty(_key))
+            throw new ArgumentException("A field must be supplied with `--key=KEY`.");
+
+        return _key;
+    }
+}

--- a/src/SeqCli/Cli/Features/ConfigValueFeature.cs
+++ b/src/SeqCli/Cli/Features/ConfigValueFeature.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace SeqCli.Cli.Features;
+
+class ConfigValueFeature: CommandFeature
+{
+    // An empty string is normalized to null/unset, which will normally be considered "cleared"; we allow this
+    // to keep the CLI backwards-compatible.
+    bool _valueSpecified;
+        
+    string? Value { get; set; }
+    bool ReadValueFromStdin { get; set; }
+
+    public override void Enable(OptionSet options)
+    {
+        options.Add("v|value=",
+            "The field value, comma-separated if multiple values are accepted",
+            v =>
+            {
+                _valueSpecified = true;
+                // Not normalized; some settings might include leading/trailing whitespace.
+                Value = v;
+            });
+
+        options.Add("value-stdin",
+            "Read the value from `STDIN`",
+            _ => ReadValueFromStdin = true);
+    }
+
+    public string? ReadValue()
+    {
+        if (!_valueSpecified && !ReadValueFromStdin)
+            throw new ArgumentException(
+                "A value must be supplied with either `--value=VALUE` or `--value-stdin`.");
+        
+        return ReadValueFromStdin ? Console.In.ReadToEnd().TrimEnd('\r', '\n') : Value;
+    }
+}

--- a/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
+++ b/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Autofac.Features.Metadata;
 using SeqCli.Cli;
-using SeqCli.Cli.Features;
 using SeqCli.Tests.Support;
 using Serilog.Core;
 using Serilog.Events;
@@ -41,7 +40,7 @@ public class CommandLineHostTests
         {
             new(
                 new Lazy<Command>(() => new ActionCommand(() => executed.Add("test"))),
-                new CommandMetadata {Name = "test", HelpText = "help", IsPreview = true}),
+                new CommandMetadata {Name = "test", HelpText = "help", Visibility = FeatureVisibility.Preview}),
         };
         var commandLineHost = new CommandLineHost(availableCommands);
         var exit = await commandLineHost.Run(["test"],new LoggingLevelSwitch());


### PR DESCRIPTION
Could definitely be a bit more elegant 😅 but this does at least remove the endlessly-annoying papercut typing `seqcli config <something>` expecting Seq's `config` subcommands to be available.