### PR TITLE
Publish a platform-neutral .NET tool

### DIFF
--- a/build/Build.Windows.ps1
+++ b/build/Build.Windows.ps1
@@ -38,7 +38,7 @@ function Create-ArtifactDir
 
 function Publish-Archives($version)
 {
-    $rids = $([xml](Get-Content .\src\SeqCli\SeqCli.csproj)).Project.PropertyGroup.RuntimeIdentifiers[0].Split(';')
+    $rids = $([xml](Get-Content .\src\SeqCli\SeqCli.csproj)).Project.PropertyGroup.RuntimeIdentifiers.Split(';')
     foreach ($rid in $rids) {
         $tfm = $framework
 

--- a/build/Build.Windows.ps1
+++ b/build/Build.Windows.ps1
@@ -13,7 +13,6 @@ $version = Get-SemVer
 Write-Output "Building version $version"
 
 $framework = 'net9.0'
-$windowsTfmSuffix = '-windows'
 
 function Clean-Output
 {
@@ -28,7 +27,7 @@ function Restore-Packages
 
 function Execute-Tests($version)
 {
-    & dotnet test ./test/SeqCli.Tests/SeqCli.Tests.csproj -c Release --framework "$framework$windowsTfmSuffix" /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version
+    & dotnet test ./test/SeqCli.Tests/SeqCli.Tests.csproj -c Release --framework "$framework" /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version
     if($LASTEXITCODE -ne 0) { throw "Build failed" }
 }
 
@@ -42,9 +41,6 @@ function Publish-Archives($version)
     $rids = $([xml](Get-Content .\src\SeqCli\SeqCli.csproj)).Project.PropertyGroup.RuntimeIdentifiers[0].Split(';')
     foreach ($rid in $rids) {
         $tfm = $framework
-        if ($rid -eq "win-x64") {
-            $tfm = "$tfm$windowsTfmSuffix"
-        }
 
         & dotnet publish ./src/SeqCli/SeqCli.csproj -c Release -f $tfm -r $rid --self-contained /p:VersionPrefix=$version
         if($LASTEXITCODE -ne 0) { throw "Build failed" }

--- a/src/SeqCli/Cli/CommandAttribute.cs
+++ b/src/SeqCli/Cli/CommandAttribute.cs
@@ -24,12 +24,14 @@ public class CommandAttribute : Attribute, ICommandMetadata
     public string HelpText { get; }
     public string? Example { get; set; }
     public FeatureVisibility Visibility { get; set; }
+    public SupportedPlatforms Platforms { get; set; }
 
     public CommandAttribute(string name, string helpText)
     {
         Name = name;
         HelpText = helpText;
         Visibility = FeatureVisibility.Visible;
+        Platforms = SupportedPlatforms.All;
     }
 
     public CommandAttribute(string name, string subCommand, string helpText) : this(name, helpText)

--- a/src/SeqCli/Cli/CommandLineHost.cs
+++ b/src/SeqCli/Cli/CommandLineHost.cs
@@ -58,7 +58,7 @@ class CommandLineHost
             
             var currentPlatform = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? SupportedPlatforms.Windows
-                : SupportedPlatforms.Unix;
+                : SupportedPlatforms.Posix;
             
             var cmd = _availableCommands.SingleOrDefault(c =>
                 c.Metadata.Platforms.HasFlag(currentPlatform) && featureVisibility.HasFlag(c.Metadata.Visibility) &&

--- a/src/SeqCli/Cli/CommandLineHost.cs
+++ b/src/SeqCli/Cli/CommandLineHost.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Autofac.Features.Metadata;
 using Serilog.Core;
@@ -55,8 +56,12 @@ class CommandLineHost
             if (args.Any(a => a.Trim() is prereleaseArg))
                 featureVisibility |= FeatureVisibility.Preview;
             
+            var currentPlatform = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? SupportedPlatforms.Windows
+                : SupportedPlatforms.Unix;
+            
             var cmd = _availableCommands.SingleOrDefault(c =>
-                featureVisibility.HasFlag(c.Metadata.Visibility) &&
+                c.Metadata.Platforms.HasFlag(currentPlatform) && featureVisibility.HasFlag(c.Metadata.Visibility) &&
                 c.Metadata.Name == commandName &&
                 (c.Metadata.SubCommand == subCommandName || c.Metadata.SubCommand == null));
                 

--- a/src/SeqCli/Cli/CommandMetadata.cs
+++ b/src/SeqCli/Cli/CommandMetadata.cs
@@ -21,4 +21,5 @@ public class CommandMetadata : ICommandMetadata
     public required string HelpText { get; set; }
     public string? Example { get; set; }
     public FeatureVisibility Visibility { get; set; }
+    public SupportedPlatforms Platforms { get; set; }
 }

--- a/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Threading.Tasks;
 using SeqCli.Cli.Features;
@@ -27,7 +28,7 @@ namespace SeqCli.Cli.Commands.Forwarder;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 
-[Command("forwarder", "install", "Install the forwarder as a Windows service", Visibility = FeatureVisibility.Preview)]
+[Command("forwarder", "install", "Install the forwarder as a Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class InstallCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if WINDOWS
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -100,7 +98,7 @@ class InstallCommand : Command
         if (netshResult != 0)
             Console.WriteLine($"Could not add URL reservation for {listenUri}: `netsh` returned {netshResult}; ignoring");
 
-        var exePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Program.BinaryName);
+        var exePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Program.WindowsBinaryName);
         var forwarderRunCmdline = $"\"{exePath}\" forwarder run --pre --storage=\"{_storagePath.StorageRootPath}\"";
 
         var binPath = forwarderRunCmdline.Replace("\"", "\\\"");
@@ -149,5 +147,3 @@ class InstallCommand : Command
         return listenUri;
     }
 }
-
-#endif

--- a/src/SeqCli/Cli/Commands/Forwarder/RestartCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/RestartCommand.cs
@@ -22,7 +22,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "restart", "Restart the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
+[Command("forwarder", "restart", "Restart the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class RestartCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/RestartCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/RestartCommand.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if WINDOWS
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.ServiceProcess;
@@ -80,5 +78,3 @@ class RestartCommand : Command
         }
     }
 }
-
-#endif

--- a/src/SeqCli/Cli/Commands/Forwarder/StartCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StartCommand.cs
@@ -20,7 +20,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "start", "Start the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
+[Command("forwarder", "start", "Start the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class StartCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/StartCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StartCommand.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if WINDOWS
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.ServiceProcess;
@@ -64,5 +62,3 @@ class StartCommand : Command
         }
     }
 }
