### PR TITLE
Mark the `seqcli forwarder` command group as non-prerelease

### DIFF
--- a/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
@@ -27,7 +27,7 @@ namespace SeqCli.Cli.Commands.Forwarder;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 
-[Command("forwarder", "install", "Install the forwarder as a Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
+[Command("forwarder", "install", "Install the forwarder as a Windows service", Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class InstallCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/RestartCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/RestartCommand.cs
@@ -22,7 +22,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "restart", "Restart the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
+[Command("forwarder", "restart", "Restart the forwarder Windows service", Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class RestartCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/RunCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/RunCommand.cs
@@ -44,7 +44,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "run", "Listen on an HTTP endpoint and forward ingested logs to Seq", Visibility = FeatureVisibility.Preview)]
+[Command("forwarder", "run", "Listen on an HTTP endpoint and forward ingested logs to Seq")]
 class RunCommand : Command
 {
     readonly StoragePathFeature _storagePath;

--- a/src/SeqCli/Cli/Commands/Forwarder/StartCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StartCommand.cs
@@ -20,7 +20,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "start", "Start the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
+[Command("forwarder", "start", "Start the forwarder Windows service", Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class StartCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/StatusCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StatusCommand.cs
@@ -20,7 +20,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "status", "Show the status of the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
+[Command("forwarder", "status", "Show the status of the forwarder Windows service", Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class StatusCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/StopCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/StopCommand.cs
@@ -20,7 +20,7 @@ using SeqCli.Forwarder.ServiceProcess;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "stop", "Stop the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
+[Command("forwarder", "stop", "Stop the forwarder Windows service", Platforms = SupportedPlatforms.Windows)]
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 class StopCommand : Command
 {

--- a/src/SeqCli/Cli/Commands/Forwarder/TruncateCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/TruncateCommand.cs
@@ -20,7 +20,7 @@ using Serilog;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "truncate", "Empty the forwarder's persistent log buffer", Visibility = FeatureVisibility.Preview)]
+[Command("forwarder", "truncate", "Empty the forwarder's persistent log buffer")]
 class TruncateCommand : Command
 {
     readonly StoragePathFeature _storagePath;

--- a/src/SeqCli/Cli/Commands/Forwarder/UninstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/UninstallCommand.cs
@@ -20,7 +20,7 @@ using SeqCli.Forwarder.Util;
 
 namespace SeqCli.Cli.Commands.Forwarder;
 
-[Command("forwarder", "uninstall", "Uninstall the forwarder Windows service", Visibility = FeatureVisibility.Preview, Platforms = SupportedPlatforms.Windows)]
+[Command("forwarder", "uninstall", "Uninstall the forwarder Windows service", Platforms = SupportedPlatforms.Windows)]
 class UninstallCommand : Command
 {
     protected override Task<int> Run()


### PR DESCRIPTION
We've had enough feedback and iteration on the preview that it makes sense to expose the commands more widely now.