### PR TITLE
feat: Add `seqcli events delete` command

### DIFF
--- a/src/SeqCli/Cli/Commands/Events/DeleteCommand.cs
+++ b/src/SeqCli/Cli/Commands/Events/DeleteCommand.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2026 Datalust Pty Ltd and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using SeqCli.Api;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using Serilog;
+// ReSharper disable UnusedType.Global
+
+namespace SeqCli.Cli.Commands;
+
+[Command("events", "delete", "Delete log events that match a given date range or filter",
+    Example = "seqcli events delete --start \"2026-01-01T00:00:00Z\" --end \"2026-01-31T23:59:59Z\"")]
+class DeleteCommand : Command
+{
+    readonly ConnectionFeature _connection;
+    readonly DateRangeFeature _range;
+    readonly SignalExpressionFeature _signal;
+    readonly StoragePathFeature _storagePath;
+    string? _filter;
+
+    public DeleteCommand()
+    {
+        Options.Add(
+            "f=|filter=",
+            "A filter to apply to deletion, for example `Host = 'xmpweb-01.example.com'`",
+            v => _filter = v);
+
+        _range = Enable<DateRangeFeature>();
+        _storagePath = Enable<StoragePathFeature>();
+        _signal = Enable<SignalExpressionFeature>();
+
+        _connection = Enable<ConnectionFeature>();
+    }
+
+    protected override async Task<int> Run()
+    {
+        try
+        {
+            var config = RuntimeConfigurationLoader.Load(_storagePath);
+            var connection = SeqConnectionFactory.Connect(_connection, config);
+
+            string? filter = null;
+            if (!string.IsNullOrWhiteSpace(_filter))
+                filter = (await connection.Expressions.ToStrictAsync(_filter)).StrictExpression;
+
+            await connection.Events.DeleteAsync(
+                null,
+                _signal.Signal,
+                filter,
+                _range.Start,
+                _range.End,
+                null);
+
+            Log.Information("Deleted matching events");
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Could not delete matching events: {ErrorMessage}", ex.Message);
+            return 1;
+        }
+    }
+}

--- a/test/SeqCli.EndToEnd/Events/EventsDeleteTestCase.cs
+++ b/test/SeqCli.EndToEnd/Events/EventsDeleteTestCase.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Delete;
+
+public class EventsDeleteTestCase : ICliTestCase
+{
+    public async Task ExecuteAsync(
+        SeqConnection connection,
+        ILogger logger,
+        CliCommandRunner runner)
+    {
+
+        var inputFile = Path.Combine("Data", "events.clef");
+        Assert.True(File.Exists(inputFile));
+
+        var exit = runner.Exec("ingest", $"-i {inputFile}");
+        Assert.Equal(0, exit);
+
+        var eventsBefore = await connection.Events.ListAsync();
+        Assert.Equal(15, eventsBefore.Count);
+
+        exit = runner.Exec("events delete");
+        Assert.Equal(0, exit);
+
+        var eventsAfter = await connection.Events.ListAsync();
+        Assert.Empty(eventsAfter);
+    }
+}

--- a/test/SeqCli.EndToEnd/Events/EventsDeleteWithDateRangeAllTestCase.cs
+++ b/test/SeqCli.EndToEnd/Events/EventsDeleteWithDateRangeAllTestCase.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Delete;
+
+public class EventsDeleteWithDateRangeAllTestCase : ICliTestCase
+{
+    readonly TestDataFolder _testDataFolder;
+
+    public EventsDeleteWithDateRangeAllTestCase(TestDataFolder testDataFolder)
+    {
+        _testDataFolder = testDataFolder;
+    }
+
+    public async Task ExecuteAsync(
+        SeqConnection connection,
+        ILogger logger,
+        CliCommandRunner runner)
+    {
+        var inputFile = _testDataFolder.ItemPath("delete-date-range-all.clef");
+
+        var isoNow = DateTime.UtcNow.ToString("o");
+        await File.WriteAllTextAsync(inputFile,
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":1}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":2}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":3}}");
+        var exit = runner.Exec("ingest", $"-i \"{inputFile}\"");
+        Assert.Equal(0, exit);
+
+        var eventsBefore = await connection.Events.ListAsync();
+        Assert.Equal(3, eventsBefore.Count);
+
+        var isoFrom = DateTime.UtcNow.AddDays(-1).ToString("o");
+        var isoTo = DateTime.UtcNow.AddDays(1).ToString("o");
+        exit = runner.Exec("events delete", $"--start={isoFrom} --end={isoTo}");
+        Assert.Equal(0, exit);
+
+        var eventsAfter = await connection.Events.ListAsync();
+        Assert.Empty(eventsAfter);
+    }
+}

