### PR TITLE
Metrics command group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1868,7 +1868,7 @@ PS > seqcli signal list -i signal-m33302 --json
 {"Title": "Alarms", "Description": "Automatically created", "Filters": [{"De...
 ```
 
-## Store-and-forward ingestion proxy (preview)
+## Store-and-forward ingestion proxy
 
 The `seqcli forwarder` family of commands provide simple, durable ingestion buffering for occasionally-connected and
 intermittently-disconnected systems. The forwarder implements the Seq ingestion API, so applications that write
@@ -1890,11 +1890,8 @@ destination Seq server.
 To start a forwarder instance at the terminal, listening on port 5341 and forwarding to `seq.example.com`, run:
 
 ```shell
-seqcli forwarder run --pre --listen http://127.0.0.1:5341 -s https://seq.example.com
+seqcli forwarder run --listen http://127.0.0.1:5341 -s https://seq.example.com
 ```
-
-> While the `forwarder` command group is in preview, all `forwarder` commands require the `--pre` switch; you'll
-> also need to supply `--pre` when requesting help, e.g. `seqcli help forwarder run --pre`.
 
 You can test your forwarder using the `seqcli log` command:
 

--- a/src/SeqCli/Cli/Commands/Mcp/RunCommand.cs
+++ b/src/SeqCli/Cli/Commands/Mcp/RunCommand.cs
@@ -14,6 +14,10 @@
 
 using System;
 using System.Threading.Tasks;
+using Autofac;
+using Autofac.Builder;
+using Autofac.Core;
+using Autofac.Core.Resolving.Pipeline;
 using Autofac.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -61,7 +65,20 @@ class RunCommand: Command
         try
         {
             var builder = Host.CreateApplicationBuilder();
-            builder.ConfigureContainer(new AutofacServiceProviderFactory());
+            builder.ConfigureContainer(new AutofacServiceProviderFactory(container =>
+            {
+                // The MCP SDK tries to use the container to resolve any parameter type; Autofac's default collection
+                // registrations cause array parameters to resolve to empty arrays. We thwart this by short-circuiting
+                // the search for matching registrations.
+                var stringArray = new TypedService(typeof(string[]));
+                container.RegisterServiceMiddleware<string[]>(PipelinePhase.ResolveRequestStart, (rr, ctx) =>
+                {
+                    if (rr.Service == stringArray)
+                        return;
+
+                    ctx(rr);
+                });
+            }));
             builder.Services.AddSerilog();
             builder.Services.AddSingleton(_ => SeqConnectionFactory.Connect(_connection, config));
             builder.Services.AddSingleton<McpSession>();

--- a/src/SeqCli/Cli/Commands/Mcp/RunCommand.cs
+++ b/src/SeqCli/Cli/Commands/Mcp/RunCommand.cs
@@ -21,7 +21,10 @@ using SeqCli.Api;
 using SeqCli.Cli.Features;
 using SeqCli.Config;
 using SeqCli.Mcp;
+using SeqCli.Mcp.Tools.Metrics;
+using SeqCli.Mcp.Tools.Query;
 using SeqCli.Mcp.Tools.Search;
+using SeqCli.Mcp.Tools.Signals;
 using Serilog;
 
 namespace SeqCli.Cli.Commands.Mcp;
@@ -66,7 +69,10 @@ class RunCommand: Command
                 .AddMcpServer()
                 .WithStdioServerTransport()
                 .WithTools([
-                    typeof(SearchAndQueryToolType)
+                    typeof(SearchTools),
+                    typeof(MetricsTools),
+                    typeof(QueryTools),
+                    typeof(SignalTools)
                 ]);
 
             await builder.Build().RunAsync();

--- a/src/SeqCli/Cli/Commands/Mcp/RunCommand.cs
+++ b/src/SeqCli/Cli/Commands/Mcp/RunCommand.cs
@@ -14,11 +14,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Autofac;
-using Autofac.Builder;
-using Autofac.Core;
-using Autofac.Core.Resolving.Pipeline;
-using Autofac.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SeqCli.Api;
@@ -65,20 +60,6 @@ class RunCommand: Command
         try
         {
             var builder = Host.CreateApplicationBuilder();
-            builder.ConfigureContainer(new AutofacServiceProviderFactory(container =>
-            {
-                // The MCP SDK tries to use the container to resolve any parameter type; Autofac's default collection
-                // registrations cause array parameters to resolve to empty arrays. We thwart this by short-circuiting
-                // the search for matching registrations.
-                var stringArray = new TypedService(typeof(string[]));
-                container.RegisterServiceMiddleware<string[]>(PipelinePhase.ResolveRequestStart, (rr, ctx) =>
-                {
-                    if (rr.Service == stringArray)
-                        return;
-
-                    ctx(rr);
-                });
-            }));
             builder.Services.AddSerilog();
             builder.Services.AddSingleton(_ => SeqConnectionFactory.Connect(_connection, config));
             builder.Services.AddSingleton<McpSession>();

--- a/src/SeqCli/Cli/Commands/Metrics/DimensionCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/DimensionCommand.cs
@@ -1,0 +1,6 @@
+namespace SeqCli.Cli.Commands.Metrics;
+
+class DimensionCommand
+{
+    
+}

--- a/src/SeqCli/Cli/Commands/Metrics/DimensionCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/DimensionCommand.cs
@@ -1,6 +1,102 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using SeqCli.Api;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using Serilog;
+
 namespace SeqCli.Cli.Commands.Metrics;
 
-class DimensionCommand
+[Command("metrics", "dimension", "List distinct values for a metric dimension",
+    Example = "seqcli metrics dimension --accessor @Resource.service.name")]
+class DimensionCommand : Command
 {
-    
+    readonly ConnectionFeature _connection;
+    readonly OutputFormatFeature _output;
+    readonly DateRangeFeature _range;
+    readonly StoragePathFeature _storagePath;
+    string? _accessor;
+    int _count = 30;
+    bool _trace;
+
+    public DimensionCommand()
+    {
+        Options.Add(
+            "d=|accessor=",
+            "The dimension accessor, e.g. `cpu.mode`",
+            v => _accessor= v);
+        
+        Options.Add(
+            "c=|count=",
+            $"The maximum number of dimensions to retrieve; the default is {_count}",
+            v => _count = int.Parse(v, CultureInfo.InvariantCulture));
+
+        _range = Enable<DateRangeFeature>();
+        _output = Enable(new OutputFormatFeature(supportNative: true));
+        _storagePath = Enable<StoragePathFeature>();
+
+        Options.Add("trace", "Enable detailed (server-side) query tracing", _ => _trace = true);
+
+        _connection = Enable<ConnectionFeature>();
+    }
+
+    protected override async Task<int> Run()
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(_accessor))
+            {
+                Log.Error("A dimension `--accessor` must be specified");
+                return 1;
+            }
+
+            var config = RuntimeConfigurationLoader.Load(_storagePath);
+            var output = _output.GetOutputFormat(config);
+            var connection = SeqConnectionFactory.Connect(_connection, config);
+            
+            var result = await connection.Metrics.ListDimensionValuesAsync(
+                _accessor,
+                _count,
+                rangeStartUtc: _range.Start,
+                rangeEndUtc: _range.End,
+                trace: _trace);
+
+            if (output.Json)
+            {
+                // In the JSON case we write an array with all values.
+                output.WriteObject(result);
+            }
+            else
+            {
+                // Native and plain text formatting use one-per-line output (both allow multi-line strings, but
+                // string boundaries are clearer in native mode).
+                foreach (var value in result)
+                {
+                    output.WriteObject(value);
+                }
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Could not retrieve metrics: {ErrorMessage}", ex.Message);
+            return 1;
+        }
+    }
 }

--- a/src/SeqCli/Cli/Commands/Metrics/DimensionValuesCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/DimensionValuesCommand.cs
@@ -22,9 +22,9 @@ using Serilog;
 
 namespace SeqCli.Cli.Commands.Metrics;
 
-[Command("metrics", "dimension", "List distinct values for a metric dimension",
-    Example = "seqcli metrics dimension --accessor @Resource.service.name")]
-class DimensionCommand : Command
+[Command("metrics", "dimensionvalues", "List distinct values for a metric dimension",
+    Example = "seqcli metrics dimensionvalues --accessor @Resource.service.name")]
+class DimensionValuesCommand : Command
 {
     readonly ConnectionFeature _connection;
     readonly OutputFormatFeature _output;
@@ -34,7 +34,7 @@ class DimensionCommand : Command
     int _count = 30;
     bool _trace;
 
-    public DimensionCommand()
+    public DimensionValuesCommand()
     {
         Options.Add(
             "d=|accessor=",

--- a/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
@@ -1,6 +1,93 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using SeqCli.Api;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using Serilog;
+
 namespace SeqCli.Cli.Commands.Metrics;
 
-class DimensionsCommand
+[Command("metrics", "dimensions", "List the dimensions that apply to a given metric",
+    Example = "seqcli metrics dimensions -m http.response.status_code")]
+class DimensionsCommand : Command
 {
-    
+    readonly ConnectionFeature _connection;
+    readonly OutputFormatFeature _output;
+    readonly DateRangeFeature _range;
+    readonly StoragePathFeature _storagePath;
+    string? _metric;
+    int _count = 30;
+    bool _trace;
+
+    public DimensionsCommand()
+    {
+        Options.Add(
+            "m=|metric=",
+            "The metric name, for example `hats-sold` or `http.request.duration`",
+            v => _metric= v);
+        
+        Options.Add(
+            "c=|count=",
+            $"The maximum number of dimensions to retrieve; the default is {_count}",
+            v => _count = int.Parse(v, CultureInfo.InvariantCulture));
+
+        _range = Enable<DateRangeFeature>();
+        _output = Enable<OutputFormatFeature>();
+        _storagePath = Enable<StoragePathFeature>();
+
+        Options.Add("trace", "Enable detailed (server-side) query tracing", _ => _trace = true);
+
+        _connection = Enable<ConnectionFeature>();
+    }
+
+    protected override async Task<int> Run()
+    {
+        try
+        {
+            var config = RuntimeConfigurationLoader.Load(_storagePath);
+            var output = _output.GetOutputFormat(config);
+            var connection = SeqConnectionFactory.Connect(_connection, config);
+            
+            var result = await connection.Metrics.ListDimensionsAsync(
+                _count,
+                _metric,
+                rangeStartUtc: _range.Start,
+                rangeEndUtc: _range.End,
+                trace: _trace);
+
+            if (output.Json)
+            {
+                output.WriteObject(result);
+            }
+            else
+            {
+                foreach (var dimension in result)
+                {
+                    output.WriteText(dimension.Accessor);
+                }
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Could not retrieve metrics: {ErrorMessage}", ex.Message);
+            return 1;
+        }
+    }
 }

--- a/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
@@ -1,0 +1,6 @@
+namespace SeqCli.Cli.Commands.Metrics;
+
+class DimensionsCommand
+{
+    
+}

--- a/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
@@ -59,12 +59,6 @@ class DimensionsCommand : Command
     {
         try
         {
-            if (string.IsNullOrWhiteSpace(_metric))
-            {
-                Log.Error("A `--metric` must be specified");
-                return 1;
-            }
-            
             var config = RuntimeConfigurationLoader.Load(_storagePath);
             var output = _output.GetOutputFormat(config);
             var connection = SeqConnectionFactory.Connect(_connection, config);

--- a/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
@@ -38,7 +38,7 @@ class DimensionsCommand : Command
     {
         Options.Add(
             "m=|metric=",
-            "The metric name, for example `hats-sold` or `http.request.duration`",
+            "A metric name, for example `hats-sold` or `http.request.duration`; omit to list dimensions for all metrics",
             v => _metric= v);
         
         Options.Add(

--- a/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/DimensionsCommand.cs
@@ -22,7 +22,7 @@ using Serilog;
 
 namespace SeqCli.Cli.Commands.Metrics;
 
-[Command("metrics", "dimensions", "List the dimensions that apply to a given metric",
+[Command("metrics", "dimensions", "List the dimensions associated with a given metric",
     Example = "seqcli metrics dimensions -m http.response.status_code")]
 class DimensionsCommand : Command
 {
@@ -59,6 +59,12 @@ class DimensionsCommand : Command
     {
         try
         {
+            if (string.IsNullOrWhiteSpace(_metric))
+            {
+                Log.Error("A `--metric` must be specified");
+                return 1;
+            }
+            
             var config = RuntimeConfigurationLoader.Load(_storagePath);
             var output = _output.GetOutputFormat(config);
             var connection = SeqConnectionFactory.Connect(_connection, config);

--- a/src/SeqCli/Cli/Commands/Metrics/SearchCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/SearchCommand.cs
@@ -1,0 +1,124 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Seq.Api.Model.Data;
+using SeqCli.Api;
+using SeqCli.Cli.Features;
+using SeqCli.Config;
+using SeqCli.Util;
+using Serilog;
+
+namespace SeqCli.Cli.Commands.Metrics;
+
+[Command("metrics", "search", "List available metric definitions",
+    Example = "seqcli metrics search -f \"@Resource.service.name = 'proxy'\" -c 100")]
+class SearchCommand : Command
+{
+    readonly ConnectionFeature _connection;
+    readonly OutputFormatFeature _output;
+    readonly DateRangeFeature _range;
+    readonly StoragePathFeature _storagePath;
+    string? _filter;
+    readonly List<string> _groups = [];
+    int _count = 1;
+    bool _trace;
+
+    public SearchCommand()
+    {
+        Options.Add(
+            "f=|filter=",
+            "A filter to apply to the search, including metric name/description text in double quotes, for example `\"cpu\" and Host = 'xmpweb-01.example.com'`",
+            v => _filter = v);
+
+        Options.Add(
+            "g=|group=",
+            "Group key for metric definition breakdown; this argument can be used multiple times",
+            c => _groups.Add(ArgumentString.Normalize(c) ?? throw new ArgumentException("Group keys require a value.")));
+        
+        Options.Add(
+            "c=|count=",
+            $"The maximum number of metric definitions to retrieve; the default is {_count}",
+            v => _count = int.Parse(v, CultureInfo.InvariantCulture));
+
+        _range = Enable<DateRangeFeature>();
+        // Native is not supported because accessor expressions appear in the output, and the escaping applied to them
+        // as native strings does more harm than good.
+        _output = Enable<OutputFormatFeature>();
+        _storagePath = Enable<StoragePathFeature>();
+
+        Options.Add("trace", "Enable detailed (server-side) query tracing", _ => _trace = true);
+
+        _connection = Enable<ConnectionFeature>();
+    }
+
+    protected override async Task<int> Run()
+    {
+        try
+        {
+            var config = RuntimeConfigurationLoader.Load(_storagePath);
+            var output = _output.GetOutputFormat(config);
+            var connection = SeqConnectionFactory.Connect(_connection, config);
+
+            string? filter = null;
+            if (!string.IsNullOrWhiteSpace(_filter))
+                filter = (await connection.Expressions.ToStrictAsync(_filter)).StrictExpression;
+
+            var result = await connection.Metrics.SearchAsync(
+                _groups,
+                filter,
+                _count,
+                rangeStartUtc: _range.Start,
+                rangeEndUtc: _range.End,
+                trace: _trace);
+            
+            // We convert the metric into a query result to improve formatting consistency. Room for an abstraction of
+            // some kind here.
+            var rows = new List<object?[]>();
+            foreach (var metric in result.Metrics)
+            {
+                var row = new List<object?>
+                {
+                    metric.Accessor,
+                    metric.Kind,
+                    metric.Unit,
+                    metric.Description
+                };
+                
+                foreach (var value in metric.GroupKey)
+                    row.Add(value);
+                
+                rows.Add(row.ToArray());
+            }
+            var asRowset = new QueryResultPart
+            {
+                Columns = new[] { "Accessor", "Kind", "Unit", "Description" }.Concat(_groups).ToArray(),
+                Rows = rows.ToArray()
+            };
+            
+            output.WriteQueryResult(asRowset);
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Could not retrieve metrics: {ErrorMessage}", ex.Message);
+            return 1;
+        }
+    }
+}