-
-#endif

--- a/src/SeqCli/Cli/Commands/Forwarder/StatusCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StatusCommand.cs
@@ -20,7 +20,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "status", "Show the status of the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
+[Command("forwarder", "status", "Show the status of the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class StatusCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/StatusCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StatusCommand.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if WINDOWS
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.ServiceProcess;
@@ -48,5 +46,3 @@ class StatusCommand : Command
         return Task.FromResult(1);
     }
 }
-
-#endif

--- a/src/SeqCli/Cli/Commands/Forwarder/StopCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StopCommand.cs
@@ -20,7 +20,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "stop", "Stop the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
+[Command("forwarder", "stop", "Stop the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class StopCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/StopCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StopCommand.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if WINDOWS
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.ServiceProcess;
@@ -65,5 +63,3 @@ class StopCommand : Command
         }
     }
 }
-
-#endif

--- a/src/SeqCli/Cli/Commands/Forwarder/UninstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/UninstallCommand.cs
@@ -20,7 +20,7 @@ using SeqCli.Forwarder.Util;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "uninstall", "Uninstall the forwarder Windows service", Visibility = FeatureVisibility.Preview)]
+[Command("forwarder", "uninstall", "Uninstall the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
 class UninstallCommand : Command
 {
     protected override Task<int> Run()

--- a/src/SeqCli/Cli/Commands/Forwarder/UninstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/UninstallCommand.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if WINDOWS
-
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -46,5 +44,3 @@ class UninstallCommand : Command
         }
     }
 }
-
-#endif

