### PR TITLE
Use Sum rather than Counter for sample delta-temporality counter metric kind

### DIFF
--- a/src/Roastery/Metrics/RoasteryMetrics.cs
+++ b/src/Roastery/Metrics/RoasteryMetrics.cs
@@ -69,8 +69,8 @@ public class RoasteryMetrics
                 timestamp,
                 new Dictionary<string, object>
                 {
-                    { "OrdersCreated", new { kind = "Counter", unit = "orders", description = "The total number of orders created in the system" } },
-                    { "OrdersShipped", new { kind = "Counter", unit = "orders", description = "The total number of orders shipped in the system" } }
+                    { "OrderCreated", new { kind = "Sum", unit = "orders", description = "An order was created" } },
+                    { "OrderShipped", new { kind = "Sum", unit = "orders", description = "An order was shipped" } }
                 },
                 new
                 {


### PR DESCRIPTION
The (current pre-release) Seq values for metric kinds are `Sum` (delta-temporality counter), `Gauge` (all other scalar-valued metrics), `Fixed` (-bucket histograms), and `Exponential` (-bucket histograms).