### PR TITLE
Fix up naming of order metrics

### DIFF
--- a/src/Roastery/Metrics/PropertyNameMapping.cs
+++ b/src/Roastery/Metrics/PropertyNameMapping.cs
@@ -1,3 +1,3 @@
 ﻿namespace Roastery.Metrics;
 
-public record struct PropertyNameMapping(string MetricDefinitions, string MetricSamples);
+public record struct PropertyNameMapping(string MetricDefinitions);

--- a/src/Roastery/Metrics/RoasteryMetrics.cs
+++ b/src/Roastery/Metrics/RoasteryMetrics.cs
@@ -49,7 +49,7 @@ public class RoasteryMetrics
                         {
                             kind = "Exponential",
                             unit = "ms",
-                            description = "The time taken to fully process a request"
+                            description = "The time taken to fully process a request."
                         }
                     },
                     new Dictionary<string, object>
@@ -78,13 +78,13 @@ public class RoasteryMetrics
                     {
                         kind = "Sum",
                         unit = "order",
-                        description = "An order was created"
+                        description = "An order was created."
                     },
                     [nameof(OrderShipped)] = new
                     {
                         kind = "Sum",
                         unit = "order",
-                        description = "An order was shipped"
+                        description = "An order was shipped."
                     }
                 },
                 new Dictionary<string, object>

--- a/src/Roastery/Metrics/RoasteryMetrics.cs
+++ b/src/Roastery/Metrics/RoasteryMetrics.cs
@@ -27,11 +27,11 @@ public class RoasteryMetrics
         public record struct HttpRequestDurationKey(string Path, int StatusCode);
         public readonly Dictionary<HttpRequestDurationKey, ExponentialHistogram> HttpRequestDuration = new();
         
-        // `OrdersCreated`: counter
-        public ulong OrdersCreated;
+        // `OrderCreated`: counter
+        public ulong OrderCreated;
         
-        // `OrdersShipped`: counter
-        public ulong OrdersShipped;
+        // `OrderShipped`: counter
+        public ulong OrderShipped;
         
         static readonly MessageTemplate Template = new MessageTemplateParser().Parse("Metrics sampled");
 
@@ -45,11 +45,16 @@ public class RoasteryMetrics
                     timestamp,
                     new Dictionary<string, object>
                     {
-                        { "HttpRequestDuration", new { kind = "Exponential", unit = "ms", description = "The time taken to fully process a request" } }
+                        [nameof(HttpRequestDuration)] = new
+                        {
+                            kind = "Exponential",
+                            unit = "ms",
+                            description = "The time taken to fully process a request"
+                        }
                     },
-                    new
+                    new Dictionary<string, object>
                     {
-                        HttpRequestDuration = new {
+                        [nameof(HttpRequestDuration)] = new {
                             buckets = metric.Buckets
                                 .Select(bucket => new { midpoint = bucket.Key, count = bucket.Value }).ToArray(),
                             scale = metric.Scale,
@@ -57,8 +62,8 @@ public class RoasteryMetrics
                             max = metric.Max,
                             count = metric.Total
                         },
-                        key.Path,
-                        key.StatusCode
+                        [nameof(key.Path)] = key.Path,
+                        [nameof(key.StatusCode)] = key.StatusCode
                     }
                 );
             }
@@ -69,24 +74,46 @@ public class RoasteryMetrics
                 timestamp,
                 new Dictionary<string, object>
                 {
-                    { "OrderCreated", new { kind = "Sum", unit = "orders", description = "An order was created" } },
-                    { "OrderShipped", new { kind = "Sum", unit = "orders", description = "An order was shipped" } }
+                    [nameof(OrderCreated)] = new
+                    {
+                        kind = "Sum",
+                        unit = "order",
+                        description = "An order was created"
+                    },
+                    [nameof(OrderShipped)] = new
+                    {
+                        kind = "Sum",
+                        unit = "order",
+                        description = "An order was shipped"
+                    }
                 },
-                new
+                new Dictionary<string, object>
                 {
-                    OrdersCreated,
-                    OrdersShipped
+                    [nameof(OrderCreated)] = OrderCreated,
+                    [nameof(OrderShipped)] = OrderShipped
                 }
             );
         }
 
