### PR TITLE
Give test processes more time to exit cleanly

### DIFF
--- a/test/SeqCli.EndToEnd/Support/CaptiveProcess.cs
+++ b/test/SeqCli.EndToEnd/Support/CaptiveProcess.cs
@@ -111,11 +111,12 @@ public sealed class CaptiveProcess : ITestProcess, IDisposable
 
         if (_captureOutput)
         {
-            if (!_outputComplete.WaitOne(TimeSpan.FromSeconds(5)))
-                throw new IOException("STDOUT did not complete in the fixed 5-second window.");
+            const int secondsWait = 15;
+            if (!_outputComplete.WaitOne(TimeSpan.FromSeconds(secondsWait)))
+                throw new IOException($"STDOUT did not complete in the fixed {secondsWait}-second window.");
                 
-            if (!_errorComplete.WaitOne(TimeSpan.FromSeconds(5)))
-                throw new IOException("STDERR did not complete in the fixed 5-second window.");
+            if (!_errorComplete.WaitOne(TimeSpan.FromSeconds(secondsWait)))
+                throw new IOException($"STDERR did not complete in the fixed {secondsWait}-second window.");
         }
 
         return _process.ExitCode;


### PR DESCRIPTION
Slow runners are making CI builds flaky; this is one of the timeouts we frequently hit, hoping this lifts the success rate ahead of us needing to do deeper surgery.