### PR TITLE
2025.2 Maintenance Release

### DIFF
--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="9.0.7" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageReference Include="Seq.Apps" Version="2023.4.0" />
-    <PackageReference Include="Seq.Syntax" Version="1.0.0" />
+    <PackageReference Include="Seq.Syntax" Version="1.1.0" />
     <PackageReference Include="Tavis.UriTemplates" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Seq.Api" Version="2025.2.0" />
+    <PackageReference Include="Seq.Api" Version="2025.2.2" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />


### PR DESCRIPTION
 * #434 - update `Seq.Syntax` to improve tracing support in hosted Seq apps