--- a/src/SeqCli/Cli/Commands/HelpCommand.cs
+++ b/src/SeqCli/Cli/Commands/HelpCommand.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Autofac.Features.Metadata;
 using CommandList = System.Collections.Generic.List<Autofac.Features.Metadata.Meta<System.Lazy<SeqCli.Cli.Command>, SeqCli.Cli.CommandMetadata>>;
@@ -25,10 +26,14 @@ namespace SeqCli.Cli.Commands;
 [Command("help", "Show information about available commands", Example = "seqcli help search")]
 class HelpCommand : Command
 {
+    readonly SupportedPlatforms _currentPlatform = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? SupportedPlatforms.Windows
+        : SupportedPlatforms.Unix;
+
     readonly IEnumerable<Meta<Lazy<Command>, CommandMetadata>> _allCommands;
     bool _markdown;
     FeatureVisibility _included = FeatureVisibility.Visible;
-
+    
     public HelpCommand(IEnumerable<Meta<Lazy<Command>, CommandMetadata>> allCommands)
     {
         _allCommands = allCommands.OrderBy(c => c.Metadata.Name).ToList();
@@ -38,12 +43,12 @@ class HelpCommand : Command
         Options.Add("m|markdown", "Generate markdown for use in documentation", _ => _markdown = true);
     }
 
-    IEnumerable<Meta<Lazy<Command>, CommandMetadata>> AvailableCommands() =>
-        _allCommands.Where(c => _included.HasFlag(c.Metadata.Visibility));
+    IEnumerable<Meta<Lazy<Command>, CommandMetadata>> AvailableCommands(SupportedPlatforms platform, FeatureVisibility visibility) =>
+        _allCommands.Where(c => (c.Metadata.Platforms & platform) != SupportedPlatforms.None && visibility.HasFlag(c.Metadata.Visibility));
 
     protected override Task<int> Run(string[] unrecognized)
     {
-        var orderedCommands = AvailableCommands()
+        var orderedCommands = (_markdown ? AvailableCommands(SupportedPlatforms.All, FeatureVisibility.Visible | FeatureVisibility.Preview) : AvailableCommands(_currentPlatform, _included))
             .OrderBy(c => c.Metadata.Name)
             .ThenBy(c => c.Metadata.SubCommand)
             .ToList();
@@ -142,6 +147,23 @@ class HelpCommand : Command
             else
                 Console.WriteLine($"### `{cmd.Metadata.Name}`");
             Console.WriteLine();
+            if (cmd.Metadata.Platforms != SupportedPlatforms.All ||
+                cmd.Metadata.Visibility == FeatureVisibility.Preview)
+            {
+                Console.Write(">");
+                if (cmd.Metadata.Visibility == FeatureVisibility.Preview)
+                {
+                    Console.Write(" Preview command: only available when the `--pre` command-line flag is specified.");
+                }
+
+                if (cmd.Metadata.Platforms != SupportedPlatforms.All)
+                {
+                    Console.Write($" This command is supported on **{cmd.Metadata.Platforms}** platforms only.");
+                }
+                Console.WriteLine();
+                Console.WriteLine();
+            }
+            
             Console.WriteLine(cmd.Metadata.HelpText + ".");
             Console.WriteLine();
 

--- a/src/SeqCli/Cli/Commands/HelpCommand.cs
+++ b/src/SeqCli/Cli/Commands/HelpCommand.cs
@@ -28,7 +28,7 @@ class HelpCommand : Command
 {
     readonly SupportedPlatforms _currentPlatform = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
         ? SupportedPlatforms.Windows
-        : SupportedPlatforms.Unix;
+        : SupportedPlatforms.Posix;
 
     readonly IEnumerable<Meta<Lazy<Command>, CommandMetadata>> _allCommands;
     bool _markdown;

--- a/src/SeqCli/Cli/Features/ServiceCredentialsFeature.cs
+++ b/src/SeqCli/Cli/Features/ServiceCredentialsFeature.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if WINDOWS
-
 using SeqCli.Cli;
 
 namespace SeqCli.Forwarder.Cli.Features
@@ -38,5 +36,3 @@ namespace SeqCli.Forwarder.Cli.Features
         }
     }
 }
