### PR TITLE
Update app building skill with publishing gotcha

### DIFF
--- a/src/SeqCli/Skills/Resources/building-seq-plug-in-apps/SKILL.md
+++ b/src/SeqCli/Skills/Resources/building-seq-plug-in-apps/SKILL.md
@@ -46,6 +46,10 @@ Input apps use `Seq.Input.{Name}` naming.
     <PackageReference Include="Seq.Apps" Version="..." />
     <!-- Add Seq.Syntax (project or package reference) if using the Seq template language -->
   </ItemGroup>
+  <ItemGroup>
+    <!-- Package dependencies into primary NUPKG file, except those shipped in the app host itself -->
+    <None Include="./obj/publish/**/*" Exclude="./obj/publish/$(MSBuildProjectName).dll;./obj/publish/Seq.Apps.dll;./obj/publish/Serilog.dll" Pack="true" PackagePath="lib/$(TargetFramework)" />
+  </ItemGroup>
 </Project>
 ```
 
@@ -520,6 +524,10 @@ Take care that the smoke test project doesn't exit or assume completion before a
 - Alert event type: `0xA1E77001`
 - Default time zone: `Etc/UTC`
 - Default date/time format: `o` (ISO-8601 round-trip)
+
+## Gotchas
+
+- Seq does not resolve package dependencies when installing apps. Apps must package assembly dependencies into their own NUPKG (see CSPROJ conventions above). 
 
 ## References
 

--- a/src/SeqCli/Skills/Resources/building-seq-plug-in-apps/SKILL.md
+++ b/src/SeqCli/Skills/Resources/building-seq-plug-in-apps/SKILL.md
@@ -532,7 +532,7 @@ Take care that the smoke test project doesn't exit or assume completion before a
 ## References
 
 - [CLEF specification](https://clef-json.org) — the Compact Log Event Format (`@t`, `@mt`, `@m`, `@l`, `@x`, `@i`, `@r`)
-- [Posting raw events](https://docs.datalust.co/docs/posting-raw-events) — CLEF reference including Seq trace extensions (`@tr`, `@sp`, `@ps`, `@st`, `@sc`, `@ra`, `@sk`)
+- [Posting raw events](https://docs.datalust.co/docs/posting-raw-events) — CLEF reference including Seq trace extensions (`@tr`, `@sp`, `@ps`, `@st`, `@sa`, `@ra`, `@sk`)
 - [Template syntax](https://docs.datalust.co/docs/template-syntax) — documentation for the Seq template language used in app settings
 - [seq-apps-runtime](https://github.com/datalust/seq-apps-runtime) — source code for the `Seq.Apps` API (`SeqApp`, `ISubscribeToAsync<LogEvent>`, `ISubscribeToJsonAsync`, etc.)
 - [seqcli](https://github.com/datalust/seqcli) — source code for the `seqcli app run` command that Seq uses to host apps at runtime


### PR DESCRIPTION
https://github.com/datalust/seq-app-opentelemetry, which was built in part using this skill, initially didn't work because the NUPKG lacked dependencies.

Not directly related to the skill, the test app harness published from the https://github.com/datalust/seq-app-mail repository, also mentioned in the skill, lacks logic required for setting handling in smoke test harnesses - we'll need a skill update once the upstream package has been extended.