--- a/test/SeqCli.EndToEnd/Events/EventsDeleteWithDateRangeNoneTestCase.cs
+++ b/test/SeqCli.EndToEnd/Events/EventsDeleteWithDateRangeNoneTestCase.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Delete;
+
+public class EventsDeleteWithDateRangeNoneTestCase : ICliTestCase
+{
+    readonly TestDataFolder _testDataFolder;
+
+    public EventsDeleteWithDateRangeNoneTestCase(TestDataFolder testDataFolder)
+    {
+        _testDataFolder = testDataFolder;
+    }
+
+    public async Task ExecuteAsync(
+        SeqConnection connection,
+        ILogger logger,
+        CliCommandRunner runner)
+    {
+        var inputFile = _testDataFolder.ItemPath("delete-date-range-none.clef");
+
+        var isoNow = DateTime.UtcNow.ToString("o");
+        await File.WriteAllTextAsync(inputFile,
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":1}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":2}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":3}}");
+        var exit = runner.Exec("ingest", $"-i \"{inputFile}\"");
+        Assert.Equal(0, exit);
+
+        var eventsBefore = await connection.Events.ListAsync();
+        Assert.Equal(3, eventsBefore.Count);
+
+        var isoFrom = DateTime.UtcNow.AddDays(-10).ToString("o");
+        var isoTo = DateTime.UtcNow.AddDays(-5).ToString("o");
+        exit = runner.Exec("events delete", $"--start={isoFrom} --end={isoTo}");
+        Assert.Equal(0, exit);
+
+        var eventsAfter = await connection.Events.ListAsync();
+        Assert.Equal(3, eventsAfter.Count);
+    }
+}

--- a/test/SeqCli.EndToEnd/Events/EventsDeleteWithDateRangeSomeTestCase.cs
+++ b/test/SeqCli.EndToEnd/Events/EventsDeleteWithDateRangeSomeTestCase.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Delete;
+
+public class EventsDeleteWithDateRangeSomeTestCase : ICliTestCase
+{
+    readonly TestDataFolder _testDataFolder;
+
+    public EventsDeleteWithDateRangeSomeTestCase(TestDataFolder testDataFolder)
+    {
+        _testDataFolder = testDataFolder;
+    }
+
+    public async Task ExecuteAsync(
+        SeqConnection connection,
+        ILogger logger,
+        CliCommandRunner runner)
+    {
+        var inputFile = _testDataFolder.ItemPath("delete-date-range-none.clef");
+
+        var isoNow = DateTime.UtcNow.ToString("o");
+        await File.WriteAllTextAsync(inputFile,
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":1}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":2}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":3}}");
+        var exit = runner.Exec("ingest", $"-i \"{inputFile}\"");
+        Assert.Equal(0, exit);
+
+        isoNow = DateTime.UtcNow.ToString("o");
+        await File.WriteAllTextAsync(inputFile,
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":4}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":5}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":6}}");
+        exit = runner.Exec("ingest", $"-i \"{inputFile}\"");
+        Assert.Equal(0, exit);
+
+        var eventsBefore = await connection.Events.ListAsync();
+        Assert.Equal(6, eventsBefore.Count);
+
+        var isoTo = DateTime.UtcNow.AddDays(1).ToString("o");
+        exit = runner.Exec("events delete", $"--start={isoNow} --end={isoTo}");
+        Assert.Equal(0, exit);
+
+        var eventsAfter = await connection.Events.ListAsync();
+        Assert.Equal(3, eventsAfter.Count);
+    }
+}