--- a/src/SeqCli/Cli/Commands/Metrics/SearchCommand.cs
+++ b/src/SeqCli/Cli/Commands/Metrics/SearchCommand.cs
@@ -27,7 +27,7 @@ using Serilog;
 namespace SeqCli.Cli.Commands.Metrics;
 
 [Command("metrics", "search", "List available metric definitions",
-    Example = "seqcli metrics search -f \"@Resource.service.name = 'proxy'\" -c 100")]
+    Example = "seqcli metrics search -f \"@Resource.service.name = 'proxy'\" -c 512")]
 class SearchCommand : Command
 {
     readonly ConnectionFeature _connection;
@@ -36,7 +36,7 @@ class SearchCommand : Command
     readonly StoragePathFeature _storagePath;
     string? _filter;
     readonly List<string> _groups = [];
-    int _count = 1;
+    int _count = 30;
     bool _trace;
 
     public SearchCommand()
@@ -94,7 +94,7 @@ class SearchCommand : Command
             {
                 var row = new List<object?>
                 {
-                    metric.Accessor,
+                    metric.Name ?? metric.Accessor,
                     metric.Kind,
                     metric.Unit,
                     metric.Description
@@ -107,7 +107,7 @@ class SearchCommand : Command
             }
             var asRowset = new QueryResultPart
             {
-                Columns = new[] { "Accessor", "Kind", "Unit", "Description" }.Concat(_groups).ToArray(),
+                Columns = new[] { "Name", "Kind", "Unit", "Description" }.Concat(_groups).ToArray(),
                 Rows = rows.ToArray()
             };
             

--- a/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
+++ b/src/SeqCli/Cli/Commands/Node/HealthCommand.cs
@@ -108,15 +108,16 @@ class HealthCommand : Command
             if (outputFormat.Json)
             {
                 var shouldBeJson = await response.Content.ReadAsStringAsync();
+                object obj;
                 try
                 {
-                    var obj = JsonConvert.DeserializeObject(shouldBeJson) ?? throw new InvalidDataException();
-                    outputFormat.WriteObject(obj);
+                    obj = JsonConvert.DeserializeObject(shouldBeJson) ?? throw new InvalidDataException();
                 }
                 catch
                 {
-                    outputFormat.WriteObject(new { Response = shouldBeJson });
+                    obj = new { Response = shouldBeJson };
                 }
+                outputFormat.WriteObject(obj);
             }
             else
             {

--- a/src/SeqCli/Csv/CsvWriter.cs
+++ b/src/SeqCli/Csv/CsvWriter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.IO;
 using Seq.Api.Model.Data;
 using SeqCli.Mcp.Data;
@@ -9,7 +8,7 @@ namespace SeqCli.Csv;
 
 static class CsvWriter
 {
-    public static void WriteQueryResult(QueryResultPart result, ConsoleTheme theme, TextWriter output)
+    public static void WriteQueryResult(QueryResultPart result, Func<object?, string> stringify, ConsoleTheme theme, TextWriter output)
     {
         if (!string.IsNullOrWhiteSpace(result.Error))
         {
@@ -24,14 +23,14 @@ static class CsvWriter
             var firstCol = true;
             foreach (var value in row)
             {
-                WriteCell(output, theme, value, ref firstCol, isHeadingRow: first);
+                WriteCell(output, theme, value, stringify, ref firstCol, isHeadingRow: first);
             }
             first = false;
             output.WriteLine();
         });
     }
 
-    static void WriteCell(TextWriter output, ConsoleTheme theme, object? value, ref bool firstCol, bool isHeadingRow = false)
+    static void WriteCell(TextWriter output, ConsoleTheme theme, object? value, Func<object?, string> stringify, ref bool firstCol, bool isHeadingRow = false)
     {
         if (firstCol)
         {
@@ -48,19 +47,7 @@ static class CsvWriter
         output.Write('"');
         theme.Reset(output);
 
-        var valueAsString = value switch
-        {
-            null => "null",
-            true => "true",
-            false => "false",
-            decimal
-                or double or float or Half
-                or byte or ushort or uint or ulong or UInt128 or
-                sbyte or short or int or long or Int128 => ((IFormattable)value).ToString(null, CultureInfo.InvariantCulture),
-            DateTime dt => dt.ToString("o"),
-            DateTimeOffset dto => dto.ToString("o"),
-            _ => value.ToString() ?? ""
-        };
+        var valueAsString = stringify(value);
         
         var dataStyle = isHeadingRow ? ConsoleThemeStyle.Name : ConsoleThemeStyle.Text;
         var doubleQuote = valueAsString.IndexOf('"');

--- a/src/SeqCli/Mcp/McpSession.cs
+++ b/src/SeqCli/Mcp/McpSession.cs
@@ -25,6 +25,8 @@ namespace SeqCli.Mcp;
 
 class McpSession
 {
+    public TimeSpan DataToolCallTimeout { get; } = TimeSpan.FromSeconds(45);
+    
     readonly Lock _sync = new();
     int _nextId = 1;
     readonly Dictionary<int, string> _resultIdToEventId = new();

--- a/src/SeqCli/Mcp/Tools/McpResults.cs
+++ b/src/SeqCli/Mcp/Tools/McpResults.cs
@@ -1,0 +1,35 @@
+// Copyright © Datalust and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using ModelContextProtocol.Protocol;
+
+namespace SeqCli.Mcp.Tools;
+
+static class McpResults
+{
+    public static CallToolResult SimpleText(string resultText, bool isError = false)
+    {
+        return new CallToolResult
+        {
+            IsError = isError,
+            Content =
+            [
+                new TextContentBlock
+                {
+                    Text = resultText
+                }
+            ]
+        };
+    }
+}

--- a/src/SeqCli/Mcp/Tools/Metrics/MetricDefinition.cs
+++ b/src/SeqCli/Mcp/Tools/Metrics/MetricDefinition.cs
@@ -1,0 +1,37 @@
+// Copyright © Datalust and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace SeqCli.Mcp.Tools.Metrics;
+
+[Description("Describes a metric.")]
+class MetricDefinition
+{
+    [Description("The metric name.")]
+    public required string Name { get; init; }
+    
+    [Description("The metric kind; normally one of `Sum` (counters with delta temporality), `Gauge`, `Fixed` (fixed-bucket histogram), or `Exponential` (exponentially-bucketed histogram).")]
+    public required string Kind { get; init; }
+    
+    [Description("The UCUM unit specified for the metric, if any.")]
+    public string? Unit { get; init; }
+    
+    [Description("A human-readable description of the metric, if available.")]
+    public string? Description { get; init; }
+
+    [Description("If group keys were specified when retrieving the metric, the values of those group keys for this definition.")]
+    public List<object?> GroupKeyValues { get; init; } = [];
+}

--- a/src/SeqCli/Mcp/Tools/Metrics/MetricsTools.cs
+++ b/src/SeqCli/Mcp/Tools/Metrics/MetricsTools.cs
@@ -1,0 +1,134 @@
+// Copyright © Datalust and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Seq.Api;
+using SeqCli.Output;
+
+// ReSharper disable UnusedMember.Global
+
+namespace SeqCli.Mcp.Tools.Metrics;
+
+[McpServerToolType]
+class MetricsTools(McpSession session, SeqConnection connection)
+{
+    [McpServerTool(Name = "seq_search_metric_definitions", ReadOnly = true, Title = "Search Metric Definitions", UseStructuredContent = true)]
+    [Description("Search for metric definitions matching given criteria.")]
+    [return: Description("Matching metric definitions.")]
+    public async Task<MetricDefinition[]> SearchMetricsAsync(
+        [Description("The maximum number of metric definitions to return.")]
+        [Range(1, 1000)]
+        int limit,
+        [Description("A Seq search expression evaluated over metric names (`Keys(@Definitions)[?]`), descriptions " +
+                     "(`@Definitions[?].description`), resource attributes, scope attributes, and raw samples.")]
+        string? predicate = null,
+        [Description("Optionally, break down the available descriptions by grouping on one or more resource, scope, or " +
+                     "sample attributes.")]
+        string[]? groups = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.IsNullOrWhiteSpace(predicate))
+        {
+            if (!predicate.Contains("@Timestamp", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new McpException(
+                    "The predicate doesn't adequately constrain the search range. " +
+                    "To avoid consuming excessive resources, add a time bound such as `@Timestamp >= now() - 4h`.");
+            }
+
+            var strict = await connection.Expressions.ToStrictAsync(predicate, cancellationToken);
+            if (strict.MatchedAsText)
+            {
+                throw new McpException(
+                    $"The search expression was rejected by the Seq server. {strict.ReasonIfMatchedAsText}");
+            }
+        }
+
+        var definitions = await connection.Metrics.SearchAsync(groups?.ToList() ?? [], predicate, limit,
+            timeout: session.DataToolCallTimeout, cancellationToken: cancellationToken);
+
+        return definitions.Metrics.Select(m => new MetricDefinition
+        {
+            Name = m.Name ?? m.Accessor,
+            Kind = m.Kind,
+            Unit = m.Unit,
+            Description = m.Description,
+            GroupKeyValues = m.GroupKey
+        }).ToArray();
+    }
+
+    [McpServerTool(Name = "seq_list_metric_dimensions", ReadOnly = true, Title = "List Metric Dimensions")]
+    [Description("List the dimensions associated with a given metric.")]
+    [return: Description("Dimension accessor expressions, one per line.")]
+    public async Task<CallToolResult> ListDimensionsAsync(
+        [Description("The maximum number of metric dimensions to return.")]
+        [Range(1, 1000)]
+        int limit,
+        [Description("An ISO 8601 timestamp specifying the lower bound for the search range.")]
+        DateTimeOffset from,
+        [Description("The upper bound for the search range.")]
+        DateTimeOffset to,
+        [Description("A human-readable metric name, for example `hats-sold` or `http.request.duration`; omit to list dimensions for all metrics.")]
+        string? metric = null,
+        CancellationToken cancellationToken = default)
+    {
+        var dimensions = await connection.Metrics.ListDimensionsAsync(limit, metric, from.UtcDateTime, to.UtcDateTime,
+            session.DataToolCallTimeout, cancellationToken: cancellationToken);
+
+        var result = new StringWriter();
+        foreach (var dimension in dimensions)
+        {
+            await result.WriteLineAsync(dimension.Accessor);
+        }
+
+        return McpResults.SimpleText(result.ToString());
+    }
+
+    [McpServerTool(Name = "seq_list_metric_dimension_values", ReadOnly = true, Title = "List Metric Dimension Values")]
+    [Description("List the unique values present in a given metric dimension.")]
+    [return: Description("Dimension values in Seq native syntax, one per line.")]
+    public async Task<CallToolResult> ListDimensionValuesAsync(
+        [Description("The maximum number of values to return.")]
+        [Range(1, 1000)]
+        int limit,
+        [Description("An ISO 8601 timestamp specifying the lower bound for the search range.")]
+        DateTimeOffset from,
+        [Description("The upper bound for the search range.")]
+        DateTimeOffset to,
+        [Description("The dimension accessor, e.g. `cpu.mode`.")]
+        string? dimension = null,
+        CancellationToken cancellationToken = default)
+    {
+        var values = await connection.Metrics.ListDimensionValuesAsync(dimension, limit, from.UtcDateTime, to.UtcDateTime,
+            session.DataToolCallTimeout, cancellationToken: cancellationToken);
+
+        var result = new StringWriter();
+        foreach (var value in values)
+        {
+            NativeFormatter.WriteValue(result, value);
+            await result.WriteLineAsync();
+        }
+
+        return McpResults.SimpleText(result.ToString());
+    }
+}

--- a/src/SeqCli/Mcp/Tools/Metrics/MetricsTools.cs
+++ b/src/SeqCli/Mcp/Tools/Metrics/MetricsTools.cs
@@ -37,7 +37,7 @@ class MetricsTools(McpSession session, SeqConnection connection)
     [return: Description("Matching metric definitions.")]
     public async Task<MetricDefinition[]> SearchMetricsAsync(
         [Description("The maximum number of metric definitions to return.")]
-        [Range(1, 1000)]
+        [Range(1, 512)]
         int limit,
         [Description("A Seq search expression evaluated over metric names (`Keys(@Definitions)[?]`), descriptions " +
                      "(`@Definitions[?].description`), resource attributes, scope attributes, and raw samples.")]
@@ -55,7 +55,7 @@ class MetricsTools(McpSession session, SeqConnection connection)
                     "The predicate doesn't adequately constrain the search range. " +
                     "To avoid consuming excessive resources, add a time bound such as `@Timestamp >= now() - 4h`.");
             }
-
+            
             var strict = await connection.Expressions.ToStrictAsync(predicate, cancellationToken);
             if (strict.MatchedAsText)
             {

--- a/src/SeqCli/Mcp/Tools/Query/QueryTools.cs
+++ b/src/SeqCli/Mcp/Tools/Query/QueryTools.cs
@@ -1,0 +1,83 @@
+// Copyright © Datalust and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Seq.Api;
+using Seq.Api.Client;
+using Seq.Api.Model.Data;
+using Seq.Api.Model.Signals;
+using SeqCli.Output;
+using SeqCli.Signals;
+using Serilog;
+
+// ReSharper disable UnusedMember.Global
+
+namespace SeqCli.Mcp.Tools.Query;
+
+[McpServerToolType]
+class QueryTools(McpSession session, SeqConnection connection)
+{
+    [McpServerTool(Name = "seq_query", ReadOnly = true, Title = "Evaluate a Query over Logs, Spans, or Metric Samples")]
+    [Description("Evaluate a Seq query, producing tabular results. Use the `seq-search-and-query` " +
+                 "skill when calling this tool.")]
+    [return: Description("Query results and status information.")]
+    public async Task<CallToolResult> QueryAsync(
+        [Description("A Seq query language query.")]
+        string query,
+        [Description("A signal expression restricting the search space. Multiple " +
+                     "signals are intersected with commas, and unioned with tilde, for example, `signal-1,(signal-2~signal-3)`.")]
+        string? signal = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (query.Contains("from", StringComparison.OrdinalIgnoreCase) &&
+            (!query.Contains("where", StringComparison.OrdinalIgnoreCase) ||
+            !query.Contains("@Timestamp", StringComparison.OrdinalIgnoreCase) &&
+            !query.Contains("@Id", StringComparison.OrdinalIgnoreCase) &&
+            !query.Contains("@TraceId", StringComparison.OrdinalIgnoreCase)))
+        {
+            return McpResults.SimpleText("The query doesn't adequately constrain the search range (by `@Timestamp`, `@TraceId`, or `@Id`). " +
+                                    "To avoid consuming excessive resources, add a time bound such as `where @Timestamp >= now() - 1d`.", isError: true);
+        }
+
+        SignalExpressionPart? parsedSignalExpression = null;
+        if (!string.IsNullOrWhiteSpace(signal))
+            parsedSignalExpression = SignalExpressionParser.ParseExpression(signal);
+        
+        QueryResultPart result;
+        try
+        {
+            result = await connection.Data.TryQueryAsync(query, signal: parsedSignalExpression, timeout: session.DataToolCallTimeout, cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            if (ex.GetBaseException() is not OperationCanceledException)
+            {
+                Log.Error(ex, "Exception thrown during query execution");
+            }
+            
+            var error = ex.GetBaseException() is SeqApiException ? ex.GetBaseException().Message : ex.ToString();
+            return McpResults.SimpleText($"The query failed. {error}", isError: true);
+        }
+        
+        var output = new StringWriter();
+        NativeFormatter.WriteQueryResult(output, result);
+        return McpResults.SimpleText(output.ToString(), isError: !string.IsNullOrWhiteSpace(result.Error));
+    }
+}

--- a/src/SeqCli/Mcp/Tools/Query/QueryTools.cs
+++ b/src/SeqCli/Mcp/Tools/Query/QueryTools.cs
@@ -56,6 +56,13 @@ class QueryTools(McpSession session, SeqConnection connection)
                                     "To avoid consuming excessive resources, add a time bound such as `where @Timestamp >= now() - 1d`.", isError: true);
         }
 
+        if (query.Contains("series", StringComparison.OrdinalIgnoreCase) &&
+            query.Contains("@Definitions", StringComparison.OrdinalIgnoreCase))
+        {
+            return McpResults.SimpleText("Queries over the `@Definitions` property are not currently permitted. Use dedicated metrics-oriented " +
+                                         "tools or CLI commands to search for metric definitions.", isError: true);
+        }
+
         SignalExpressionPart? parsedSignalExpression = null;
         if (!string.IsNullOrWhiteSpace(signal))
             parsedSignalExpression = SignalExpressionParser.ParseExpression(signal);

--- a/src/SeqCli/Mcp/Tools/Search/SearchTools.cs
+++ b/src/SeqCli/Mcp/Tools/Search/SearchTools.cs
@@ -24,9 +24,7 @@ using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Seq.Api;
 using Seq.Api.Client;
-using Seq.Api.Model.Data;
 using Seq.Api.Model.Events;
-using Seq.Api.Model.Expressions;
 using Seq.Api.Model.Signals;
 using Seq.Syntax.Templates;
 using SeqCli.Mapping;
@@ -41,14 +39,23 @@ using NativeFormatter = SeqCli.Output.NativeFormatter;
 namespace SeqCli.Mcp.Tools.Search;
 
 [McpServerToolType]
-class SearchAndQueryToolType(McpSession session, SeqConnection connection)
+class SearchTools(McpSession session, SeqConnection connection)
 {
     const string ResultIdPropertyName = "__seqcli_ResultId";
     static readonly ExpressionTemplate SearchResultFormatter = new (
         $"{{{ResultIdPropertyName}}} [{{UtcDateTime(@t)}} {{{LevelMapping.SurrogateLevelProperty}}}] {{@m}}\n{{#if @x is not null}}{{Substring(ToString(@x), 0, 512)}}...\n{{#end}}"
     );
     
-    [McpServerTool(Name = "seq_search", ReadOnly = true, Title = "Search Events")]
+    [McpServerTool(Name = "seq_new_session", ReadOnly = true, Title = "Begin a new Search/Query Session")]
+    [Description("Call this before interacting with Seq tools for the first time (optimizes resource usage by clearing caches).")]
+    public Task NewSessionAsync(CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        session.Clear();
+        return Task.CompletedTask;
+    }
+
+    [McpServerTool(Name = "seq_search_events", ReadOnly = true, Title = "Search Events")]
     [Description("Search Seq for log events and spans matching given criteria. Each result is prefixed with " +
                  "a `result_id` of the form `R#####` which is valid in the current MCP session. Individual events can be " +
                  "viewed in full using the `seq_read_search_result` tool. Use the `seq-search-and-query` " +
@@ -71,36 +78,14 @@ class SearchAndQueryToolType(McpSession session, SeqConnection connection)
                 !predicate.Contains("@Id", StringComparison.OrdinalIgnoreCase) &&
                 !predicate.Contains("@TraceId", StringComparison.OrdinalIgnoreCase))
             {
-                return SimpleTextResult("The predicate doesn't adequately constrain the search range (by `@Timestamp`, `@TraceId`, or `@Id`). " +
+                return McpResults.SimpleText("The predicate doesn't adequately constrain the search range (by `@Timestamp`, `@TraceId`, or `@Id`). " +
                                    "To avoid consuming excessive resources, add a time bound such as `@Timestamp >= now() - 1d`.", isError: true);
             }
             
-            ExpressionPart strict;
-            try
-            {
-                strict = await connection.Expressions.ToStrictAsync(predicate, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                return new CallToolResult
-                {
-                    IsError = true,
-                    Content =
-                    [
-                        new TextContentBlock
-                        {
-                            Text = "The Seq API client failed while attempting to validate the search expression."
-                        },
-                        new TextContentBlock
-                        {
-                            Text = ex.ToString()
-                        }
-                    ],
-                };
-            }
+            var strict = await connection.Expressions.ToStrictAsync(predicate, cancellationToken);
             if (strict.MatchedAsText)
             {
-                return SimpleTextResult($"The search expression was rejected by the Seq server. {strict.ReasonIfMatchedAsText}",
+                return McpResults.SimpleText($"The search expression was rejected by the Seq server. {strict.ReasonIfMatchedAsText}",
                     isError: true);
             }
         }
@@ -112,7 +97,7 @@ class SearchAndQueryToolType(McpSession session, SeqConnection connection)
         var resultsLock = new Lock();
         string? error = null;
         var results = new List<EventEntity>();
-        var timeout = Task.Delay(TimeSpan.FromSeconds(45), cancellationToken);
+        var timeout = Task.Delay(session.DataToolCallTimeout, cancellationToken);
         using var cancelEnumerate = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var cancelEnumerateToken = cancelEnumerate.Token;
         var enumerate = Task.Run(async () =>
@@ -141,10 +126,9 @@ class SearchAndQueryToolType(McpSession session, SeqConnection connection)
 
                 lock (resultsLock)
                 {
-                    error = ex.GetBaseException() is SeqApiException ? ex.GetBaseException().Message : ex.ToString();
+                    error = ex.GetBaseException() is SeqApiException ? ex.GetBaseException().Message : "The Seq API call failed.";
                 }
             }
-
         }, cancellationToken);
 
         var completed = await Task.WhenAny(enumerate, timeout) == enumerate;
@@ -167,25 +151,15 @@ class SearchAndQueryToolType(McpSession session, SeqConnection connection)
         }
         else if (takenError != null)
         {
-            if (takenResults.Length == 0)
-            {
-                resultSetStatus = $"The search failed. {takenError}";
-            }
-            else
-            {
-                resultSetStatus = $"The search failed after retrieving {takenResults.Length} matching event(s). {takenError}";
-            }
+            resultSetStatus = takenResults.Length == 0 ? 
+                $"The search failed. {takenError}" : 
+                $"The search failed after retrieving {takenResults.Length} matching event(s). {takenError}";
         }
         else if (completed)
         {
-            if (takenResults.Length == 0)
-            {
-                resultSetStatus = "No events matched the search expression.";
-            }
-            else
-            {
-                resultSetStatus = $"Showing all {takenResults.Length} matching event(s).";
-            }
+            resultSetStatus = takenResults.Length == 0 ?
+                "No events matched the search expression." :
+                $"Showing all {takenResults.Length} matching event(s).";
         }
         else
         {
@@ -225,24 +199,24 @@ class SearchAndQueryToolType(McpSession session, SeqConnection connection)
     
     
     [McpServerTool(Name = "seq_read_search_result", ReadOnly = true, Title = "Read Full Event Details")]
-    [Description("Read the full details of an event appearing in `seq_search` results, including all property " +
+    [Description("Read the full details of an event appearing in `seq_search_events` results, including all property " +
                  "values and a complete stack trace (if present). The event is formatted precisely as a Seq syntax literal, " +
                  "using Seq's native data model.")]
     [return: Description("A Seq-native object literal representation of the event data.")]
     public Task<CallToolResult> ReadSearchResultJsonAsync(
-        [Description("The result id from the `seq_search` tool.")]
+        [Description("The result id from the `seq_search_events` tool.")]
         // ReSharper disable once InconsistentNaming
         string result_id)
     {
         if (!session.TryGetSearchResult(result_id, out var result, out var error))
         {
-            return Task.FromResult(SimpleTextResult(error, isError: true));
+            return Task.FromResult(McpResults.SimpleText(error, isError: true));
         }
 
         var resultText = new StringWriter();
         NativeFormatter.WriteEvent(resultText, result);
 
-        return Task.FromResult(SimpleTextResult(resultText.ToString()));
+        return Task.FromResult(McpResults.SimpleText(resultText.ToString()));
     }
 
     [McpServerTool(Name = "seq_inspect_result_schema", ReadOnly = true, Title = "Inspect Search Result Schema")]
@@ -253,86 +227,5 @@ class SearchAndQueryToolType(McpSession session, SeqConnection connection)
     public Task<string[]> InspectSchemaAsync(CancellationToken cancellationToken)
     {
         return Task.FromResult(session.EnumerateUserPropertyNames(cancellationToken).OrderBy(n => n).ToArray());
-    }
-
-    [McpServerTool(Name = "seq_query", ReadOnly = true, Title = "Evaluate a Query over Logs, Spans, or Metric Samples")]
-    [Description("Evaluate a Seq query, producing tabular results. Use the `seq-search-and-query` " +
-                 "skill when calling this tool.")]
-    [return: Description("Query results and status information.")]
-    public async Task<CallToolResult> QueryAsync(
-        [Description("A Seq query language query.")]
-        string query,
-        [Description("A signal expression restricting the search space. Multiple " +
-                     "signals are intersected with commas, and unioned with tilde, for example, `signal-1,(signal-2~signal-3)`.")]
-        string? signal = null,
-        CancellationToken cancellationToken = default)
-    {
-        if (query.Contains("from", StringComparison.OrdinalIgnoreCase) &&
-            (!query.Contains("where", StringComparison.OrdinalIgnoreCase) ||
-            !query.Contains("@Timestamp", StringComparison.OrdinalIgnoreCase) &&
-            !query.Contains("@Id", StringComparison.OrdinalIgnoreCase) &&
-            !query.Contains("@TraceId", StringComparison.OrdinalIgnoreCase)))
-        {
-            return SimpleTextResult("The query doesn't adequately constrain the search range (by `@Timestamp`, `@TraceId`, or `@Id`). " +
-                                    "To avoid consuming excessive resources, add a time bound such as `where @Timestamp >= now() - 1d`.", isError: true);
-        }
-
-        SignalExpressionPart? parsedSignalExpression = null;
-        if (!string.IsNullOrWhiteSpace(signal))
-            parsedSignalExpression = SignalExpressionParser.ParseExpression(signal);
-        
-        QueryResultPart result;
-        try
-        {
-            result = await connection.Data.TryQueryAsync(query, signal: parsedSignalExpression, cancellationToken: cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            if (ex.GetBaseException() is not OperationCanceledException)
-            {
-                Log.Error(ex, "Exception thrown during query execution");
-            }
-            
-            var error = ex.GetBaseException() is SeqApiException ? ex.GetBaseException().Message : ex.ToString();
-            return SimpleTextResult($"The query failed. {error}", isError: true);
-        }
-        
-        var output = new StringWriter();
-        NativeFormatter.WriteQueryResult(output, result);
-        return SimpleTextResult(output.ToString(), isError: !string.IsNullOrWhiteSpace(result.Error));
-    }
-    
-    [McpServerTool(Name = "seq_new_session", ReadOnly = true, Title = "Begin a new Search/Query Session")]
-    [Description("Call this before interacting with Seq tools for the first time (optimizes resource usage by clearing caches).")]
-    public Task NewSessionAsync(CancellationToken cancellationToken)
-    {
-        _ = cancellationToken;
-        session.Clear();
-        return Task.CompletedTask;
-    }
-
-    [McpServerTool(Name = "seq_list_signals", ReadOnly = true, Title = "List Signals", UseStructuredContent = true)]
-    [Description("List available signals. Use signals when searching and querying to efficiently work with well-known " +
-                 "event streams while dramatically improving response times.")]
-    public async Task<SignalSummary[]> ListSignalsAsync(CancellationToken cancellationToken)
-    {
-        return (await connection.Signals.ListAsync(shared: true, partial: true, cancellationToken: cancellationToken))
-            .Select(s => new SignalSummary { Id = s.Id, Title = s.Title })
-            .ToArray();
-    }
-    
-    static CallToolResult SimpleTextResult(string resultText, bool isError = false)
-    {
-        return new CallToolResult
-        {
-            IsError = isError,
-            Content =
-            [
-                new TextContentBlock
-                {
-                    Text = resultText
-                }
-            ]
-        };
     }
 }

--- a/src/SeqCli/Mcp/Tools/Signals/SignalSummary.cs
+++ b/src/SeqCli/Mcp/Tools/Signals/SignalSummary.cs
@@ -14,7 +14,7 @@
 
 using System.ComponentModel;
 
-namespace SeqCli.Mcp.Tools.Search;
+namespace SeqCli.Mcp.Tools.Signals;
 
 [Description("A signal is a saved, indexed filter over log events and spans.")]
 class SignalSummary

--- a/src/SeqCli/Mcp/Tools/Signals/SignalTools.cs
+++ b/src/SeqCli/Mcp/Tools/Signals/SignalTools.cs
@@ -1,0 +1,38 @@
+// Copyright © Datalust and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+using Seq.Api;
+
+// ReSharper disable UnusedMember.Global
+
+namespace SeqCli.Mcp.Tools.Signals;
+
+[McpServerToolType]
+class SignalTools(SeqConnection connection)
+{
+    [McpServerTool(Name = "seq_list_signals", ReadOnly = true, Title = "List Signals", UseStructuredContent = true)]
+    [Description("List available signals. Use signals when searching and querying to efficiently work with well-known " +
+                 "event streams while dramatically improving response times.")]
+    public async Task<SignalSummary[]> ListSignalsAsync(CancellationToken cancellationToken)
+    {
+        return (await connection.Signals.ListAsync(shared: true, partial: true, cancellationToken: cancellationToken))
+            .Select(s => new SignalSummary { Id = s.Id, Title = s.Title })
+            .ToArray();
+    }
+}

--- a/src/SeqCli/Output/NativeFormatter.cs
+++ b/src/SeqCli/Output/NativeFormatter.cs
@@ -255,7 +255,6 @@ static partial class NativeFormatter
                         output.Write(' ');
                     output.Write(heading);
                 }
-                output.WriteLine();
             }
             else
             {

--- a/src/SeqCli/Output/OutputFormat.cs
+++ b/src/SeqCli/Output/OutputFormat.cs
@@ -172,11 +172,12 @@ sealed class OutputFormat
         }
         else if (Text)
         {
-            Console.WriteLine(value.ToString());
+            Console.WriteLine(Stringify(value));
         }
         else
         {
-            throw new InvalidOperationException("Native formatting not supported for raw objects.");
+            NativeFormatter.WriteValue(Console.Out, value);
+            Console.WriteLine();
         }
     }
 
@@ -208,7 +209,7 @@ sealed class OutputFormat
         }
         else
         {
-            CsvWriter.WriteQueryResult(result, Theme, Console.Out);
+            CsvWriter.WriteQueryResult(result, Stringify, Theme, Console.Out);
         }
     }
 
@@ -296,5 +297,23 @@ sealed class OutputFormat
             default:
                 return new ScalarValue(value);
         }
+    }
+    
+    static string Stringify(object? value)
+    {
+        return value switch
+        {
+            null => "null",
+            true => "true",
+            false => "false",
+            decimal
+                or double or float or Half
+                or byte or ushort or uint or ulong or UInt128 or
+                sbyte or short or int or long
+                or Int128 => ((IFormattable)value).ToString(null, CultureInfo.InvariantCulture),
+            DateTime dt => dt.ToString("o"),
+            DateTimeOffset dto => dto.ToString("o"),
+            _ => value.ToString() ?? ""
+        };
     }
 }

--- a/src/SeqCli/Output/OutputFormat.cs
+++ b/src/SeqCli/Output/OutputFormat.cs
@@ -156,7 +156,9 @@ sealed class OutputFormat
                 }
             });
             