-
-#endif

--- a/src/SeqCli/Cli/Features/StoragePathFeature.cs
+++ b/src/SeqCli/Cli/Features/StoragePathFeature.cs
@@ -1,9 +1,7 @@
 using System;
 using System.IO;
-
-#if WINDOWS
+using System.Runtime.InteropServices;
 using SeqCli.Forwarder.ServiceProcess;
-#endif
 
 namespace SeqCli.Cli.Features;
 
@@ -63,12 +61,13 @@ class StoragePathFeature : CommandFeature
 
     static string? TryQueryInstalledStorageRoot()
     {
-#if WINDOWS
-        if (Forwarder.Util.ServiceConfiguration.GetServiceStoragePath(
-            SeqCliForwarderWindowsService.WindowsServiceName, out var storage))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+            Forwarder.Util.ServiceConfiguration.GetServiceStoragePath(
+                SeqCliForwarderWindowsService.WindowsServiceName, out var storage))
+        {
             return storage;
-#endif
-            
+        }
+
         return null;
     }
 }

--- a/src/SeqCli/Cli/SupportedPlatforms.cs
+++ b/src/SeqCli/Cli/SupportedPlatforms.cs
@@ -7,6 +7,6 @@ public enum SupportedPlatforms
 {
     None,
     Windows,
-    Unix,
-    All = Windows | Unix
+    Posix,
+    All = Windows | Posix
 }

--- a/src/SeqCli/Cli/SupportedPlatforms.cs
+++ b/src/SeqCli/Cli/SupportedPlatforms.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace SeqCli.Cli;
+
+[Flags]
+public enum SupportedPlatforms
+{
+    None,
+    Windows,
+    Unix,
+    All = Windows | Unix
+}

--- a/src/SeqCli/Config/SeqCliEncryptionProviderConfig.cs
+++ b/src/SeqCli/Config/SeqCliEncryptionProviderConfig.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Runtime.InteropServices;
 using SeqCli.Encryptor;
 
 namespace SeqCli.Config;
@@ -38,10 +39,6 @@ class SeqCliEncryptionProviderConfig
             return new ExternalDataProtector(Encryptor, EncryptorArgs, Decryptor, DecryptorArgs);
         }
 
-#if WINDOWS
-        return new WindowsNativeDataProtector();
-#else
-        return new PlaintextDataProtector();
-#endif
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? new WindowsNativeDataProtector() : new PlaintextDataProtector();
     }
 }

--- a/src/SeqCli/Forwarder/Filesystem/System/SystemStoreDirectory.cs
+++ b/src/SeqCli/Forwarder/Filesystem/System/SystemStoreDirectory.cs
@@ -21,9 +21,7 @@ using System.Text;
 using SeqCli.Config;
 using Serilog;
 
-#if UNIX
 using SeqCli.Forwarder.Filesystem.System.Unix;
-#endif
 
 namespace SeqCli.Forwarder.Filesystem.System;
 
@@ -145,7 +143,8 @@ sealed class SystemStoreDirectory : StoreDirectory
 
     static void Dirsync(string directoryPath)
     {
-#if UNIX
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        
         var dir = Libc.open(directoryPath, 0);
         if (dir == -1) return;
 
@@ -155,6 +154,5 @@ sealed class SystemStoreDirectory : StoreDirectory
         Libc.fsync(dir);
         Libc.close(dir);
 #pragma warning restore CA1806
-#endif
     }
 }

--- a/src/SeqCli/Forwarder/Filesystem/System/Unix/Libc.cs
+++ b/src/SeqCli/Forwarder/Filesystem/System/Unix/Libc.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if UNIX
 using System.Runtime.InteropServices;
 
 namespace SeqCli.Forwarder.Filesystem.System.Unix;
@@ -28,4 +27,3 @@ static class Libc
     [DllImport("libc")]
     public static extern int fsync(int fd);
 }
-#endif