--- a/test/SeqCli.EndToEnd/Events/EventsDeleteWithFilterTestCase.cs
+++ b/test/SeqCli.EndToEnd/Events/EventsDeleteWithFilterTestCase.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Delete;
+
+public class EventsDeleteWithFilterTestCase : ICliTestCase
+{
+    readonly TestDataFolder _testDataFolder;
+
+    public EventsDeleteWithFilterTestCase(TestDataFolder testDataFolder)
+    {
+        _testDataFolder = testDataFolder;
+    }
+
+    public async Task ExecuteAsync(
+        SeqConnection connection,
+        ILogger logger,
+        CliCommandRunner runner)
+    {
+        var inputFile = _testDataFolder.ItemPath("delete-with-filter.clef");
+
+        var isoNow = DateTime.UtcNow.ToString("o");
+        await File.WriteAllTextAsync(inputFile,
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":1}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":2}}");
+        var hostOne = "xmpweb-01.example.com";
+        var exit = runner.Exec("ingest", $"-i \"{inputFile}\" -p \"host={hostOne}\"");
+        Assert.Equal(0, exit);
+
+        isoNow = DateTime.UtcNow.ToString("o");
+        await File.WriteAllTextAsync(inputFile,
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":3}}" + Environment.NewLine +
+            $"{{\"@t\":\"{isoNow}\",\"@mt\":\"Event {{N}}\",\"N\":4}}");
+        var hostTwo = "xmpweb-02.example.com";
+        exit = runner.Exec("ingest", $"-i \"{inputFile}\" -p \"host={hostTwo}\"");
+        Assert.Equal(0, exit);
+
+        var eventsBefore = await connection.Events.ListAsync();
+        Assert.Equal(4, eventsBefore.Count);
+
+        exit = runner.Exec("events delete", $"--filter=\"host='{hostTwo}'\"");
+        Assert.Equal(0, exit);
+
+        var eventsAfter = await connection.Events.ListAsync();
+        Assert.Equal(2, eventsAfter.Count);
+    }
+}


### PR DESCRIPTION
The `events delete` command is modelled after the `seqcli search` and accepts date range as well as filter expressions.

The `events delete` command is covered with e2e tests.

The idea of adding delete command came up in this thread:
- https://github.com/datalust/seq-tickets/discussions/2529

### `seqcli delete` or `seqcli events delete`

~Since there `search` and `ingest` are not sub-commands of `seqcli events`, I decided to follow the convention and add `seqcli delete` instead of `seqcli events delete`.~

I eventually refactored the command into `seqcli events delete`, see discussion in https://github.com/datalust/seqcli/pull/445#pullrequestreview-3828337040

### Testing

```bash
$  dotnet run -- Delete.* --docker-server --verbose
dotnet run -- Delete.* --docker-server --verbose
Using launch settings from /home/mloskot/workshop/seq/seqcli/test/SeqCli.EndToEnd/Properties/launchSettings.json...
TESTING /home/mloskot/workshop/seq/seqcli/src/SeqCli/bin/Debug/net10.0/seqcli.dll
RUNNING EventsDeleteWithDateRangeNoneTestCase             
RUNNING EventsDeleteTestCase                              
RUNNING EventsDeleteWithDateRangeSomeTestCase             
RUNNING EventsDeleteWithFilterTestCase                    
PASS
RUNNING EventsDeleteWithDateRangeAllTestCase              
PASS
PASS
PASS
PASS
Done; 5 total, 5 passed, 0 failed, 0 skipped.
```

I have also tested `seqcli events delete` against live server running Seq 2025.2.15571.

### Examples

```bash
$ seqcli events delete -f "app='myservice'"
$ seqcli events delete --start=2026-02-11T23:00:00.01Z --end=2026-02-12T23:59:59Z
$ seqcli events delete --start=2026-02-11T23:00:00.01Z --end=2026-02-12T23:59:59Z --filter="app='myservice'"
```