-            var jo = value is ICollection and not IDictionary ? (JToken)JArray.FromObject(value, settings) : JObject.FromObject(value, settings);
+            var jo = value is ICollection and not (IDictionary or JToken) ?
+                (JToken)JArray.FromObject(value, settings) :
+                JObject.FromObject(value, settings);
 
             // Using the same method of JSON colorization as above
 

--- a/src/SeqCli/Output/OutputFormat.cs
+++ b/src/SeqCli/Output/OutputFormat.cs
@@ -43,6 +43,15 @@ sealed class OutputFormat
     readonly bool _forceColor;
     readonly Logger _formatter;
 
+    readonly JsonSerializer _serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings
+    {
+        DateParseHandling = DateParseHandling.None,
+        Converters =
+        {
+            new StringEnumConverter()
+        }
+    });
+
     public const string DefaultOutputTemplate =
         "[{Timestamp:o} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}";
 
@@ -109,12 +118,7 @@ sealed class OutputFormat
 
         var jo = JObject.FromObject(
             entity,
-            JsonSerializer.CreateDefault(new JsonSerializerSettings {
-                DateParseHandling = DateParseHandling.None,
-                Converters = {
-                    new StringEnumConverter()
-                }
-            }));
+            _serializer);
             
         if (Json)
         {
@@ -147,18 +151,9 @@ sealed class OutputFormat
             
         if (Json)
         {
-            var settings = JsonSerializer.CreateDefault(new JsonSerializerSettings
-            {
-                DateParseHandling = DateParseHandling.None,
-                Converters =
-                {
-                    new StringEnumConverter()
-                }
-            });
-            
             var jo = value is ICollection and not (IDictionary or JToken) ?
-                (JToken)JArray.FromObject(value, settings) :
-                JObject.FromObject(value, settings);
+                (JToken)JArray.FromObject(value, _serializer) :
+                JObject.FromObject(value, _serializer);
 
             // Using the same method of JSON colorization as above
 

--- a/src/SeqCli/Output/OutputFormat.cs
+++ b/src/SeqCli/Output/OutputFormat.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -146,14 +147,16 @@ sealed class OutputFormat
             
         if (Json)
         {
-            var jo = JObject.FromObject(
-                value,
-                JsonSerializer.CreateDefault(new JsonSerializerSettings {
-                    DateParseHandling = DateParseHandling.None,
-                    Converters = {
-                        new StringEnumConverter()
-                    }
-                }));
+            var settings = JsonSerializer.CreateDefault(new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.None,
+                Converters =
+                {
+                    new StringEnumConverter()
+                }
+            });
+            
+            var jo = value is ICollection and not IDictionary ? (JToken)JArray.FromObject(value, settings) : JObject.FromObject(value, settings);
 
             // Using the same method of JSON colorization as above
 

--- a/src/SeqCli/SeqCli.csproj
+++ b/src/SeqCli/SeqCli.csproj
@@ -19,19 +19,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="..\..\asset\SeqCli.ico" Link="SeqCli.ico" />
-    <Content Include="Attribution\*.txt;..\..\LICENSE">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Cli\Commands\Bench\BenchCases.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Sample\Templates\*.template">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Skills\Resources\**\*" Link="Skills\%(RecursiveDir)%(Filename)%(Extension)">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="..\..\asset\SeqCli.ico" Link="SeqCli.ico" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\LICENSE" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Attribution\*.txt" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Cli\Commands\Bench\BenchCases.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Sample\Templates\*.template" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Skills\Resources\**\*" Link="Skills\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="1.3.0" />

--- a/src/SeqCli/Skills/Resources/seq-search-and-query/SKILL.md
+++ b/src/SeqCli/Skills/Resources/seq-search-and-query/SKILL.md
@@ -20,16 +20,15 @@ session MUST begin with the following steps:
 
 1. Check for relevant signals. Many event filtering problems have already been solved and the resulting filters saved as efficiently indexed signals.
 2. Retrieve a sample of relevant events. Use signals identified in (1) where appropriate, event search and query supports them.
-3. Confirm the schema of the search results (important!).
+3. Proactively confirm the schema of the search results using appropriate tools.
 4. Inspect a subset of relevant events in full.
 5. Determine how the correctness of any conclusions can be verified using real diagnostic data.
 
-DO NOT skip steps just because early results suggest a quicker path to a solution: this is often the path to being
-confidently wrong!
+DO NOT skip steps just because early results suggest a quicker path to a solution: this is the path to being confidently wrong!
 
 ## Event Data Model
 
-All events stored in Seq use the same data model. Spans are only distinguished from log events by the presence of the
+All events stored in Seq use the same data model. Spans are distinguished from log events by the presence of the
 `@Start` property. The following built-in properties are supported.
 
 | Built in property name | Type | Description |
@@ -133,7 +132,7 @@ These built-in functions and operators work with individual values. See Aggregat
 
 ## Aggregate Functions
 
-`select` queries (see grammar below) have access to the following aggregate functions.
+`select` queries have access to the following aggregate functions.
 
 | Aggregate function signature | Description | Example |
 |---|---|---|
@@ -149,20 +148,9 @@ These built-in functions and operators work with individual values. See Aggregat
 | `max(expr: number): number` | Computes the largest value for `expr`. | `max(Elapsed / 1000)` |
 | `mean(expr: number): number` | Computes the arithmetic mean (average) of `expr`, i.e. `sum(expr) / count(expr)`. Events where the expression is `null` or not numeric are ignored and do not contribute to the final result. | `mean(ItemCount)` |
 | `percentile(expr: number, p: number [, err: number?]): number` | Given a percentage `p`, calculates the value of `expr` at or below which `p` percent of the results fall. The optional `err` parameter specifies the maximum permissible error fraction. Higher error values reduce compute and memory resource consumption. | `percentile(ResponseTime, 95 , 0.01)` |
+| `phist(expr: number, count: number, p: number): number` | Bucketed (histogram) percentile. | |
 | `sum(expr: number): number` | Calculates the sum of `expr`. Non-numeric values are ignored. | `sum(ItemsOrdered)` |
 | `top(expr: any, n: number): rowset` | Select the first `n` values of `expr`. The `top` function cannot appear with any other aggregate functions. | `top(StatusCode, 5)` |
-
-## Schema
-
-The `stream` source contains log events and spans. The `series` source contains
-metric samples (not discussed in this skill).
-
-Seq servers are compatible with a vast array of data sources. They may use a mix of OpenTelemetry and
-framework/ecosystem-specific property names, and may do so inconsistently.
-
-When available, **always use the MCP schema tool** to inspect the actual properties appearing on search results. In
-particular, don't skip schema checks early in investigations just because you've seen a few events. Events are
-inconsistent! Use the schema tool at least once just to be safe.
 
 ## Base Grammar
 
@@ -291,7 +279,7 @@ Keywords are case-insensitive.
 | `@Timestamp >= Now() - 10m` | Match events that occurred in the last ten minutes. |
 | `@TraceId = '0af7651916cd43dd8448eb211c80319c'` | Match all events (both spans and log events) belonging to the given trace. |
 | `Has(@Start)` | Match all spans (excludes log events). |
-| `@Message like '%overflow%' ci or @Exception like '%overflow%' ci` | Given a piece of text, find events with that text in their message or exception/stack trace. |
+| `@Message like '%overflow%' ci or @Exception like '%overflow%' ci` | Given a piece of text, find events with that text in their message or exception/stack trace, using case-insensitive comparisons. |
 | `Items[?] = 'coffee'` | Wildcard "any" - check if element appears in collection. |
 | `ToIsoString(@Timestamp)` | Render a numeric timestamp as ISO-8601. |
 | `ToTimeString(@Elapsed)` | Render a numeric duration value as a human-readable time string. |
@@ -299,7 +287,7 @@ Keywords are case-insensitive.
 | `@TraceId = '...' and @SpanId = '...' and Has(@Start)` | Retrieve a specific trace span using a search expression |
 | `@Level like 'err%' ci` | Perform a case-insensitive prefix search |
 
-## Example Queries
+## Query Example
 
 Grouped query with ordering:
 
@@ -350,6 +338,15 @@ having spans > 50                              -- filter groups by the select al
 order by p95_ms desc                           -- order by a selected aggregate's alias
 limit 100
 ```
+
+## User-Defined Property Schema
+
+Seq servers are compatible with a vast array of data sources. They may use a mix of OpenTelemetry and
+framework/ecosystem-specific property names, and may do so inconsistently.
+
+When available, **always use the MCP schema tool** to inspect the actual properties appearing on search results. In
+particular, don't skip schema checks early in investigations just because you've seen a few events. Events are
+inconsistent! Use the schema tool at least once just to be safe.
 
 ## Gotchas
 

--- a/src/SeqCli/Skills/Resources/working-with-seq-metrics/SKILL.md
+++ b/src/SeqCli/Skills/Resources/working-with-seq-metrics/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: seq-search-and-query
+description: Query metrics stored in Seq. Use this when monitoring data or diagnostic metric information is required.
+license: Apache-2.0
+metadata:
+ author: Datalust and Contributors
+---
+
+Seq stores OpenTelemetry metric samples in the `series` data source, which is a columnar data store.
+
+Metrics are accessed **strictly** using the following workflow:
+
+ 1. Search for metric definitions
+ 2. Note the _kind_ of any relevant metrics
+ 3. List the dimensions that apply to the metric
+ 4. Optionally, list the values present in dimensions of interest
+ 5. Run aggregate queries on metric samples using metric names, kinds, and dimensions discovered in the previous steps
+
+**NEVER** query the `series` data source for metric definitions directly. **ALWAYS** use the dedicated definition search tools instead.
+
+**NEVER** query the `series` data source directly for available dimensions. **ALWAYS** use the dedicated dimension listing tools instead.
+
+**NEVER** list dimension values using the `distinct` aggregation. **ALWAYS** use the dedicated dimension value listing tools instead.
+
+**NEVER** evaluate projection queries against the `series` data source. This risks impacting the performance of Seq for other
+users and workloads.
+
+## Searching for Metric Definitions
+
+Metric samples carry an `@Definitions` object where metric names are keys into the object. Under each metric name key,
+a `description` property is available.
+
+Search for metrics with `cpu` in their **name** or **description** (case-insensitive):
+
+```
+Keys(@Definitions)[?] like '%cpu%' ci or @Definitions[?].description like '%cpu%' ci
+```
+
+Search for metrics reported by a specific service:
+
+```
+@Resource.service.name = 'accounting'
+```
+
+If metrics searches report syntax errors, you MUST load the `seq-search-and-query` skill.
+
+## Listing Dimensions
+
+Determine the dimensions that apply to a metric using the dimensions MCP tool or the `seqcli metrics dimensions` CLI
+command.
+
+## Listing Unique Dimension Values
+
+DO NOT use `distinct` to query for the values of a metric dimension like `@Resource.service.name`. Always use the
+dimension values MCP tool or `seqcli metrics dimensionvalues` CLI command.
+
+## Querying Metric Samples
+
+Metrics returned from definition searches are tagged with a kind:
+
+* `Sum` - counter with delta aggregation temporality
+* `Gauge` - gauge or counter with cumulative aggregation temporality
+* `Fixed` - histogram with fixed buckets
+* `Exponential` - histogram with exponential buckets
+
+Correctly querying metric sample data from `series` relies on knowing the metric kind.
+
+### `Sum` Query Example
+
+```
+select sum(app_product_review_counter) as reviews_submitted
+from series
+where Has(app_product_review_counter)
+  and @Timestamp >= now() - 15m
+group by time(1m)
+```
+
+### `Gauge` Query Examples
+
+```
+select max(dotnet.gc.last_collection.heap.size) as heap_size_bytes
+from series 
+where (Has(dotnet.gc.last_collection.heap.size))
+  and @Resource.service.name = 'accounting'
+  and @Timestamp >= now() - 15m
+group by time(1m), @Resource.service.instance.id
+having heap_size_bytes > 5000000
+limit 100
+```
+
+### `Fixed` Query Examples
+
+HTTP request timing percentiles:
+
+```
+select
+  phist(coalesce((bucket.from + bucket.to) / 2, bucket.from, bucket.to), bucket.count, 95) as p95,
+  phist(coalesce((bucket.from + bucket.to) / 2, bucket.from, bucket.to), bucket.count, 99) as p99
+from series lateral unnest(http.server.request.duration.buckets) as bucket 
+where Has(http.server.request.duration.buckets)
+  and @Resource.service.name = 'cart'
+  and @Scope.name = 'Microsoft.AspNetCore.Hosting'
+  and @Timestamp >= now() - 15m
+group by time(1m)
+limit 100
+```
+
+HTTP request througput (counts):
+
+```
+select sum(http.server.request.duration.count) as request_throughput
+from series
+where Has(http.server.request.duration.buckets)
+  and @Resource.service.name = 'cart'
+  and @Scope.name = 'Microsoft.AspNetCore.Hosting'
+  and @Timestamp >= now() - 15m
+group by time(1m)
+limit 100
+```
+
+Maximium HTTP request body size:
+
+```
+select max(http.server.request.body.size.max) as max_body_size
+from series 
+where Has(http.server.request.body.size.buckets)
+  and @Resource.service.name = 'shipping'
+  and @Scope.name = 'opentelemetry-instrumentation-actix-web'
+  and @Timestamp >= now() - 15m
+group by time(1m)
+limit 100
+```
+
+## Gotchas
+
+- If metrics that should be _counters_ show up as _gauges_, aggregation temporality is likely to be misconfigured: danger! This can produce wildly inaccurate results if not detected.
+- When writing queries that aggregate metric samples, `where Has(<metric name>)` must always be included to avoid row count skew.
+- Do NOT use `select disctint(<dimension>)` with metric dimensions: aways use the optimized dimension value searches exposed by `seqcli` or the MCP tools.
+- Group keys are automatically included in result rowsets and **must not** be explicitly included in the `select` list.
+- To order by group keys, apply an alias with `group by <expr> as <alias>` and use `order by <alias>`. Never add the group key to the `select` list, this will fail.

--- a/test/SeqCli.EndToEnd/Mcp/McpMetricsBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Mcp/McpMetricsBasicsTestCase.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace SeqCli.EndToEnd.Mcp;
 
-//[CliTestCase(MinimumApiVersion = "2026.1.0")]
+[CliTestCase(MinimumApiVersion = "2026.1.0")]
 public class McpMetricsBasicsTestCase : McpToolTestCase
 {
     [UsedImplicitly]

--- a/test/SeqCli.EndToEnd/Mcp/McpMetricsBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Mcp/McpMetricsBasicsTestCase.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using ModelContextProtocol.Client;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+#nullable enable
+
+namespace SeqCli.EndToEnd.Mcp;
+
+//[CliTestCase(MinimumApiVersion = "2026.1.0")]
+public class McpMetricsBasicsTestCase : McpToolTestCase
+{
+    [UsedImplicitly]
+    record MetricDefinition(string Name, string Kind, string? Unit, string? Description);
+
+    protected override async Task ExecuteAsync(SeqConnection connection, ILogger logger, McpClient client)
+    {
+        await DirectIngestion.IngestClef(connection, "'a': 1, 'b': 2, '@d': {'a': {'kind': 'Sum', 'description': 'xyz'}}");
+        await DirectIngestion.IngestClef(connection, "'a': 1, 'c': 3, 'd': 4, '@d': {'a': {'kind': 'Sum','description': 'xyz'}}");
+        await DirectIngestion.IngestClef(connection, "'a': 1, 'b': 5, 'e': 6, '@d': {'a': {'kind': 'Sum','description': 'xyz'}, 'e': {'kind': 'Sum', 'description': 'ghi'}}");
+
+        var allMetrics = AssertStructuredResult<MetricDefinition[]>(await client.CallToolAsync(
+            "seq_search_metric_definitions",
+            new Dictionary<string, object?> { ["limit"] = 100 }));
+        Assert.Equal(2, allMetrics.Length);
+
+        var groupedByB = AssertStructuredResult<MetricDefinition[]>(await client.CallToolAsync(
+            "seq_search_metric_definitions",
+            new Dictionary<string, object?> { ["limit"] = 100, ["groups"] = (string[])["b"] }));
+        Assert.Equal(4, groupedByB.Length);
+
+        var filteredByDescription = AssertStructuredResult<MetricDefinition[]>(await client.CallToolAsync(
+            "seq_search_metric_definitions",
+            new Dictionary<string, object?>
+            {
+                ["limit"] = 100,
+                ["predicate"] = "\"xyz\" and @Timestamp >= Now() - 1d",
+                ["groups"] = (string[])["b"]
+            }));
+        Assert.Equal(3, filteredByDescription.Length);
+
+        var from = DateTimeOffset.UtcNow.AddDays(-1).ToString("o");
+        var to = DateTimeOffset.UtcNow.AddDays(1).ToString("o");
+        var allDimensions = TextLines(AssertTextResult(await client.CallToolAsync(
+            "seq_list_metric_dimensions",
+            new Dictionary<string, object?> { ["limit"] = 100, ["from"] = from, ["to"] = to })));
+        Assert.All(["b", "c", "d"], name => Assert.Contains(name, allDimensions));
+
+        var dimensionsForE = AssertTextResult(await client.CallToolAsync(
+            "seq_list_metric_dimensions",
+            new Dictionary<string, object?> { ["limit"] = 100, ["from"] = from, ["to"] = to, ["metric"] = "e" }));
+        Assert.Equal("b", dimensionsForE.Trim());
+
+        var bValues = TextLines(AssertTextResult(await client.CallToolAsync(
+            "seq_list_metric_dimension_values",
+            new Dictionary<string, object?> { ["limit"] = 100, ["from"] = from, ["to"] = to, ["dimension"] = "b" })));
+        Assert.All(["2", "5"], value => Assert.Contains(value, bValues));
+
+        var unbounded = await client.CallToolAsync(
+            "seq_search_metric_definitions",
+            new Dictionary<string, object?> { ["limit"] = 100, ["predicate"] = "\"xyz\"" });
+        Assert.True(unbounded.IsError ?? false);
+    }
+
+    static string[] TextLines(string text)
+    {
+        return text.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+}

--- a/test/SeqCli.EndToEnd/Mcp/McpSessionBasicsTestCase.cs
+++ b/test/SeqCli.EndToEnd/Mcp/McpSessionBasicsTestCase.cs
@@ -31,7 +31,7 @@ public class McpSessionBasicsTestCase : McpToolTestCase
 
         var predicate = $"RunId = '{runId}' and Customer.Tier = 'gold' and @Timestamp >= Now() - 1d";
         var searchResult = AssertTextResult(await client.CallToolAsync(
-            "seq_search",
+            "seq_search_events",
             new Dictionary<string, object> { ["limit"] = 10, ["predicate"] = predicate }));
         var resultIds = OrderedSearchResultIds(searchResult);
         Assert.Equal(orders.Count(o => o.Customer.Tier == "gold"), resultIds.Length);

--- a/test/SeqCli.EndToEnd/Mcp/McpSignalUsageTestCase.cs
+++ b/test/SeqCli.EndToEnd/Mcp/McpSignalUsageTestCase.cs
@@ -12,6 +12,7 @@ namespace SeqCli.EndToEnd.Mcp;
 // ReSharper disable once UnusedType.Global
 public class McpSignalUsageTestCase : McpToolTestCase
 {
+    // ReSharper disable once NotAccessedPositionalProperty.Local
     record SignalSummary(string Id, string Title);
 
     // Default signals included in every Seq installation.
@@ -56,7 +57,7 @@ public class McpSignalUsageTestCase : McpToolTestCase
     static async Task<int> CountSearchResultsAsync(McpClient client, string predicate, string signal)
     {
         var searchResult = AssertTextResult(await client.CallToolAsync(
-            "seq_search",
+            "seq_search_events",
             new Dictionary<string, object> { ["limit"] = 10, ["predicate"] = predicate, ["signal"] = signal }));
         return OrderedSearchResultIds(searchResult).Length;
     }

--- a/test/SeqCli.EndToEnd/Mcp/McpToolTestCase.cs
+++ b/test/SeqCli.EndToEnd/Mcp/McpToolTestCase.cs
@@ -50,7 +50,7 @@ public abstract partial class McpToolTestCase : ICliTestCase
         // Tools returning non-object values have them wrapped in a `result` property by the MCP
         // SDK, because the protocol requires `structuredContent` to be an object.
         var result = callToolResult.StructuredContent.Value.GetProperty("result");
-        return JsonSerializer.Deserialize<T>(result, JsonSerializerOptions.Web)!;
+        return result.Deserialize<T>(JsonSerializerOptions.Web)!;
     }
 
     protected static string[] OrderedSearchResultIds(string searchResult)

--- a/test/SeqCli.EndToEnd/Mcp/McpToolTestCase.cs
+++ b/test/SeqCli.EndToEnd/Mcp/McpToolTestCase.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using Seq.Api;
@@ -15,6 +16,7 @@ namespace SeqCli.EndToEnd.Mcp;
 /// Base class for test cases exercising the tools provided by <c>seqcli mcp run</c>. The MCP server
 /// is spawned over stdio and supplied to the subclass as a connected <see cref="McpClient"/>.
 /// </summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
 public abstract partial class McpToolTestCase : ICliTestCase
 {
     public async Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)

--- a/test/SeqCli.EndToEnd/Metrics/MetricsCliBasics.cs
+++ b/test/SeqCli.EndToEnd/Metrics/MetricsCliBasics.cs
@@ -32,7 +32,7 @@ class MetricsCliBasics: ICliTestCase
         Assert.Equal(0, runner.Exec("metrics dimensions", "--metric e"));
         Assert.Equal("b", runner.LastRunProcess!.Output.Trim());
         
-        Assert.Equal(0, runner.Exec("metrics dimension", "--accessor b"));
+        Assert.Equal(0, runner.Exec("metrics dimensionvalues", "--accessor b"));
         var bValues = runner.LastRunProcess!.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
         Assert.All(["2", "5"], value => Assert.Contains(bValues, l => l.Trim() == value));
     }

--- a/test/SeqCli.EndToEnd/Metrics/MetricsCliBasics.cs
+++ b/test/SeqCli.EndToEnd/Metrics/MetricsCliBasics.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Seq.Api;
+using SeqCli.EndToEnd.Support;
+using Serilog;
+using Xunit;
+
+#nullable enable
+
+namespace SeqCli.EndToEnd.Metrics;
+
+[CliTestCase(MinimumApiVersion = "2026.1.0")]
+class MetricsCliBasics: ICliTestCase
+{
+    public async Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
+    {
+        await IngestClef(connection, "'a': 1, 'b': 2, '@d': {'a': {'kind': 'Sum', 'description': 'xyz'}}");
+        await IngestClef(connection, "'a': 1, 'c': 3, 'd': 4, '@d': {'a': {'kind': 'Sum','description': 'xyz'}}");
+        await IngestClef(connection, "'a': 1, 'b': 5, 'e': 6, '@d': {'a': {'kind': 'Sum','description': 'xyz'}, 'e': {'kind': 'Sum', 'description': 'ghi'}}");
+        
+        Assert.Equal(2, SearchResultLines(runner).Count());
+        Assert.Equal(4, SearchResultLines(runner, groups: ["b"]).Count());
+        Assert.Equal(3, SearchResultLines(runner, filter: "\"xyz\"", groups: ["b"]).Count());
+        
+        Assert.Equal(0, runner.Exec("metrics dimensions"));
+        var allDimensions = runner.LastRunProcess!.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        Assert.All(["b", "c", "d"], name => Assert.Contains(allDimensions, l => l.Trim() == name));
+
+        Assert.Equal(0, runner.Exec("metrics dimensions", "--metric e"));
+        Assert.Equal("b", runner.LastRunProcess!.Output.Trim());
+        
+        Assert.Equal(0, runner.Exec("metrics dimension", "--accessor b"));
+        var bValues = runner.LastRunProcess!.Output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        Assert.All(["2", "5"], value => Assert.Contains(bValues, l => l.Trim() == value));
+    }
+
+    static IEnumerable<string> SearchResultLines(CliCommandRunner runner, string? filter = null, string[]? groups = null)
+    {
+        var args = "";
+        if (filter != null)
+            args += $"--filter=\"{filter.Replace("\"", "\\\"")}\"";
+        foreach (var group in groups ?? [])
+            args += $" --group=\"{group.Replace("\"", "\\\"")}\"";
+        
+        Assert.Equal(0, runner.Exec("metrics search", args));
+        var reader = new StringReader(runner.LastRunProcess!.Output);
+        var skippedHeading = false;
+        while (reader.ReadLine() is { } line)
+        {
+            if (!skippedHeading)
+            {
+                skippedHeading = true;
+            }
+            else
+            {
+                yield return line!;
+            }
+        }
+    }
+
+    static async Task IngestClef(SeqConnection connection, string fields)
+    {
+        var prefix = $"{{\"@t\":\"{DateTime.UtcNow:o}\",";
+        const string suffix = "}";
+        var content = new StringContent($"{prefix}{fields.Replace("'", "\"")}{suffix}");
+        var response = await connection.Client.HttpClient.PostAsync("ingest/clef", content);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+}

--- a/test/SeqCli.EndToEnd/Metrics/MetricsCliBasics.cs
+++ b/test/SeqCli.EndToEnd/Metrics/MetricsCliBasics.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Seq.Api;
 using SeqCli.EndToEnd.Support;
@@ -19,9 +17,9 @@ class MetricsCliBasics: ICliTestCase
 {
     public async Task ExecuteAsync(SeqConnection connection, ILogger logger, CliCommandRunner runner)
     {
-        await IngestClef(connection, "'a': 1, 'b': 2, '@d': {'a': {'kind': 'Sum', 'description': 'xyz'}}");
-        await IngestClef(connection, "'a': 1, 'c': 3, 'd': 4, '@d': {'a': {'kind': 'Sum','description': 'xyz'}}");
-        await IngestClef(connection, "'a': 1, 'b': 5, 'e': 6, '@d': {'a': {'kind': 'Sum','description': 'xyz'}, 'e': {'kind': 'Sum', 'description': 'ghi'}}");
+        await DirectIngestion.IngestClef(connection, "'a': 1, 'b': 2, '@d': {'a': {'kind': 'Sum', 'description': 'xyz'}}");
+        await DirectIngestion.IngestClef(connection, "'a': 1, 'c': 3, 'd': 4, '@d': {'a': {'kind': 'Sum','description': 'xyz'}}");
+        await DirectIngestion.IngestClef(connection, "'a': 1, 'b': 5, 'e': 6, '@d': {'a': {'kind': 'Sum','description': 'xyz'}, 'e': {'kind': 'Sum', 'description': 'ghi'}}");
         
         Assert.Equal(2, SearchResultLines(runner).Count());
         Assert.Equal(4, SearchResultLines(runner, groups: ["b"]).Count());
@@ -61,14 +59,5 @@ class MetricsCliBasics: ICliTestCase
                 yield return line!;
             }
         }
-    }
-
-    static async Task IngestClef(SeqConnection connection, string fields)
-    {
-        var prefix = $"{{\"@t\":\"{DateTime.UtcNow:o}\",";
-        const string suffix = "}";
-        var content = new StringContent($"{prefix}{fields.Replace("'", "\"")}{suffix}");
-        var response = await connection.Client.HttpClient.PostAsync("ingest/clef", content);
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 }

--- a/test/SeqCli.EndToEnd/Properties/launchSettings.json
+++ b/test/SeqCli.EndToEnd/Properties/launchSettings.json
@@ -15,6 +15,10 @@
     "SeqCli.EndToEnd (datalust/seq:preview)": {
       "commandName": "Project",
       "commandLineArgs": "--docker-server --pre"
+    },
+    "SeqCli.EndToEnd (McpMetrics*)": {
+      "commandName": "Project",
+      "commandLineArgs": "--docker-server --pre McpMetrics"
     }
   }
 }

--- a/test/SeqCli.EndToEnd/Support/DirectIngestion.cs
+++ b/test/SeqCli.EndToEnd/Support/DirectIngestion.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Seq.Api;
+using Xunit;
+
+namespace SeqCli.EndToEnd.Support;
+
+public static class DirectIngestion
+{
+    // In questionable taste, but very handy, `fields` carries the comma-separated `'key': value` pairs massaged
+    // into JSON by replacing `'` with `"`.
+    public static async Task IngestClef(SeqConnection connection, string fields)
+    {
+        var prefix = $"{{\"@t\":\"{DateTime.UtcNow:o}\",";
+        const string suffix = "}";
+        var content = new StringContent($"{prefix}{fields.Replace("'", "\"")}{suffix}");
+        var response = await connection.Client.HttpClient.PostAsync("ingest/clef", content);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+}

--- a/test/SeqCli.Tests/SeqCli.Tests.csproj
+++ b/test/SeqCli.Tests/SeqCli.Tests.csproj
@@ -9,6 +9,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.ML.Tokenizers" Version="2.0.0" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SeqCli\SeqCli.csproj" />

--- a/test/SeqCli.Tests/Skills/SkillComplexityTests.cs
+++ b/test/SeqCli.Tests/Skills/SkillComplexityTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.ML.Tokenizers;
+using Xunit;
+
+namespace SeqCli.Tests.Skills;
+
+public class SkillComplexityTests
+{
+    public static IEnumerable<object[]> FindPackagedSkills()
+    {
+        var sourcePath = Path.Combine(AppContext.BaseDirectory, "Skills");
+
+        foreach (var skillSourceDirectory in Directory.EnumerateDirectories(sourcePath))
+        {
+            var skillName = Path.GetFileName(skillSourceDirectory);
+            yield return [skillName, Path.Combine(skillSourceDirectory, "SKILL.md")];
+        }        
+    }
+    
+    [Theory]
+    [MemberData(nameof(FindPackagedSkills))]
+    public void SkillIsWithinRecommendedSizeLimits(string skillName, string path)
+    {
+        const int recommendedMaxLines = 500, recommendedMaxTokens = 5000;
+        
+        // Still some work to do, here.
+        const int allowedMaxTokens = recommendedMaxTokens + 4000;
+        
+        var lines = File.ReadAllLines(path);
+        Assert.True(lines.Length < recommendedMaxLines, $"`{skillName}/SKILL.md` line count {lines.Length} exceeds the recommended {recommendedMaxLines}-line limit");
+
+        const string benchmarkModelName = "gpt-5";
+        var tokenizer = TiktokenTokenizer.CreateForModel(benchmarkModelName);
+        var tokenCount = tokenizer.CountTokens(File.ReadAllText(path));
+        Assert.True(tokenCount < allowedMaxTokens, $"`{skillName}/SKILL.md` token count {tokenCount} ({benchmarkModelName}) exceeds {allowedMaxTokens} ({recommendedMaxTokens} is the recommended limit)");
+    }
+}

--- a/test/SeqCli.Tests/Skills/SkillComplexityTests.cs
+++ b/test/SeqCli.Tests/Skills/SkillComplexityTests.cs
@@ -26,10 +26,11 @@ public class SkillComplexityTests
         const int recommendedMaxLines = 500, recommendedMaxTokens = 5000;
         
         // Still some work to do, here.
-        const int allowedMaxTokens = recommendedMaxTokens + 4000;
+        const int allowedMaxLines = recommendedMaxLines + 100,
+            allowedMaxTokens = recommendedMaxTokens + 4000;
         
         var lines = File.ReadAllLines(path);
-        Assert.True(lines.Length < recommendedMaxLines, $"`{skillName}/SKILL.md` line count {lines.Length} exceeds the recommended {recommendedMaxLines}-line limit");
+        Assert.True(lines.Length < allowedMaxLines, $"`{skillName}/SKILL.md` line count {lines.Length} exceeds the {allowedMaxLines} lines ({recommendedMaxLines} is the recommended limit)");
 
         const string benchmarkModelName = "gpt-5";
         var tokenizer = TiktokenTokenizer.CreateForModel(benchmarkModelName);


### PR DESCRIPTION
This uncovers a panic in the current Seq 2026.1 preview, so may not build/be mergeable until we've pushed up a fix for that.

Adds basic CLI commands for interacting with metrics, and matching MCP tools.

```
Usage: seqcli metrics <sub-command> [<args>]

Available sub-commands are:
  dimension   List distinct values for a metric dimension
  dimensions  List the dimensions associated with a given metric
  search      List available metric definitions
```

```
seqcli metrics search [<args>]

List available metric definitions

Example:
  seqcli metrics search -f "@Resource.service.name = 'proxy'" -c 512

Arguments:
  -f, --filter=VALUE         A filter to apply to the search, including metric
                               name/description text in double quotes, for
                               example `"cpu" and Host = 'xmpweb-01.example.
                               com'`
  -g, --group=VALUE          Group key for metric definition breakdown; this
                               argument can be used multiple times
  -c, --count=VALUE          The maximum number of metric definitions to
                               retrieve; the default is 30
      --start=VALUE          ISO 8601 date/time to query from
      --end=VALUE            ISO 8601 date/time to query to
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --no-color             Don't colorize text output
      --force-color          Force redirected output to have ANSI color (
                               unless `--no-color` is also specified)
      --storage=VALUE        The folder where `SeqCli.json` and other data
                               will be stored; falls back to `SEQCLI_STORAGE_
                               PATH` from the environment, then the `seqcli
                               forwarder` service's configured storage path (
                               Windows only), then `/home/nblumhardt`
      --trace                Enable detailed (server-side) query tracing
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --verbose              Print verbose output to `STDERR`
```

```
seqcli metrics dimensions [<args>]

List the dimensions associated with a given metric

Example:
  seqcli metrics dimensions -m http.response.status_code

Arguments:
  -m, --metric=VALUE         A metric name, for example `hats-sold` or `http.
                               request.duration`; omit to list dimensions for
                               all metrics
  -c, --count=VALUE          The maximum number of dimensions to retrieve; the
                               default is 30
      --start=VALUE          ISO 8601 date/time to query from
      --end=VALUE            ISO 8601 date/time to query to
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --no-color             Don't colorize text output
      --force-color          Force redirected output to have ANSI color (
                               unless `--no-color` is also specified)
      --storage=VALUE        The folder where `SeqCli.json` and other data
                               will be stored; falls back to `SEQCLI_STORAGE_
                               PATH` from the environment, then the `seqcli
                               forwarder` service's configured storage path (
                               Windows only), then `/home/nblumhardt`
      --trace                Enable detailed (server-side) query tracing
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --verbose              Print verbose output to `STDERR`
```

```
seqcli metrics dimension [<args>]

List distinct values for a metric dimension

Example:
  seqcli metrics dimension --accessor @Resource.service.name

Arguments:
  -d, --accessor=VALUE       The dimension accessor, e.g. `cpu.mode`
  -c, --count=VALUE          The maximum number of dimensions to retrieve; the
                               default is 30
      --start=VALUE          ISO 8601 date/time to query from
      --end=VALUE            ISO 8601 date/time to query to
      --json                 Print output in newline-delimited JSON (the
                               default is plain text)
      --native               Print output using Seq's native value syntax (
                               ideal for agent usage)
      --no-color             Don't colorize text output
      --force-color          Force redirected output to have ANSI color (
                               unless `--no-color` is also specified)
      --storage=VALUE        The folder where `SeqCli.json` and other data
                               will be stored; falls back to `SEQCLI_STORAGE_
                               PATH` from the environment, then the `seqcli
                               forwarder` service's configured storage path (
                               Windows only), then `/home/nblumhardt`
      --trace                Enable detailed (server-side) query tracing
  -s, --server=VALUE         The URL of the Seq server; by default the `
                               connection.serverUrl` config value will be used
  -a, --apikey=VALUE         The API key to use when connecting to the server;
                               by default the `connection.apiKey` config
                               value will be used
      --profile=VALUE        A connection profile to use; by default the `
                               connection.serverUrl` and `connection.apiKey`
                               config values will be used
      --verbose              Print verbose output to `STDERR`
```

The MCP endpoints follow largely the same pattern. We'll need a new skill to cover metrics, which I'll kick off and add to the PR shortly. Some iteration/testing is going to be needed, it's not clear just yet how well agents will go using metrics this way.

The commands, command tests, and MCP tool are written by hand. I used Claude to port the command tests over to cover the MCP endpoints.