### PR TITLE
Use executing binary path for install command

### DIFF
--- a/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
+++ b/src/SeqCli/Cli/Commands/Forwarder/InstallCommand.cs
@@ -98,7 +98,7 @@ class InstallCommand : Command
         if (netshResult != 0)
             Console.WriteLine($"Could not add URL reservation for {listenUri}: `netsh` returned {netshResult}; ignoring");
 
-        var exePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Program.WindowsBinaryName);
+        var exePath = Environment.ProcessPath;
         var forwarderRunCmdline = $"\"{exePath}\" forwarder run --pre --storage=\"{_storagePath.StorageRootPath}\"";
 
         var binPath = forwarderRunCmdline.Replace("\"", "\\\"");


### PR DESCRIPTION
Closes #432 

When installed as a dotnet tool, we distribute a platform-independent nupkg and the local dotnet toolchain assembles a shim binary over it. The DLL path in this case doesn't point anywhere near where the actual binary is.

I've tweaked it to use [`Environment.ProcessPath`](https://learn.microsoft.com/en-us/dotnet/api/system.environment.processpath?view=net-10.0), which in my local testing here in Windows does point in the right direction. It'll need a check with the actual nupkg too.