### PR TITLE
Don't show span kinds for non-span events

### DIFF
--- a/src/SeqCli/Output/NativeFormatter.cs
+++ b/src/SeqCli/Output/NativeFormatter.cs
@@ -74,7 +74,8 @@ static partial class NativeFormatter
             ("@Elapsed", evt.Elapsed ?? UndefinedValue),
             ("@TraceId", evt.TraceId ?? UndefinedValue),
             ("@SpanId", evt.SpanId ?? UndefinedValue),
-            ("@SpanKind", evt.SpanKind ?? UndefinedValue),
+            // This temporarily works around an events API bug; non-span events should not carry span kinds.
+            ("@SpanKind", evt.Start != null ? evt.SpanKind ?? UndefinedValue : UndefinedValue),
             ("@Start", evt.Start != null ? DateTimeOffset.Parse(evt.Start).UtcDateTime : UndefinedValue),
             ("@ParentId", evt.ParentId ?? UndefinedValue),
             ("@Properties", evt.Properties?.Count > 0 ? new Action<TextWriter>(w => WritePropertiesObject(w, evt.Properties)) : UndefinedValue),

--- a/src/SeqCli/Output/OutputFormat.cs
+++ b/src/SeqCli/Output/OutputFormat.cs
@@ -256,7 +256,8 @@ sealed class OutputFormat
         if (!string.IsNullOrWhiteSpace(evt.Start))
             serilogEvent.AddOrUpdateProperty(new("@st", new ScalarValue(evt.Start)));
 
-        if (!string.IsNullOrWhiteSpace(evt.SpanKind))
+        // This temporarily works around an events API bug; non-span events should not carry span kinds.
+        if (!string.IsNullOrWhiteSpace(evt.Start) && !string.IsNullOrWhiteSpace(evt.SpanKind))
             serilogEvent.AddOrUpdateProperty(new("@sk", new ScalarValue(evt.SpanKind)));
         
         return serilogEvent;

--- a/test/SeqCli.Tests/Output/NativeFormatterTests.cs
+++ b/test/SeqCli.Tests/Output/NativeFormatterTests.cs
@@ -51,7 +51,14 @@ public class NativeFormatterTests
         [Some.MakeEvent(e => e.Elapsed = TimeSpan.FromSeconds(13)), "@Elapsed: 13s"],
         [Some.MakeEvent(e => e.TraceId = "abc123"), "@TraceId: 'abc123'"],
         [Some.MakeEvent(e => e.SpanId = "def456"), "@SpanId: 'def456'"],
-        [Some.MakeEvent(e => e.SpanKind = "server"), "@SpanKind: 'server'"],
+        [
+            Some.MakeEvent(e =>
+            {
+                e.Start = "2024-01-01T00:00:00.0000000Z";
+                e.SpanKind = "server";
+            }),
+            "@SpanKind: 'server'"
+        ],
         [Some.MakeEvent(e => e.Start = "2024-01-01T00:00:00.0000000Z"), "@Start: DateTime('2024-01-01T00:00:00.0000000Z')"],
         [Some.MakeEvent(e => e.ParentId = "p1"), "@ParentId: 'p1'"],
         [Some.MakeEvent(e => e.Properties = Some.MakeProperties(("UserId", 42))), "@Properties: {UserId: 42}"],
@@ -116,6 +123,13 @@ public class NativeFormatterTests
     public void OptionalPropertiesAreOmittedWhenAbsent(string token)
     {
         Assert.DoesNotContain(token, Render(Some.MakeEvent()));
+    }
+
+    [Fact]
+    public void SpanKindIsOmittedFromEventsThatAreNotSpans()
+    {
+        // The events API reports a span kind for every event, defaulting to `Internal`.
+        Assert.DoesNotContain("@SpanKind", Render(Some.MakeEvent(e => e.SpanKind = "Internal")));
     }
 
     [Fact]

--- a/test/SeqCli.Tests/Output/OutputFormatTests.cs
+++ b/test/SeqCli.Tests/Output/OutputFormatTests.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using SeqCli.Tests.Support;
+using Serilog.Events;
+using Xunit;
+using OutputFormat = SeqCli.Output.OutputFormat;
+
+namespace SeqCli.Tests.Output;
+
+public class OutputFormatTests
+{
+    [Fact]
+    public void SpanKindIsMappedFromSpans()
+    {
+        var evt = OutputFormat.ToSerilogEvent(Some.MakeEvent(e =>
+        {
+            e.Properties = [];
+            e.Start = "2024-01-01T00:00:00.0000000Z";
+            e.SpanKind = "Server";
+        }));
+
+        Assert.Equal("Server", Assert.IsType<ScalarValue>(evt.Properties["@sk"]).Value);
+    }
+
+    [Fact]
+    public void SpanKindIsOmittedFromEventsThatAreNotSpans()
+    {
+        // The events API reports a span kind for every event, defaulting to `Internal`.
+        var evt = OutputFormat.ToSerilogEvent(Some.MakeEvent(e =>
+        {
+            e.Properties = [];
+            e.SpanKind = "Internal";
+        }));
+
+        Assert.DoesNotContain("@sk", evt.Properties.Keys);
+    }
+}


### PR DESCRIPTION
The events API incorrectly sets `EventEntity.SpanKind` to `Internal` (a default `enum` value) for events with no associated span kind. The PR works around this by making span kind emission conditional on the presence of `Start`; we'll need to make a full fix on the Seq side.