--- a/src/SeqCli/Forwarder/ServiceProcess/SeqCliForwarderWindowsService.cs
+++ b/src/SeqCli/Forwarder/ServiceProcess/SeqCliForwarderWindowsService.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if WINDOWS
-
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.ServiceProcess;
@@ -46,5 +44,3 @@ namespace SeqCli.Forwarder.ServiceProcess
         }
     }
 }
-
-#endif

--- a/src/SeqCli/Forwarder/Util/AccountRightsHelper.cs
+++ b/src/SeqCli/Forwarder/Util/AccountRightsHelper.cs
@@ -3,8 +3,6 @@
 // http://www.codeproject.com/Articles/4863/LSA-Functions-Privileges-and-Impersonation
 // Modified and reformatted.
 
-#if WINDOWS
-
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -189,5 +187,3 @@ namespace SeqCli.Forwarder.Util
         }
     }
 }
-
-#endif

--- a/src/SeqCli/Forwarder/Util/ExecutionEnvironment.cs
+++ b/src/SeqCli/Forwarder/Util/ExecutionEnvironment.cs
@@ -1,6 +1,4 @@
-﻿#if WINDOWS
-using SeqCli.Forwarder.Util;
-#endif
+﻿using System.Runtime.InteropServices;
 
 namespace SeqCli.Forwarder.Util;
 
@@ -12,12 +10,13 @@ static class ExecutionEnvironment
     {
         get
         {
-#if WINDOWS
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
                 var parent = WindowsProcess.GetParentProcess();
                 return parent?.ProcessName == "services";
-#else
+            }
+
             return false;
-#endif
         }
     }
 }

--- a/src/SeqCli/Forwarder/Util/ServiceConfiguration.cs
+++ b/src/SeqCli/Forwarder/Util/ServiceConfiguration.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if WINDOWS
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -107,6 +105,4 @@ namespace SeqCli.Forwarder.Util
         }
     }
 }
-
-#endif
 

--- a/src/SeqCli/Forwarder/Util/WindowsProcess.cs
+++ b/src/SeqCli/Forwarder/Util/WindowsProcess.cs
@@ -1,6 +1,4 @@
-﻿#if WINDOWS
-
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -47,5 +45,3 @@ namespace SeqCli.Forwarder.Util
         }
     }
 }
-
-#endif

--- a/src/SeqCli/PlainText/Framing/FrameReader.cs
+++ b/src/SeqCli/PlainText/Framing/FrameReader.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Superpower;
@@ -36,13 +37,11 @@ class FrameReader
         _frameStart = frameStart ?? throw new ArgumentNullException(nameof(frameStart));
         _trailingLineArrivalDeadline = trailingLineArrivalDeadline;
 
-#if WINDOWS
         // Somehow, PowerShell manages to send a UTF-8 BOM when piping a command's output to us
         // via STDIN, regardless of how we set Console.InputEncoding. This hackily skips the BOM,
         // while we all live in hope of some brighter future.
-        if (_source.Peek() == 65279)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _source.Peek() == 65279)
             _source.Read();
-#endif
     }
 
     public async Task<Frame> TryReadAsync()

--- a/src/SeqCli/Program.cs
+++ b/src/SeqCli/Program.cs
@@ -27,9 +27,7 @@ namespace SeqCli;
 
 class Program
 {
-#if WINDOWS
-    public const string BinaryName = "seqcli.exe";
-#endif   
+    public const string WindowsBinaryName = "seqcli.exe";
     
     static async Task<int> Main(string[] args)
     {

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -16,19 +16,11 @@
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
-    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
-    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsWindows Condition="'$(TargetFramework)' == 'net9.0-windows'">true</IsWindows>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsWindows)'=='true'">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsOSX)'=='true'">
-    <DefineConstants>$(DefineConstants);OSX</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsLinux)'=='true'">
-    <DefineConstants>$(DefineConstants);LINUX</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsWindows)'!='true'">
     <DefineConstants>$(DefineConstants);UNIX</DefineConstants>

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net9.0-windows</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>seqcli</AssemblyName>
     <ApplicationIcon>..\..\asset\SeqCli.ico</ApplicationIcon>
     <RuntimeIdentifiers>win-x64;linux-x64;linux-musl-x64;osx-x64;linux-arm64;linux-musl-arm64;osx-arm64</RuntimeIdentifiers>
