### PR TITLE
Update `dashboard render` to accept `--native`

### DIFF
--- a/src/SeqCli/Cli/Commands/Dashboard/RenderCommand.cs
+++ b/src/SeqCli/Cli/Commands/Dashboard/RenderCommand.cs
@@ -58,7 +58,7 @@ class RenderCommand : Command
         _range = Enable<DateRangeFeature>();
         _signal = Enable<SignalExpressionFeature>();
         _timeout = Enable<TimeoutFeature>();
-        _output = Enable<OutputFormatFeature>();
+        _output = Enable(new OutputFormatFeature(supportNative: true));
         _storagePath = Enable<StoragePathFeature>();
         _connection = Enable<ConnectionFeature>();
     }
@@ -191,7 +191,7 @@ class RenderCommand : Command
 
     static SignalExpressionPart? Intersect(params SignalExpressionPart?[] expressions)
     {
-        var result = (SignalExpressionPart?) null;
+        SignalExpressionPart? result = null;
 
         foreach (var s in expressions)
         {

--- a/src/SeqCli/Output/NativeFormatter.cs
+++ b/src/SeqCli/Output/NativeFormatter.cs
@@ -255,7 +255,6 @@ static partial class NativeFormatter
                         output.Write(' ');
                     output.Write(heading);
                 }
-                output.WriteLine();
             }
             else
             {

--- a/test/SeqCli.EndToEnd/Dashboard/RenderTestCase.cs
+++ b/test/SeqCli.EndToEnd/Dashboard/RenderTestCase.cs
@@ -18,7 +18,7 @@ public class RenderTestCase : ICliTestCase
         var exit = runner.Exec("dashboard list");
         Assert.Equal(0, exit);
 
-        var id = runner.LastRunProcess.Output.Split(' ')[0];
+        var id = runner.LastRunProcess!.Output.Split(' ')[0];
 
         exit = runner.Exec("dashboard render", $"-i {id} -c \"All Events\" --last 1d --by 1h --no-color");
         Assert.Equal(0, exit);


### PR DESCRIPTION
Lines this up with the other commands that output query results.

```
> seqcli dashboard render --id dashboard-14 --chart "All Events" --last 15m --native
count
657868
```

Dropped the superfluous newline between the headings and values.