-        static LogEvent ToLogEvent(ILogger logger, PropertyNameMapping propertyNameMapping, DateTimeOffset timestamp, Dictionary<string, object> definitions, object samples)
+        static LogEvent ToLogEvent(ILogger logger, PropertyNameMapping propertyNameMapping, DateTimeOffset timestamp, Dictionary<string, object> definitions, Dictionary<string, object> samples)
         {
-            logger.BindProperty(propertyNameMapping.MetricDefinitions, definitions, true, out var definitionsProperty);
-            logger.BindProperty(propertyNameMapping.MetricSamples, samples, true, out var sampleProperty);
+            var properties = new List<LogEventProperty>();
 
-            return new LogEvent(timestamp, LogEventLevel.Information, null, Template,
-                [definitionsProperty!, sampleProperty!]);
+            if (logger.BindProperty(propertyNameMapping.MetricDefinitions, definitions, true,
+                    out var definitionsProperty))
+            {
+                properties.Add(definitionsProperty);
+            }
+
+            foreach (var (key, value) in samples)
+            {
+                if (logger.BindProperty(key, value, true, out var sample))
+                {
+                    properties.Add(sample);
+                }
+            }
+
+            return new LogEvent(timestamp, LogEventLevel.Information, null, Template, properties);
         }
     }
     
@@ -113,7 +140,7 @@ public class RoasteryMetrics
     {
         lock (_lock)
         {
-            _current.OrdersCreated += 1;
+            _current.OrderCreated += 1;
         }
     }
 
@@ -121,7 +148,7 @@ public class RoasteryMetrics
     {
         lock (_lock)
         {
-            _current.OrdersShipped += 1;
+            _current.OrderShipped += 1;
         }
     }
 

--- a/src/SeqCli/Mapping/MetricsMapping.cs
+++ b/src/SeqCli/Mapping/MetricsMapping.cs
@@ -5,5 +5,4 @@ namespace SeqCli.Mapping;
 public static class MetricsMapping
 {
     internal static readonly string SurrogateDefinitionsProperty = $"_SeqcliMetricDefinitions_{Guid.NewGuid():N}";
-    internal static readonly string SurrogateSamplesProperty = $"_SeqcliMetricSamples_{Guid.NewGuid():N}";
 }

--- a/src/SeqCli/Output/OutputFormatter.cs
+++ b/src/SeqCli/Output/OutputFormatter.cs
@@ -15,7 +15,7 @@ static class OutputFormatter
         $"{{ " +
             $"if {MetricsMapping.SurrogateDefinitionsProperty} is not null then " +
                 // Emit a metric sample
-                $"{{@t, @l: undefined(), @d: {MetricsMapping.SurrogateDefinitionsProperty}, ..{MetricsMapping.SurrogateSamplesProperty}, ..rest()}} " +
+                $"{{@t, @l: undefined(), @d: {MetricsMapping.SurrogateDefinitionsProperty}, ..rest()}} " +
             $"else " +
                 // Emit a log or span
                 $"{{@t, @mt, @l: coalesce({LevelMapping.SurrogateLevelProperty}, if @l = 'Information' then undefined() else @l), @x, @sp, @tr, @ps: coalesce({TraceConstants.ParentSpanIdProperty}, @ps), @st: coalesce({TraceConstants.SpanStartTimestampProperty}, @st), ..rest()}} " +

--- a/src/SeqCli/Properties/launchSettings.json
+++ b/src/SeqCli/Properties/launchSettings.json
@@ -1,9 +1,13 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "SeqCli": {
+    "SeqCli Forwarder": {
       "commandName": "Project",
       "commandLineArgs": "forwarder run --pre"
+    },
+    "SeqCli Sample": {
+      "commandName": "Project",
+      "commandLineArgs": "sample ingest -y"
     }
   }
 }

--- a/src/SeqCli/Sample/Loader/Simulation.cs
+++ b/src/SeqCli/Sample/Loader/Simulation.cs
@@ -39,7 +39,7 @@ static class Simulation
         var ship = Task.Run(() => LogShipper.ShipEventsAsync(connection, apiKey, buffer,
             InvalidDataHandling.Fail, SendFailureHandling.Continue, batchSize, null, cancellationToken), cancellationToken);
 
-        await Roastery.Program.Main(logger, new PropertyNameMapping(MetricsMapping.SurrogateDefinitionsProperty, MetricsMapping.SurrogateSamplesProperty), cancellationToken);
+        await Roastery.Program.Main(logger, new PropertyNameMapping(MetricsMapping.SurrogateDefinitionsProperty), cancellationToken);
         await logger.DisposeAsync();
         await ship;
     }


### PR DESCRIPTION
This PR fixes up a lingering data issue with the pre-release metrics generated by `sample ingest` where the definitions and values don't line up. I've refactored it slightly to make this less likely in the future. We don't really need that extra layer of spread for metric samples, since they're just regular properties anyways, it's only the definitions that are a bit special.