### PR TITLE
Fix read worker shut-down

### DIFF
--- a/src/SeqCli/Forwarder/Channel/ForwardingChannel.cs
+++ b/src/SeqCli/Forwarder/Channel/ForwardingChannel.cs
@@ -83,7 +83,7 @@ class ForwardingChannel
             }
         }, cancellationToken: hardCancel);
 
-        _readWorker = Task.Run<Task>(async () =>
+        _readWorker = Task.Run(async () =>
         {
             try
             {


### PR DESCRIPTION
Not sure why I was forcing a particular `Task.Run` overload, there, but it was the wrong one 😅 