@@ -17,13 +17,6 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsWindows Condition="'$(TargetFramework)' == 'net9.0-windows'">true</IsWindows>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsWindows)'=='true'">
-    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsWindows)'!='true'">
-    <DefineConstants>$(DefineConstants);UNIX</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="..\..\asset\SeqCli.ico" Link="SeqCli.ico" />

--- a/test/SeqCli.EndToEnd/Help/MarkdownHelpTestCase.cs
+++ b/test/SeqCli.EndToEnd/Help/MarkdownHelpTestCase.cs
@@ -24,8 +24,6 @@ public class MarkdownHelpTestCase : ICliTestCase
         var indexOfTemplateImport = markdown.IndexOf("### `template import`", StringComparison.Ordinal);
         Assert.NotEqual(indexOfTemplateExport, indexOfTemplateImport);
         Assert.True(indexOfTemplateExport < indexOfTemplateImport);
-        
-        Assert.DoesNotContain("### `forwarder run`", markdown);
 
         return Task.CompletedTask;
     }

--- a/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
+++ b/test/SeqCli.EndToEnd/SeqCli.EndToEnd.csproj
@@ -2,8 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">$(TargetFrameworks);net9.0-windows</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
+++ b/test/SeqCli.Tests/Cli/CommandLineHostTests.cs
@@ -21,10 +21,10 @@ public class CommandLineHostTests
         {
             new(
                 new Lazy<Command>(() => new ActionCommand(() => executed.Add("test"))),
-                new CommandMetadata {Name = "test", HelpText = "help"}),
+                new CommandMetadata {Name = "test", HelpText = "help", Platforms = SupportedPlatforms.All}),
             new(
                 new Lazy<Command>(() => new ActionCommand(() => executed.Add("test2"))),
-                new CommandMetadata {Name = "test2", HelpText = "help"})
+                new CommandMetadata {Name = "test2", HelpText = "help", Platforms = SupportedPlatforms.All})
         };
         var commandLineHost = new CommandLineHost(availableCommands);
         await commandLineHost.Run(["test"],new LoggingLevelSwitch());
@@ -40,7 +40,7 @@ public class CommandLineHostTests
         {
             new(
                 new Lazy<Command>(() => new ActionCommand(() => executed.Add("test"))),
-                new CommandMetadata {Name = "test", HelpText = "help", Visibility = FeatureVisibility.Preview}),
+                new CommandMetadata {Name = "test", HelpText = "help", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.All}),
         };
         var commandLineHost = new CommandLineHost(availableCommands);
         var exit = await commandLineHost.Run(["test"],new LoggingLevelSwitch());
@@ -61,10 +61,10 @@ public class CommandLineHostTests
             {
                 new(
                     new Lazy<Command>(() => new ActionCommand(() => executed.Add("test-subcommand1"))),
-                    new CommandMetadata {Name = "test", SubCommand = "subcommand1", HelpText = "help"}),
+                    new CommandMetadata {Name = "test", SubCommand = "subcommand1", HelpText = "help", Platforms = SupportedPlatforms.All}),
                 new(
                     new Lazy<Command>(() => new ActionCommand(() => executed.Add("test-subcommand2"))),
-                    new CommandMetadata {Name = "test", SubCommand = "subcommand2", HelpText = "help"})
+                    new CommandMetadata {Name = "test", SubCommand = "subcommand2", HelpText = "help", Platforms = SupportedPlatforms.All})
             };
         var commandLineHost = new CommandLineHost(availableCommands);
         await commandLineHost.Run(["test", "subcommand2"], new LoggingLevelSwitch());
@@ -82,7 +82,7 @@ public class CommandLineHostTests
             {
                 new(
                     new Lazy<Command>(() => new ActionCommand(() => { })),
-                    new CommandMetadata {Name = "test", HelpText = "help"})
+                    new CommandMetadata {Name = "test", HelpText = "help", Platforms = SupportedPlatforms.All})
             };
             
         var commandLineHost = new CommandLineHost(availableCommands);

