### PR TITLE
Run end-to-end tests on Windows

### DIFF
--- a/build/Build.Windows.ps1
+++ b/build/Build.Windows.ps1
@@ -31,6 +31,7 @@ function Execute-Tests($version)
     if($LASTEXITCODE -ne 0) { throw "Build failed" }
 
     choco install seq
+    $env:PATH="C:\Program Files\Seq;$env:PATH"
 
     cd ./test/SeqCli.EndToEnd/
     & dotnet run -f $framework

--- a/build/Build.Windows.ps1
+++ b/build/Build.Windows.ps1
@@ -29,10 +29,11 @@ function Execute-Tests($version)
 {
     & dotnet test ./test/SeqCli.Tests/SeqCli.Tests.csproj -c Release --framework "$framework" /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version
     if($LASTEXITCODE -ne 0) { throw "Build failed" }
-    
+
+    choco install seq
+
     cd ./test/SeqCli.EndToEnd/
-    docker pull datalust/seq:latest
-    & dotnet run -f $framework -- --docker-server
+    & dotnet run -f $framework
     if ($LASTEXITCODE -ne 0)
     { 
         cd ../..

--- a/build/Build.Windows.ps1
+++ b/build/Build.Windows.ps1
@@ -29,6 +29,16 @@ function Execute-Tests($version)
 {
     & dotnet test ./test/SeqCli.Tests/SeqCli.Tests.csproj -c Release --framework "$framework" /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version
     if($LASTEXITCODE -ne 0) { throw "Build failed" }
+    
+    cd ./test/SeqCli.EndToEnd/
+    docker pull datalust/seq:latest
+    & dotnet run -f $framework -- --docker-server
+    if ($LASTEXITCODE -ne 0)
+    { 
+        cd ../..
+        exit 1 
+    }
+    cd ../..
 }
 
 function Create-ArtifactDir

--- a/src/SeqCli/Forwarder/Util/CaptiveProcess.cs
+++ b/src/SeqCli/Forwarder/Util/CaptiveProcess.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace SeqCli.Forwarder.Util;
@@ -25,7 +26,8 @@ public static class CaptiveProcess
         string? args = null,
         Action<string>? writeStdout = null,
         Action<string>? writeStderr = null, 
-        string? workingDirectory = null)
+        string? workingDirectory = null,
+        Dictionary<string, string>? environment = null)
     {
         if (fullExePath == null) throw new ArgumentNullException(nameof(fullExePath));
 
@@ -47,6 +49,14 @@ public static class CaptiveProcess
             
         if (!string.IsNullOrEmpty(workingDirectory))
             startInfo.WorkingDirectory = workingDirectory;
+
+        if (environment != null)
+        {
+            foreach (var (k, v) in environment)
+            {
+                startInfo.EnvironmentVariables.Add(k, v);
+            }
+        }
 
         using var process = Process.Start(startInfo)!;
         using var outputComplete = new ManualResetEvent(false);

--- a/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
+++ b/test/SeqCli.EndToEnd/Support/TestConfiguration.cs
@@ -53,6 +53,9 @@ public class TestConfiguration
             return new CaptiveProcess(containerRuntime, $"run --name {containerName} -d -e ACCEPT_EULA=Y -e SEQ_FIRSTRUN_NOAUTHENTICATION=True -p {_serverListenPort}:80 datalust/seq:{imageTag}", stopCommandFullExePath: containerRuntime, stopCommandArgs: $"rm -f {containerName}");
         }
         
-        return new CaptiveProcess("seq", commandWithArgs);
+        return new CaptiveProcess("seq", commandWithArgs, environment: new Dictionary<string, string>
+            {
+                { "SEQ_FIRSTRUN_NOAUTHENTICATION", "True" }
+            });
     }
 }


### PR DESCRIPTION
This PR ensures we also run seqcli's end-to-end test suite on Windows hosts, since there is some small amount of platform-specific code involved.