--- a/test/SeqCli.Tests/Config/ExternalDataProtectorTests.cs
+++ b/test/SeqCli.Tests/Config/ExternalDataProtectorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using SeqCli.Encryptor;
 using SeqCli.Tests.Support;
@@ -17,10 +18,11 @@ public class ExternalDataProtectorTests
         Assert.Throws<Win32Exception>(() => protector.Encrypt(Some.Bytes(200)));
     }
 
-#if UNIX
     [Fact]
     public void IfEncryptorFailsEncryptThrows()
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        
         var protector = new ExternalDataProtector("bash", "-c \"exit 1\"", Some.String(), null);
         // May be `Exception` or `IOException`.
         Assert.ThrowsAny<Exception>(() => protector.Encrypt(Some.Bytes(200)));
@@ -29,6 +31,8 @@ public class ExternalDataProtectorTests
     [Fact]
     public void EncryptCallsEncryptor()
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        
         const string prefix = "123";
         
         var encoding = new UTF8Encoding(false);
@@ -47,6 +51,8 @@ public class ExternalDataProtectorTests
     [Fact]
     public void EncryptionRoundTrips()
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        
         const string echo = "bash";
         const string echoArgs = "-c \"cat -\"";
         var protector = new ExternalDataProtector(echo, echoArgs, echo, echoArgs);
@@ -54,5 +60,4 @@ public class ExternalDataProtectorTests
         var actual = protector.Decrypt(protector.Encrypt(expected));
         Assert.Equal(expected, actual);
     }
-#endif
 }

--- a/test/SeqCli.Tests/Config/SeqCliEncryptionProviderConfigTests.cs
+++ b/test/SeqCli.Tests/Config/SeqCliEncryptionProviderConfigTests.cs
@@ -8,27 +8,27 @@ namespace SeqCli.Tests.Config;
 
 public class SeqCliEncryptionProviderConfigTests
 {
-#if WINDOWS
     [Fact]
     public void DefaultDataProtectorOnWindowsIsDpapi()
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        
         Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
         
         var config = new SeqCliEncryptionProviderConfig();
         var provider = config.DataProtector();
         Assert.IsType<WindowsNativeDataProtector>(provider);
     }
-#else
+
     [Fact]
     public void DefaultDataProtectorOnUnixIsPlaintext()
     {
-        Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
         
         var config = new SeqCliEncryptionProviderConfig();
         var provider = config.DataProtector();
         Assert.IsType<PlaintextDataProtector>(provider);
     }
-#endif
 
     [Fact]
     public void SpecifyingEncryptorRequiresDecryptor()

--- a/test/SeqCli.Tests/SeqCli.Tests.csproj
+++ b/test/SeqCli.Tests/SeqCli.Tests.csproj
@@ -2,18 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0</TargetFrameworks>
     <TargetFrameworks Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">$(TargetFrameworks);net9.0-windows</TargetFrameworks>
-    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
-    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
-    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+    <IsWindows Condition="'$(TargetFramework)' == 'net9.0-windows'">true</IsWindows>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsWindows)'=='true'">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsOSX)'=='true'">
-    <DefineConstants>$(DefineConstants);OSX</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsLinux)'=='true'">
-    <DefineConstants>$(DefineConstants);LINUX</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsWindows)'!='true'">
     <DefineConstants>$(DefineConstants);UNIX</DefineConstants>

--- a/test/SeqCli.Tests/SeqCli.Tests.csproj
+++ b/test/SeqCli.Tests/SeqCli.Tests.csproj
@@ -1,14 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">$(TargetFrameworks);net9.0-windows</TargetFrameworks>
-    <IsWindows Condition="'$(TargetFramework)' == 'net9.0-windows'">true</IsWindows>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsWindows)'=='true'">
-    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsWindows)'!='true'">
-    <DefineConstants>$(DefineConstants);UNIX</DefineConstants>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />


### PR DESCRIPTION
We previously had to `#if` our way through the Windows services APIs, but it turns out that recent versions of these packages include (non-functional) platform-independent targets, so all of this cruft and complexity is gone :-) :tada: 