### PR TITLE
Improve text search result output, remove use of `Serilog.Sinks.Console` theming to improve consistency

### DIFF
--- a/src/SeqCli/Csv/CsvWriter.cs
+++ b/src/SeqCli/Csv/CsvWriter.cs
@@ -1,20 +1,22 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Seq.Api.Model.Data;
 using SeqCli.Mcp.Data;
-using Serilog.Sinks.SystemConsole.Themes;
+using SeqCli.Output;
+using Serilog.Templates.Themes;
 
 namespace SeqCli.Csv;
 
 static class CsvWriter
 {
-    public static void WriteQueryResult(QueryResultPart result, Func<object?, string> stringify, ConsoleTheme theme, TextWriter output)
+    public static void WriteQueryResult(QueryResultPart result, Func<object?, string> stringify, TemplateTheme? theme, TextWriter output)
     {
         if (!string.IsNullOrWhiteSpace(result.Error))
         {
-            theme.Set(output, ConsoleThemeStyle.Text);
+            theme?.Set(output, TemplateThemeStyle.Text);
             QueryResultHelper.WriteErrorResult(output, result);
-            theme.Reset(output);
+            theme?.Reset(output);
         }
         
         var first = true;
@@ -30,7 +32,7 @@ static class CsvWriter
         });
     }
 
-    static void WriteCell(TextWriter output, ConsoleTheme theme, object? value, Func<object?, string> stringify, ref bool firstCol, bool isHeadingRow = false)
+    static void WriteCell(TextWriter output, TemplateTheme? theme, object? value, Func<object?, string> stringify, ref bool firstCol, bool isHeadingRow = false)
     {
         if (firstCol)
         {
@@ -38,39 +40,39 @@ static class CsvWriter
         }
         else
         {
-            theme.Set(output, ConsoleThemeStyle.TertiaryText);
+            theme?.Set(output, TemplateThemeStyle.TertiaryText);
             output.Write(',');
-            theme.Reset(output);
+            theme?.Reset(output);
         }
         
-        theme.Set(output, ConsoleThemeStyle.TertiaryText);
+        theme?.Set(output, TemplateThemeStyle.TertiaryText);
         output.Write('"');
-        theme.Reset(output);
+        theme?.Reset(output);
 
         var valueAsString = stringify(value);
         
-        var dataStyle = isHeadingRow ? ConsoleThemeStyle.Name : ConsoleThemeStyle.Text;
+        var dataStyle = isHeadingRow ? TemplateThemeStyle.Name : TemplateThemeStyle.Text;
         var doubleQuote = valueAsString.IndexOf('"');
         while (doubleQuote != -1)
         {
-            theme.Set(output, dataStyle);
+            theme?.Set(output, dataStyle);
             output.Write(valueAsString[..doubleQuote]);
-            theme.Reset(output);
+            theme?.Reset(output);
             
-            theme.Set(output, ConsoleThemeStyle.Scalar);
+            theme?.Set(output, TemplateThemeStyle.Scalar);
             output.Write("\"\"");
-            theme.Reset(output);
+            theme?.Reset(output);
 
             valueAsString = valueAsString[(doubleQuote + 1)..];
             doubleQuote = valueAsString.IndexOf('"');
         }
         
-        theme.Set(output, dataStyle);
+        theme?.Set(output, dataStyle);
         output.Write(valueAsString);
-        theme.Reset(output);
+        theme?.Reset(output);
         
-        theme.Set(output, ConsoleThemeStyle.TertiaryText);
+        theme?.Set(output, TemplateThemeStyle.TertiaryText);
         output.Write('"');
-        theme.Reset(output);
+        theme?.Reset(output);
     }
 }

--- a/src/SeqCli/Forwarder/ForwarderModule.cs
+++ b/src/SeqCli/Forwarder/ForwarderModule.cs
@@ -68,13 +68,13 @@ class ForwarderModule : Module
             Log.ForContext<ForwarderModule>().Warning("Configured to expose ingestion log via HTTP API");
             builder.RegisterType<IngestionLogEndpoints>().As<IMapEndpoints>();
 
-            var ingestionLogTemplate = "[{@t:o} {@l:u3}] {@m}\n";
+            var ingestionLogTemplate = $"[{{@t:o}} {{@l:u3}}] {{@m}}{Environment.NewLine}";
             if (_config.Forwarder.Diagnostics.IngestionLogShowDetail)
             {
                 Log.ForContext<ForwarderModule>().Warning("Including full client, payload, and error detail in the ingestion log");
                 ingestionLogTemplate +=
-                    "{#if ClientHostIP is not null}Client IP address: {ClientHostIP}\n{#end}" +
-                    "{#if DocumentStart is not null}First {StartToLog} characters of payload: {DocumentStart:l}\n{#end}" +
+                    $"{{#if ClientHostIP is not null}}Client IP address: {{ClientHostIP}}{Environment.NewLine}{{#end}}" +
+                    $"{{#if DocumentStart is not null}}First {{StartToLog}} characters of payload: {{DocumentStart:l}}{Environment.NewLine}{{#end}}" +
                     "{@x}";
             }
             

--- a/src/SeqCli/Ingestion/LogShipper.cs
+++ b/src/SeqCli/Ingestion/LogShipper.cs
@@ -33,7 +33,7 @@ namespace SeqCli.Ingestion;
 
 static class LogShipper
 {
-    static readonly ITextFormatter JsonFormatter = OutputFormatter.Json(null);
+    static readonly ITextFormatter JsonFormatter = TextFormatters.Json(null);
 
     public static async Task ShipBufferAsync(
         SeqConnection connection,

--- a/src/SeqCli/Mcp/McpServerInstaller.cs
+++ b/src/SeqCli/Mcp/McpServerInstaller.cs
@@ -87,13 +87,13 @@ static class McpServerInstaller
                 "mcpServers"),
 
             ["codex"] = Unsupported(
-                "Codex reads MCP servers from ~/.codex/config.toml (TOML), which seqcli can't edit automatically. Add this block:\n\n[mcp_servers.seq]\ncommand = \"seqcli\"\nargs = [\"mcp\", \"run\"]"),
+                $"Codex reads MCP servers from ~/.codex/config.toml (TOML), which seqcli can't edit automatically. Add this block:{Environment.NewLine}{Environment.NewLine}[mcp_servers.seq]{Environment.NewLine}command = \"seqcli\"{Environment.NewLine}args = [\"mcp\", \"run\"]"),
 
             ["goose"] = Unsupported(
-                "Goose reads MCP servers from ~/.config/goose/config.yaml (YAML) under `extensions`, which seqcli can't edit automatically. Add:\n\nextensions:\n  seq:\n    type: stdio\n    cmd: seqcli\n    args: [mcp, run]\n    enabled: true"),
+                $"Goose reads MCP servers from ~/.config/goose/config.yaml (YAML) under `extensions`, which seqcli can't edit automatically. Add:{Environment.NewLine}{Environment.NewLine}extensions:{Environment.NewLine}  seq:{Environment.NewLine}    type: stdio{Environment.NewLine}    cmd: seqcli{Environment.NewLine}    args: [mcp, run]{Environment.NewLine}    enabled: true"),
 
             ["continue"] = Unsupported(
-                "Continue reads MCP servers from YAML, which seqcli can't edit automatically. Create .continue/mcpServers/seq.yaml with:\n\nname: Seq\nversion: 0.0.1\nschema: v1\nmcpServers:\n  - name: seq\n    command: seqcli\n    args:\n      - mcp\n      - run"),
+                $"Continue reads MCP servers from YAML, which seqcli can't edit automatically. Create .continue/mcpServers/seq.yaml with:{Environment.NewLine}{Environment.NewLine}name: Seq{Environment.NewLine}version: 0.0.1{Environment.NewLine}schema: v1{Environment.NewLine}mcpServers:{Environment.NewLine}  - name: seq{Environment.NewLine}    command: seqcli{Environment.NewLine}    args:{Environment.NewLine}      - mcp{Environment.NewLine}      - run"),
         };
     
     static readonly IReadOnlyDictionary<string, string> AgentAliases =

--- a/src/SeqCli/Mcp/Tools/Search/SearchTools.cs
+++ b/src/SeqCli/Mcp/Tools/Search/SearchTools.cs
@@ -43,7 +43,7 @@ class SearchTools(McpSession session, SeqConnection connection)
 {
     const string ResultIdPropertyName = "__seqcli_ResultId";
     static readonly ExpressionTemplate SearchResultFormatter = new (
-        $"{{{ResultIdPropertyName}}} [{{UtcDateTime(@t)}} {{{LevelMapping.SurrogateLevelProperty}}}] {{@m}}\n{{#if @x is not null}}{{Substring(ToString(@x), 0, 512)}}...\n{{#end}}"
+        $"{{{ResultIdPropertyName}}} [{{UtcDateTime(@t)}} {{{LevelMapping.SurrogateLevelProperty}}}] {{@m}}{Environment.NewLine}{{#if @x is not null}}{{Substring(ToString(@x), 0, 512)}}...{Environment.NewLine}{{#end}}"
     );
     
     [McpServerTool(Name = "seq_new_session", ReadOnly = true, Title = "Begin a new Search/Query Session")]

--- a/src/SeqCli/Output/FlareTheme.cs
+++ b/src/SeqCli/Output/FlareTheme.cs
@@ -18,35 +18,39 @@ using Serilog.Templates.Themes;
 
 namespace SeqCli.Output;
 
-static class OutputTheme
+/// <summary>
+/// <c>Flare</c> is Seq's embedded stream/columnar database. This theme is derived from one build originally
+/// for the <c>flaretl</c> command-line tooling used there.
+/// </summary>
+static class FlareTheme
 {
-    static readonly Dictionary<TemplateThemeStyle, string> SeqCliThemeStyles = new()
+    static readonly Dictionary<TemplateThemeStyle, string> FlareThemeStyles = new()
     {
+        [TemplateThemeStyle.Name] = "\e[38;5;0215m",
+        [TemplateThemeStyle.Number] = "\e[38;5;0200m",
+        [TemplateThemeStyle.Boolean] = "\e[38;5;0039m",
+        [TemplateThemeStyle.Null] = "\e[38;5;0039m",
+        [TemplateThemeStyle.String] = "\e[38;5;0217m",
+        [TemplateThemeStyle.Scalar] = "\e[38;5;0217m",
+        [TemplateThemeStyle.LevelError] = "\e[38;5;0197m",
+        [TemplateThemeStyle.TertiaryText] = "\e[38;5;0244m",
         // Based on `TemplateTheme.Code`
-        [TemplateThemeStyle.Text] = "\u001B[38;5;0253m",
-        [TemplateThemeStyle.SecondaryText] = "\u001B[38;5;0246m",
-        [TemplateThemeStyle.TertiaryText] = "\u001B[38;5;0242m",
-        [TemplateThemeStyle.Invalid] = "\u001B[33;1m",
-        [TemplateThemeStyle.Null] = "\u001B[38;5;0038m",
-        [TemplateThemeStyle.Name] = "\u001B[38;5;0215m",
-        [TemplateThemeStyle.String] = "\u001B[38;5;0217m",
-        [TemplateThemeStyle.Number] = "\u001B[38;5;0200m",
-        [TemplateThemeStyle.Boolean] = "\u001B[38;5;0039m",
-        [TemplateThemeStyle.Scalar] = "\u001B[38;5;0079m",
-        [TemplateThemeStyle.LevelVerbose] = "\u001B[37m",
-        [TemplateThemeStyle.LevelDebug] = "\u001B[37m",
-        [TemplateThemeStyle.LevelInformation] = "\u001B[37;1m",
-        [TemplateThemeStyle.LevelWarning] = "\u001B[38;5;0229m",
-        [TemplateThemeStyle.LevelError] = "\u001B[38;5;0197m\u001B[48;5;0238m",
-        [TemplateThemeStyle.LevelFatal] = "\u001B[38;5;0197m\u001B[48;5;0238m"
+        [TemplateThemeStyle.Text] = "\e[38;5;0253m",
+        [TemplateThemeStyle.SecondaryText] = "\e[38;5;0246m",
+        [TemplateThemeStyle.Invalid] = "\e[33;1m",
+        [TemplateThemeStyle.LevelVerbose] = "\e[37m",
+        [TemplateThemeStyle.LevelDebug] = "\e[37m",
+        [TemplateThemeStyle.LevelInformation] = "\e[37;1m",
+        [TemplateThemeStyle.LevelWarning] = "\e[38;5;0229m",
+        [TemplateThemeStyle.LevelFatal] = "\e[38;5;0197m\e[48;5;0238m"
     };
 
-    public static readonly TemplateTheme SeqCli = new(SeqCliThemeStyles);
+    public static readonly TemplateTheme SeqCli = new(FlareThemeStyles);
     
     // `CsvWriter` implements its own theming behavior because the required APIs are not public in Serilog.Expressions.
     // The best way forward for this is likely to be porting theming to Seq.Syntax, and exposing the required APIs there.
     
-    const string AnsiStyleResetSequence = "\u001B[0m";
+    const string AnsiStyleResetSequence = "\e[0m";
     
     // The passed-in theme is ignored because SerilogExpressions themes are opaque. All formatting uses the SeqCli theme.
     // ReSharper disable once UnusedParameter.Global
@@ -54,7 +58,7 @@ static class OutputTheme
     {
         public void Set(TextWriter output, TemplateThemeStyle style)
         {
-            if (SeqCliThemeStyles.TryGetValue(style, out var styleSequence))
+            if (FlareThemeStyles.TryGetValue(style, out var styleSequence))
                 output.Write(styleSequence);
         }
 

--- a/src/SeqCli/Output/OutputFormat.cs
+++ b/src/SeqCli/Output/OutputFormat.cs
@@ -171,7 +171,7 @@ sealed class OutputFormat
             var writer = new LoggerConfiguration()
                 .Destructure.With<JsonNetDestructuringPolicy>()
                 .Enrich.With<StripStructureTypeEnricher>()
-                .WriteTo.Console(TextFormatters.Plain(TemplateTheme, "{@m}\n"))
+                .WriteTo.Console(TextFormatters.Plain(TemplateTheme, "{@m}" + Environment.NewLine))
                 .CreateLogger();
             writer.Information("{@Entity}", jo);
         }
@@ -201,7 +201,7 @@ sealed class OutputFormat
             var writer = new LoggerConfiguration()
                 .Destructure.With<JsonNetDestructuringPolicy>()
                 .Enrich.With<StripStructureTypeEnricher>()
-                .WriteTo.Console(TextFormatters.Plain(TemplateTheme, "{@m}\n"))
+                .WriteTo.Console(TextFormatters.Plain(TemplateTheme, "{@m}" + Environment.NewLine))
                 .CreateLogger();
             writer.Information("{@Entity}", jo);
         }

--- a/src/SeqCli/Output/OutputFormat.cs
+++ b/src/SeqCli/Output/OutputFormat.cs
@@ -32,7 +32,6 @@ using Serilog;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Parsing;
-using Serilog.Sinks.SystemConsole.Themes;
 using Serilog.Templates.Themes;
 
 namespace SeqCli.Output;
@@ -41,21 +40,9 @@ sealed class OutputFormat
 {
     // See https://no-color.org for semantics.
     const string NoColorEnvironmentVariable = "NO_COLOR";
-
-    internal const string DefaultOutputTemplate =
-        "[{Timestamp:o} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}";
-
-    static bool AnsiIsDefault => !OperatingSystem.IsWindows();
-
-    internal static readonly ConsoleTheme DefaultAnsiTheme = AnsiConsoleTheme.Code;
-
-    internal static readonly ConsoleTheme DefaultTheme =
-        AnsiIsDefault ? DefaultAnsiTheme : SystemConsoleTheme.Literate;
-
-    static readonly TemplateTheme DefaultTemplateTheme = TemplateTheme.Code;
-
+    
     readonly OutputSyntax _syntax;
-    readonly string _outputTemplate;
+    readonly string? _outputTemplate;
     readonly Logger _formatter;
 
     readonly JsonSerializer _serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings
@@ -80,7 +67,8 @@ sealed class OutputFormat
             outputConfig,
             outputTemplate,
             noColorSetInEnvironment: NoColorSetInEnvironment(),
-            outputIsRedirected: Console.IsOutputRedirected)
+            outputIsRedirected: Console.IsOutputRedirected,
+            allowAnsiEscapes: TerminalFeatures.TryEnableAnsiEscapes())
     {
     }
 
@@ -91,6 +79,8 @@ sealed class OutputFormat
     /// <param name="outputTemplate">The template controlling plain-text formatting, or <c>null</c> for the default.</param>
     /// <param name="noColorSetInEnvironment">Whether <c>NO_COLOR</c> is set; see <see cref="NoColorSetInEnvironment"/>.</param>
     /// <param name="outputIsRedirected">Whether <c>STDOUT</c> is redirected, i.e. not attached to a terminal.</param>
+    /// <param name="allowAnsiEscapes">Whether ANSI escape sequences are allowed; generally <c>false</c> for interactive
+    /// legacy Windows terminals and <c>true</c> otherwise.</param>
     internal OutputFormat(
         OutputSyntax syntax,
         bool? noColor,
@@ -98,30 +88,18 @@ sealed class OutputFormat
         SeqCliOutputConfig outputConfig,
         string? outputTemplate,
         bool noColorSetInEnvironment,
-        bool outputIsRedirected)
+        bool outputIsRedirected,
+        bool allowAnsiEscapes)
     {
         _syntax = syntax;
-        _outputTemplate = outputTemplate ?? DefaultOutputTemplate;
+        _outputTemplate = outputTemplate;
 
-        NoColor = ResolveNoColor(noColor, forceColor, outputConfig, noColorSetInEnvironment);
-        ApplyThemeToRedirectedOutput = !NoColor && (forceColor ?? outputConfig.ForceColor);
+        var resolvedNoColor = ResolveNoColor(noColor, forceColor, outputConfig, noColorSetInEnvironment, allowAnsiEscapes);
+        var applyThemeToRedirectedOutput = !resolvedNoColor && (forceColor ?? outputConfig.ForceColor);
+        var colorize = !resolvedNoColor && (applyThemeToRedirectedOutput || !outputIsRedirected);
 
-        // Serilog's console sink applies the `NO_COLOR` convention itself, unconditionally, overriding whatever
-        // theme it's passed. When `--force-color` has opted back out of `NO_COLOR`, the variable is cleared (for
-        // this process only) so that the sink can't undo the decision made here.
-        if (!NoColor && noColorSetInEnvironment)
-            Environment.SetEnvironmentVariable(NoColorEnvironmentVariable, null);
-
-        var colorize = !NoColor && (ApplyThemeToRedirectedOutput || !outputIsRedirected);
-
-        Theme = !colorize                       ? ConsoleTheme.None
-            :   ApplyThemeToRedirectedOutput    ? DefaultAnsiTheme
-            :                                     DefaultTheme;
-
-        // Rather than emit escapes that a downlevel Windows terminal would show literally,
-        // JSON output stays plain there unless ANSI has been opted into with `--force-color`.
-        TemplateTheme = colorize && (ApplyThemeToRedirectedOutput || AnsiIsDefault)
-            ? DefaultTemplateTheme
+        TemplateTheme = colorize
+            ? OutputTheme.SeqCli
             : null;
 
         _formatter = CreateOutputLogger();
@@ -129,13 +107,17 @@ sealed class OutputFormat
 
     static bool NoColorSetInEnvironment()
         => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(NoColorEnvironmentVariable));
-
-    static bool ResolveNoColor(
+    
+    internal static bool ResolveNoColor(
         bool? noColorFlag,
         bool? forceColorFlag,
         SeqCliOutputConfig config,
-        bool noColorSetInEnvironment)
+        bool noColorSetInEnvironment,
+        bool supportsAnsiEscapes)
     {
+        if (!supportsAnsiEscapes)
+            return true;
+
         if (noColorFlag != null)
             return noColorFlag.Value;
 
@@ -148,12 +130,6 @@ sealed class OutputFormat
     public bool Json => _syntax == OutputSyntax.Json;
     public bool Text => _syntax == OutputSyntax.Text;
     public bool Native => _syntax == OutputSyntax.Native;
-
-    internal bool NoColor { get; }
-
-    bool ApplyThemeToRedirectedOutput { get; }
-
-    internal ConsoleTheme Theme { get; }
 
     internal TemplateTheme? TemplateTheme { get; }
 
@@ -171,10 +147,7 @@ sealed class OutputFormat
         }
         else if (Text)
         {
-            outputConfiguration.WriteTo.Console(
-                outputTemplate: _outputTemplate,
-                theme: Theme,
-                applyThemeToRedirectedOutput: ApplyThemeToRedirectedOutput);
+            outputConfiguration.WriteTo.Console(OutputFormatter.Text(TemplateTheme, _outputTemplate));
         }
         
         // The logger is not configured for Native output, which avoids it. Ideally we'll shift away from using
@@ -198,10 +171,7 @@ sealed class OutputFormat
             var writer = new LoggerConfiguration()
                 .Destructure.With<JsonNetDestructuringPolicy>()
                 .Enrich.With<StripStructureTypeEnricher>()
-                .WriteTo.Console(
-                    outputTemplate: "{@Message:j}{NewLine}",
-                    theme: Theme,
-                    applyThemeToRedirectedOutput: ApplyThemeToRedirectedOutput)
+                .WriteTo.Console(OutputFormatter.Text(TemplateTheme, "{@m}\n"))
                 .CreateLogger();
             writer.Information("{@Entity}", jo);
         }
@@ -231,10 +201,7 @@ sealed class OutputFormat
             var writer = new LoggerConfiguration()
                 .Destructure.With<JsonNetDestructuringPolicy>()
                 .Enrich.With<StripStructureTypeEnricher>()
-                .WriteTo.Console(
-                    outputTemplate: "{@Message:j}{NewLine}",
-                    theme: Theme,
-                    applyThemeToRedirectedOutput: ApplyThemeToRedirectedOutput)
+                .WriteTo.Console(OutputFormatter.Text(TemplateTheme, "{@m}\n"))
                 .CreateLogger();
             writer.Information("{@Entity}", jo);
         }
@@ -277,7 +244,7 @@ sealed class OutputFormat
         }
         else
         {
-            CsvWriter.WriteQueryResult(result, Stringify, Theme, Console.Out);
+            CsvWriter.WriteQueryResult(result, Stringify, TemplateTheme, Console.Out);
         }
     }
 

--- a/src/SeqCli/Output/OutputFormat.cs
+++ b/src/SeqCli/Output/OutputFormat.cs
@@ -99,7 +99,7 @@ sealed class OutputFormat
         var colorize = !resolvedNoColor && (applyThemeToRedirectedOutput || !outputIsRedirected);
 
         TemplateTheme = colorize
-            ? OutputTheme.SeqCli
+            ? FlareTheme.SeqCli
             : null;
 
         _formatter = CreateOutputLogger();
@@ -143,11 +143,11 @@ sealed class OutputFormat
 
         if (Json)
         {
-            outputConfiguration.WriteTo.Console(OutputFormatter.Json(TemplateTheme));
+            outputConfiguration.WriteTo.Console(TextFormatters.Json(TemplateTheme));
         }
         else if (Text)
         {
-            outputConfiguration.WriteTo.Console(OutputFormatter.Text(TemplateTheme, _outputTemplate));
+            outputConfiguration.WriteTo.Console(TextFormatters.Plain(TemplateTheme, _outputTemplate));
         }
         
         // The logger is not configured for Native output, which avoids it. Ideally we'll shift away from using
@@ -171,7 +171,7 @@ sealed class OutputFormat
             var writer = new LoggerConfiguration()
                 .Destructure.With<JsonNetDestructuringPolicy>()
                 .Enrich.With<StripStructureTypeEnricher>()
-                .WriteTo.Console(OutputFormatter.Text(TemplateTheme, "{@m}\n"))
+                .WriteTo.Console(TextFormatters.Plain(TemplateTheme, "{@m}\n"))
                 .CreateLogger();
             writer.Information("{@Entity}", jo);
         }
@@ -201,7 +201,7 @@ sealed class OutputFormat
             var writer = new LoggerConfiguration()
                 .Destructure.With<JsonNetDestructuringPolicy>()
                 .Enrich.With<StripStructureTypeEnricher>()
-                .WriteTo.Console(OutputFormatter.Text(TemplateTheme, "{@m}\n"))
+                .WriteTo.Console(TextFormatters.Plain(TemplateTheme, "{@m}\n"))
                 .CreateLogger();
             writer.Information("{@Entity}", jo);
         }

--- a/src/SeqCli/Output/OutputFormatter.cs
+++ b/src/SeqCli/Output/OutputFormatter.cs
@@ -1,17 +1,34 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
 using SeqCli.Ingestion;
 using SeqCli.Mapping;
+using Serilog.Events;
+using Serilog.Expressions;
 using Serilog.Formatting;
 using Serilog.Templates;
 using Serilog.Templates.Themes;
 
 namespace SeqCli.Output;
 
+// This is the only usage of Serilog.Expressions remaining in seqcli; the upstream Seq.Syntax doesn't yet support
+// tracing properties or theming.
 static class OutputFormatter
 {
-    // This is the only usage of Serilog.Expressions remaining in seqcli; the upstream Seq.Syntax doesn't yet support
-    // the `@sp` property, because it needs to load on older Seq installs with older Serilog versions embedded in the
-    // app runner. Once we've updated it, we can switch this to a Seq.Syntax template.
-    internal static ITextFormatter Json(TemplateTheme? theme) => new ExpressionTemplate(
+    public static ITextFormatter Json(TemplateTheme? theme) => new ExpressionTemplate(
         $"{{ " +
             $"if {MetricsMapping.SurrogateDefinitionsProperty} is not null then " +
                 // Emit a metric sample
@@ -24,4 +41,46 @@ static class OutputFormatter
         // The `OutputFormat` constructor has already decided whether to colorize.
         applyThemeWhenOutputIsRedirected: true
     );
+    
+    const string DefaultTextOutputTemplate = "[{@t:o} {@l:u3}] {@m}{#if IsSpan()} ({Milliseconds(Elapsed()):0.###} ms){#end} {@p}\n{@x}";
+
+    public static ITextFormatter Text(TemplateTheme? theme, string? outputTemplate) => new ExpressionTemplate(
+        outputTemplate ?? DefaultTextOutputTemplate,
+        theme: theme,
+        nameResolver: new StaticMemberNameResolver(typeof(OutputFormatter)),
+        // The `OutputFormat` constructor has already decided whether to colorize.
+        applyThemeWhenOutputIsRedirected: true
+    );
+    
+    public static LogEventPropertyValue? Elapsed(LogEvent logEvent)
+    {
+        if (logEvent.Properties.TryGetValue(TraceConstants.SpanStartTimestampProperty, out var sst) &&
+            sst is ScalarValue { Value: DateTime spanStart })
+        {
+            return new ScalarValue(logEvent.Timestamp - spanStart);
+        }
+
+        if (logEvent.Properties.TryGetValue("@st", out var st) &&
+            st is ScalarValue { Value: string spanStartIso } &&
+            DateTimeOffset.TryParse(spanStartIso, CultureInfo.InvariantCulture, out var spanStartDto))
+        {
+            return new ScalarValue(logEvent.Timestamp - spanStartDto);
+        }
+
+        return null;
+    }
+
+    public static LogEventPropertyValue? IsSpan(LogEvent logEvent)
+    {
+        return new ScalarValue(Elapsed(logEvent) != null);
+    }
+    
+    public static LogEventPropertyValue? Milliseconds(LogEventPropertyValue? timeSpan)
+    {
+        // Truncates instead of rounding.
+        if (timeSpan is ScalarValue { Value: TimeSpan ts })
+            return new ScalarValue((decimal)ts.Ticks / TimeSpan.TicksPerMillisecond);
+
+        return null;
+    }
 }

--- a/src/SeqCli/Output/OutputFormatter.cs
+++ b/src/SeqCli/Output/OutputFormatter.cs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Globalization;
 using SeqCli.Ingestion;
 using SeqCli.Mapping;
-using Serilog.Events;
 using Serilog.Expressions;
 using Serilog.Formatting;
 using Serilog.Templates;
@@ -30,57 +27,27 @@ static class OutputFormatter
 {
     public static ITextFormatter Json(TemplateTheme? theme) => new ExpressionTemplate(
         $"{{ " +
-            $"if {MetricsMapping.SurrogateDefinitionsProperty} is not null then " +
-                // Emit a metric sample
-                $"{{@t, @l: undefined(), @d: {MetricsMapping.SurrogateDefinitionsProperty}, ..rest()}} " +
-            $"else " +
-                // Emit a log or span
-                $"{{@t, @mt, @l: coalesce({LevelMapping.SurrogateLevelProperty}, if @l = 'Information' then undefined() else @l), @x, @sp, @tr, @ps: coalesce({TraceConstants.ParentSpanIdProperty}, @ps), @st: coalesce({TraceConstants.SpanStartTimestampProperty}, @st), ..rest()}} " +
+        $"if {MetricsMapping.SurrogateDefinitionsProperty} is not null then " +
+        // Emit a metric sample
+        $"{{@t, @l: undefined(), @d: {MetricsMapping.SurrogateDefinitionsProperty}, ..rest()}} " +
+        $"else " +
+        // Emit a log or span
+        $"{{@t, @mt, @l: coalesce({LevelMapping.SurrogateLevelProperty}, if @l = 'Information' then undefined() else @l), @x, @sp, @tr, @ps: coalesce({TraceConstants.ParentSpanIdProperty}, @ps), @st: coalesce({TraceConstants.SpanStartTimestampProperty}, @st), ..rest()}} " +
         $"}}\n",
         theme: theme,
         // The `OutputFormat` constructor has already decided whether to colorize.
         applyThemeWhenOutputIsRedirected: true
     );
-    
-    const string DefaultTextOutputTemplate = "[{@t:o} {@l:u3}] {@m}{#if IsSpan()} ({Milliseconds(Elapsed()):0.###} ms){#end} {@p}\n{@x}";
+
+    const string DefaultTextOutputTemplate =
+        "[{@t:o} {@l:u3}] {@m}{#if IsSpan()} ({Milliseconds(Elapsed()):0.###} ms){#end} {@p}\n{@x}";
 
     public static ITextFormatter Text(TemplateTheme? theme, string? outputTemplate) => new ExpressionTemplate(
         outputTemplate ?? DefaultTextOutputTemplate,
         theme: theme,
-        nameResolver: new StaticMemberNameResolver(typeof(OutputFormatter)),
+        nameResolver: new StaticMemberNameResolver(typeof(TracingFunctions)),
         // The `OutputFormat` constructor has already decided whether to colorize.
         applyThemeWhenOutputIsRedirected: true
     );
-    
-    public static LogEventPropertyValue? Elapsed(LogEvent logEvent)
-    {
-        if (logEvent.Properties.TryGetValue(TraceConstants.SpanStartTimestampProperty, out var sst) &&
-            sst is ScalarValue { Value: DateTime spanStart })
-        {
-            return new ScalarValue(logEvent.Timestamp - spanStart);
-        }
 
-        if (logEvent.Properties.TryGetValue("@st", out var st) &&
-            st is ScalarValue { Value: string spanStartIso } &&
-            DateTimeOffset.TryParse(spanStartIso, CultureInfo.InvariantCulture, out var spanStartDto))
-        {
-            return new ScalarValue(logEvent.Timestamp - spanStartDto);
-        }
-
-        return null;
-    }
-
-    public static LogEventPropertyValue? IsSpan(LogEvent logEvent)
-    {
-        return new ScalarValue(Elapsed(logEvent) != null);
-    }
-    
-    public static LogEventPropertyValue? Milliseconds(LogEventPropertyValue? timeSpan)
-    {
-        // Truncates instead of rounding.
-        if (timeSpan is ScalarValue { Value: TimeSpan ts })
-            return new ScalarValue((decimal)ts.Ticks / TimeSpan.TicksPerMillisecond);
-
-        return null;
-    }
 }

--- a/src/SeqCli/Output/OutputTheme.cs
+++ b/src/SeqCli/Output/OutputTheme.cs
@@ -1,0 +1,66 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.IO;
+using Serilog.Templates.Themes;
+
+namespace SeqCli.Output;
+
+static class OutputTheme
+{
+    static readonly Dictionary<TemplateThemeStyle, string> SeqCliThemeStyles = new()
+    {
+        // Based on `TemplateTheme.Code`
+        [TemplateThemeStyle.Text] = "\u001B[38;5;0253m",
+        [TemplateThemeStyle.SecondaryText] = "\u001B[38;5;0246m",
+        [TemplateThemeStyle.TertiaryText] = "\u001B[38;5;0242m",
+        [TemplateThemeStyle.Invalid] = "\u001B[33;1m",
+        [TemplateThemeStyle.Null] = "\u001B[38;5;0038m",
+        [TemplateThemeStyle.Name] = "\u001B[38;5;0215m",
+        [TemplateThemeStyle.String] = "\u001B[38;5;0217m",
+        [TemplateThemeStyle.Number] = "\u001B[38;5;0200m",
+        [TemplateThemeStyle.Boolean] = "\u001B[38;5;0039m",
+        [TemplateThemeStyle.Scalar] = "\u001B[38;5;0079m",
+        [TemplateThemeStyle.LevelVerbose] = "\u001B[37m",
+        [TemplateThemeStyle.LevelDebug] = "\u001B[37m",
+        [TemplateThemeStyle.LevelInformation] = "\u001B[37;1m",
+        [TemplateThemeStyle.LevelWarning] = "\u001B[38;5;0229m",
+        [TemplateThemeStyle.LevelError] = "\u001B[38;5;0197m\u001B[48;5;0238m",
+        [TemplateThemeStyle.LevelFatal] = "\u001B[38;5;0197m\u001B[48;5;0238m"
+    };
+
+    public static readonly TemplateTheme SeqCli = new(SeqCliThemeStyles);
+    
+    // `CsvWriter` implements its own theming behavior because the required APIs are not public in Serilog.Expressions.
+    // The best way forward for this is likely to be porting theming to Seq.Syntax, and exposing the required APIs there.
+    
+    const string AnsiStyleResetSequence = "\u001B[0m";
+    
+    // The passed-in theme is ignored because SerilogExpressions themes are opaque. All formatting uses the SeqCli theme.
+    // ReSharper disable once UnusedParameter.Global
+    extension(TemplateTheme theme)
+    {
+        public void Set(TextWriter output, TemplateThemeStyle style)
+        {
+            if (SeqCliThemeStyles.TryGetValue(style, out var styleSequence))
+                output.Write(styleSequence);
+        }
+
+        public void Reset(TextWriter output)
+        {
+            output.Write(AnsiStyleResetSequence);
+        }
+    }
+}

--- a/src/SeqCli/Output/TerminalFeatures.cs
+++ b/src/SeqCli/Output/TerminalFeatures.cs
@@ -1,0 +1,52 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace SeqCli.Output;
+
+static class TerminalFeatures
+{
+    const int StandardOutputHandleId = -11;
+    const uint EnableVirtualTerminalProcessingMode = 4;
+    const long InvalidHandleValue = -1;
+
+    public static bool TryEnableAnsiEscapes()
+    {
+        if (Console.IsOutputRedirected || !OperatingSystem.IsWindows())
+            return true;
+
+        var stdout = GetStdHandle(StandardOutputHandleId);
+        if (stdout == InvalidHandleValue)
+            return false;
+
+        if (!GetConsoleMode(stdout, out var mode))
+            return false;
+
+        if ((mode & EnableVirtualTerminalProcessingMode) != 0)
+            return true;
+
+        return SetConsoleMode(stdout, mode | EnableVirtualTerminalProcessingMode);
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern IntPtr GetStdHandle(int handleId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool GetConsoleMode(IntPtr handle, out uint mode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool SetConsoleMode(IntPtr handle, uint mode);
+}

--- a/src/SeqCli/Output/TextFormatters.cs
+++ b/src/SeqCli/Output/TextFormatters.cs
@@ -23,7 +23,7 @@ namespace SeqCli.Output;
 
 // This is the only usage of Serilog.Expressions remaining in seqcli; the upstream Seq.Syntax doesn't yet support
 // tracing properties or theming.
-static class OutputFormatter
+static class TextFormatters
 {
     public static ITextFormatter Json(TemplateTheme? theme) => new ExpressionTemplate(
         $"{{ " +
@@ -39,15 +39,14 @@ static class OutputFormatter
         applyThemeWhenOutputIsRedirected: true
     );
 
-    const string DefaultTextOutputTemplate =
-        "[{@t:o} {@l:u3}] {@m}{#if IsSpan()} ({Milliseconds(Elapsed()):0.###} ms){#end} {@p}\n{@x}";
+    const string DefaultPlainTextOutputTemplate =
+        "[{@t:o} {@l:u3}] {@m}{#if IsSpan()} ({Milliseconds(Elapsed()):0.###} ms){#end}\n{@x}";
 
-    public static ITextFormatter Text(TemplateTheme? theme, string? outputTemplate) => new ExpressionTemplate(
-        outputTemplate ?? DefaultTextOutputTemplate,
+    public static ITextFormatter Plain(TemplateTheme? theme, string? outputTemplate) => new ExpressionTemplate(
+        outputTemplate ?? DefaultPlainTextOutputTemplate,
         theme: theme,
         nameResolver: new StaticMemberNameResolver(typeof(TracingFunctions)),
         // The `OutputFormat` constructor has already decided whether to colorize.
         applyThemeWhenOutputIsRedirected: true
     );
-
 }

--- a/src/SeqCli/Output/TextFormatters.cs
+++ b/src/SeqCli/Output/TextFormatters.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using SeqCli.Ingestion;
 using SeqCli.Mapping;
 using Serilog.Expressions;
@@ -33,14 +34,15 @@ static class TextFormatters
         $"else " +
         // Emit a log or span
         $"{{@t, @mt, @l: coalesce({LevelMapping.SurrogateLevelProperty}, if @l = 'Information' then undefined() else @l), @x, @sp, @tr, @ps: coalesce({TraceConstants.ParentSpanIdProperty}, @ps), @st: coalesce({TraceConstants.SpanStartTimestampProperty}, @st), ..rest()}} " +
-        $"}}\n",
+        $"}}" +
+        Environment.NewLine,
         theme: theme,
         // The `OutputFormat` constructor has already decided whether to colorize.
         applyThemeWhenOutputIsRedirected: true
     );
 
-    const string DefaultPlainTextOutputTemplate =
-        "[{@t:o} {@l:u3}] {@m}{#if IsSpan()} ({Milliseconds(Elapsed()):0.###} ms){#end}\n{@x}";
+    static readonly string DefaultPlainTextOutputTemplate =
+        "[{@t:o} {@l:u3}] {@m}{#if IsSpan()} ({Milliseconds(Elapsed()):0.###} ms){#end}" + Environment.NewLine + "{@x}";
 
     public static ITextFormatter Plain(TemplateTheme? theme, string? outputTemplate) => new ExpressionTemplate(
         outputTemplate ?? DefaultPlainTextOutputTemplate,

--- a/src/SeqCli/Output/TracingFunctions.cs
+++ b/src/SeqCli/Output/TracingFunctions.cs
@@ -1,0 +1,55 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+using SeqCli.Ingestion;
+using Serilog.Events;
+
+namespace SeqCli.Output;
+
+static class TracingFunctions
+{
+    public static LogEventPropertyValue? Elapsed(LogEvent logEvent)
+    {
+        if (logEvent.Properties.TryGetValue(TraceConstants.SpanStartTimestampProperty, out var sst) &&
+            sst is ScalarValue { Value: DateTime spanStart })
+        {
+            return new ScalarValue(logEvent.Timestamp - spanStart);
+        }
+
+        if (logEvent.Properties.TryGetValue("@st", out var st) &&
+            st is ScalarValue { Value: string spanStartIso } &&
+            DateTimeOffset.TryParse(spanStartIso, CultureInfo.InvariantCulture, out var spanStartDto))
+        {
+            return new ScalarValue(logEvent.Timestamp - spanStartDto);
+        }
+
+        return null;
+    }
+
+    public static LogEventPropertyValue? IsSpan(LogEvent logEvent)
+    {
+        return new ScalarValue(Elapsed(logEvent) != null);
+    }
+    
+    public static LogEventPropertyValue? Milliseconds(LogEventPropertyValue? timeSpan)
+    {
+        // Truncates instead of rounding.
+        if (timeSpan is ScalarValue { Value: TimeSpan ts })
+            return new ScalarValue((decimal)ts.Ticks / TimeSpan.TicksPerMillisecond);
+
+        return null;
+    }
+}

--- a/src/SeqCli/Program.cs
+++ b/src/SeqCli/Program.cs
@@ -26,8 +26,6 @@ namespace SeqCli;
 
 class Program
 {
-    public const string WindowsBinaryName = "seqcli.exe";
-    
     static async Task<int> Main(string[] args)
     {
         var levelSwitch = new LoggingLevelSwitch(LogEventLevel.Error);

--- a/test/SeqCli.EndToEnd/ApiKey/ApiKeyCreateTestCase.cs
+++ b/test/SeqCli.EndToEnd/ApiKey/ApiKeyCreateTestCase.cs
@@ -13,11 +13,11 @@ public class ApiKeyCreateTestCase : ICliTestCase
         var exit = runner.Exec("apikey create", "-t Test");
         Assert.Equal(0, exit);
 
-        exit = runner.Exec("apikey list", "-t Test --json --no-color");
+        exit = runner.Exec("apikey list", "-t Test --json");
         Assert.Equal(0, exit);
 
         var output = runner.LastRunProcess!.Output;
-        Assert.Contains("\"AssignedPermissions\": [\"Ingest\"]", output);
+        Assert.Contains("\"AssignedPermissions\":[\"Ingest\"]", output);
 
         return Task.CompletedTask;
     }

--- a/test/SeqCli.EndToEnd/ApiKey/ApiKeyDelegatePermissionsTestCase.cs
+++ b/test/SeqCli.EndToEnd/ApiKey/ApiKeyDelegatePermissionsTestCase.cs
@@ -21,11 +21,11 @@ public class ApiKeyDelegatePermissionsTestCase : ICliTestCase
             "-t Setup --permissions=Setup,Write --connect-username=carol --connect-password=\"test@1234\"");
         Assert.Equal(0, exit);
 
-        exit = runner.Exec("apikey list", "-t Setup --json --no-color");
+        exit = runner.Exec("apikey list", "-t Setup --json");
         Assert.Equal(0, exit);
 
         var output = runner.LastRunProcess.Output;
-        Assert.Contains("\"AssignedPermissions\": [\"Setup\", \"Write\"]", output);
+        Assert.Contains("\"AssignedPermissions\":[\"Setup\",\"Write\"]", output);
 
         return Task.CompletedTask;
     }

--- a/test/SeqCli.Tests/Csv/CsvWriterTests.cs
+++ b/test/SeqCli.Tests/Csv/CsvWriterTests.cs
@@ -2,8 +2,7 @@
 using System.IO;
 using Seq.Api.Model.Data;
 using SeqCli.Csv;
-using SeqCli.Output;
-using Serilog.Sinks.SystemConsole.Themes;
+using Serilog.Templates.Themes;
 using Xunit;
 
 namespace SeqCli.Tests.Csv;
@@ -42,10 +41,10 @@ public class CsvWriterTests
         Assert.Contains("The query could not be executed.", rendered);
     }
 
-    static ConsoleTheme RedirectedTheme(bool forceColor) =>
-        forceColor ? OutputFormat.DefaultAnsiTheme : ConsoleTheme.None;
+    static TemplateTheme? RedirectedTheme(bool forceColor) =>
+        forceColor ? TemplateTheme.Code : null;
 
-    static string Render(ConsoleTheme theme, QueryResultPart? result = null)
+    static string Render(TemplateTheme? theme, QueryResultPart? result = null)
     {
         result ??= new QueryResultPart
         {

--- a/test/SeqCli.Tests/Csv/CsvWriterTests.cs
+++ b/test/SeqCli.Tests/Csv/CsvWriterTests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.IO;
 using Seq.Api.Model.Data;
 using SeqCli.Csv;
@@ -19,7 +20,7 @@ public class CsvWriterTests
         var rendered = Render(RedirectedTheme(forceColor: false));
 
         Assert.DoesNotContain(Escape, rendered);
-        Assert.Equal("\"Events\",\"Application\"\n\"852\",\"Roastery \"\"Web\"\" Frontend\"\n", rendered);
+        Assert.Equal($"\"Events\",\"Application\"{Environment.NewLine}\"852\",\"Roastery \"\"Web\"\" Frontend\"{Environment.NewLine}", rendered);
     }
 
     [Fact]
@@ -52,7 +53,7 @@ public class CsvWriterTests
             Rows = [[852, "Roastery \"Web\" Frontend"]]
         };
 
-        var output = new StringWriter { NewLine = "\n" };
+        var output = new StringWriter();
         CsvWriter.WriteQueryResult(result, v => v?.ToString() ?? "null", theme, output);
         return output.ToString();
     }

--- a/test/SeqCli.Tests/Output/OutputFormatTests.cs
+++ b/test/SeqCli.Tests/Output/OutputFormatTests.cs
@@ -1,7 +1,6 @@
 using System;
 using SeqCli.Config;
 using SeqCli.Output;
-using Serilog.Sinks.SystemConsole.Themes;
 using Xunit;
 
 namespace SeqCli.Tests.Output;
@@ -14,6 +13,7 @@ public class OutputFormatTests
         bool disableColor = false,
         bool noColorSetInEnvironment = false,
         bool outputIsRedirected = true,
+        bool supportsAnsiEscapes = true,
         OutputSyntax syntax = OutputSyntax.Text)
         => new(
             syntax,
@@ -22,27 +22,28 @@ public class OutputFormatTests
             new SeqCliOutputConfig { DisableColor = disableColor },
             outputTemplate: null,
             noColorSetInEnvironment,
-            outputIsRedirected);
+            outputIsRedirected,
+            supportsAnsiEscapes);
 
     [Fact]
     public void RedirectedOutputIsNotThemedByDefault()
     {
         var format = Create(outputIsRedirected: true);
-        Assert.Same(ConsoleTheme.None, format.Theme);
+        Assert.Null(format.TemplateTheme);
     }
 
     [Fact]
     public void RedirectedOutputIsThemedWhenColorIsForced()
     {
         var format = Create(forceColor: true, outputIsRedirected: true);
-        Assert.Same(OutputFormat.DefaultAnsiTheme, format.Theme);
+        Assert.NotNull(format.TemplateTheme);
     }
 
     [Fact]
     public void TerminalOutputIsThemed()
     {
         var format = Create(outputIsRedirected: false);
-        Assert.Same(OutputFormat.DefaultTheme, format.Theme);
+        Assert.NotNull(format.TemplateTheme);
     }
 
     [Theory]
@@ -51,7 +52,7 @@ public class OutputFormatTests
     public void NoColorSuppressesTheThemeRegardlessOfRedirection(bool outputIsRedirected)
     {
         var format = Create(noColor: true, outputIsRedirected: outputIsRedirected);
-        Assert.Same(ConsoleTheme.None, format.Theme);
+        Assert.Null(format.TemplateTheme);
     }
 
     [Fact]
@@ -90,23 +91,31 @@ public class OutputFormatTests
     }
 
     [Theory]
-    // noColorFlag, forceColorFlag, disableColor, noColorSetInEnvironment, expected
-    [InlineData(null, null, false, false, false)] // Color is on by default.
-    [InlineData(null, null, false, true, true)]   // `NO_COLOR` disables color.
-    [InlineData(null, true, false, true, false)]  // `--force-color` is more specific than `NO_COLOR`.
-    [InlineData(true, null, false, false, true)]  // `--no-color` disables color.
-    [InlineData(true, true, false, false, true)]  // `--no-color` beats `--force-color`.
-    [InlineData(null, null, true, false, true)]   // `output.disableColor` disables color.
-    [InlineData(null, true, true, false, true)]   // `--force-color` doesn't override configuration.
+    // noColorFlag, forceColorFlag, disableColor, noColorSetInEnvironment, supportsAnsiEscapes, expected
+    [InlineData(null, null, false, false, true, false)] // Color is on by default.
+    [InlineData(null, null, false, true, true, true)]   // `NO_COLOR` disables color.
+    [InlineData(null, true, false, true, true, false)]  // `--force-color` is more specific than `NO_COLOR`.
+    [InlineData(true, null, false, false, true, true)]  // `--no-color` disables color.
+    [InlineData(true, true, false, false, true, true)]  // `--no-color` beats `--force-color`.
+    [InlineData(null, null, true, false, true, true)]   // `output.disableColor` disables color.
+    [InlineData(null, true, true, false, true, true)]   // `--force-color` doesn't override configuration.
+    [InlineData(null, null, false, false, false, true)] // No ANSI escape support disables color.
+    [InlineData(null, true, false, false, false, true)] // ...and `--force-color` can't override it.
     public void NoColorIsResolvedFromFlagsConfigurationAndEnvironment(
         bool? noColorFlag,
         bool? forceColorFlag,
         bool disableColor,
         bool noColorSetInEnvironment,
+        bool supportsAnsiEscapes,
         bool expected)
     {
-        var format = Create(noColorFlag, forceColorFlag, disableColor, noColorSetInEnvironment);
+        Assert.Equal(expected, OutputFormat.ResolveNoColor(noColorFlag, forceColorFlag, new SeqCliOutputConfig { DisableColor = disableColor }, noColorSetInEnvironment, supportsAnsiEscapes));
+    }
 
-        Assert.Equal(expected, format.NoColor);
+    [Fact]
+    public void TerminalOutputIsNotThemedWithoutAnsiEscapeSupport()
+    {
+        var format = Create(outputIsRedirected: false, supportsAnsiEscapes: false);
+        Assert.Null(format.TemplateTheme);
     }
 }

--- a/test/SeqCli.Tests/Output/OutputFormatTests.cs
+++ b/test/SeqCli.Tests/Output/OutputFormatTests.cs
@@ -69,18 +69,6 @@ public class OutputFormatTests
         Assert.NotNull(format.TemplateTheme);
     }
 
-    // Template themes are ANSI-only, so JSON output is themed on a terminal wherever ANSI is the platform default.
-    [Fact]
-    public void TerminalJsonOutputIsThemedWhereverAnsiIsThePlatformDefault()
-    {
-        var format = Create(syntax: OutputSyntax.Json, outputIsRedirected: false);
-
-        if (OperatingSystem.IsWindows())
-            Assert.Null(format.TemplateTheme);
-        else
-            Assert.NotNull(format.TemplateTheme);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/test/SeqCli.Tests/Output/OutputFormatterTests.cs
+++ b/test/SeqCli.Tests/Output/OutputFormatterTests.cs
@@ -1,7 +1,10 @@
 #nullable enable
+using System;
 using System.IO;
 using SeqCli.Output;
 using SeqCli.Tests.Support;
+using Serilog.Events;
+using Serilog.Parsing;
 using Serilog.Templates.Themes;
 using Xunit;
 
@@ -10,20 +13,107 @@ namespace SeqCli.Tests.Output;
 public class OutputFormatterTests
 {
     const char Escape = '\x1b';
+    static readonly DateTimeOffset FixedTimestamp = new DateTimeOffset(2024, 1, 1, 10, 0, 1, 250, TimeSpan.Zero);
 
     [Fact]
     public void ThemedJsonOutputIsColorizedRegardlessOfRedirection()
     {
-        Assert.Contains(Escape, Render(TemplateTheme.Code));
+        Assert.Contains(Escape, RenderJson(TemplateTheme.Code));
     }
 
     [Fact]
     public void UnthemedJsonOutputIsNotColorized()
     {
-        Assert.DoesNotContain(Escape, Render(theme: null));
+        Assert.DoesNotContain(Escape, RenderJson(theme: null));
     }
 
-    static string Render(TemplateTheme? theme)
+    [Fact]
+    public void LogEventsAreFormattedWithTheDefaultTextTemplate()
+    {
+        var evt = SomeLogEvent(
+            level: LogEventLevel.Warning,
+            properties: new LogEventProperty("Name", new ScalarValue("world")));
+
+        Assert.Equal(
+            "[2024-01-01T10:00:01.2500000+00:00 WRN] Hello, world! {\"Name\":\"world\"}\n",
+            RenderText(evt));
+    }
+
+    [Fact]
+    public void ExceptionsAreIncludedInTextOutput()
+    {
+        var evt = SomeLogEvent(
+            FixedTimestamp,
+            LogEventLevel.Error,
+            new Exception("Boom!"),
+            new LogEventProperty("Name", new ScalarValue("world")));
+
+        Assert.Equal(
+            "[2024-01-01T10:00:01.2500000+00:00 ERR] Hello, world! {\"Name\":\"world\"}\nSystem.Exception: Boom!\n",
+            RenderText(evt));
+    }
+
+    [Fact]
+    public void SpanElapsedTimeIsComputedFromTheStartTimestampProperty()
+    {
+        // Events retrieved from the Seq API carry span start timestamps in ISO-8601 `@st` properties.
+        var evt = SomeLogEvent(FixedTimestamp, properties:
+        [
+            new LogEventProperty("Name", new ScalarValue("world")),
+            new LogEventProperty("@st", new ScalarValue("2024-01-01T10:00:00.0000000Z"))
+        ]);
+
+        Assert.Equal(
+            "[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1250 ms) {\"Name\":\"world\",\"@st\":\"2024-01-01T10:00:00.0000000Z\"}\n",
+            RenderText(evt));
+    }
+
+    [Fact]
+    public void SpanElapsedTimeIsComputedFromTheSurrogateStartTimestampProperty()
+    {
+        // Ingested spans carry a surrogate `SpanStartTimestamp` property with a `DateTime` value.
+        var evt = SomeLogEvent(FixedTimestamp, properties:
+        [
+            new LogEventProperty("Name", new ScalarValue("world")),
+            new LogEventProperty("SpanStartTimestamp", new ScalarValue(
+                FixedTimestamp.UtcDateTime.AddMilliseconds(-1.5)))
+        ]);
+
+        Assert.Equal(
+            "[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1.5 ms) {\"Name\":\"world\",\"SpanStartTimestamp\":\"2024-01-01T10:00:01.2485000Z\"}\n",
+            RenderText(evt));
+    }
+
+    [Fact]
+    public void ACustomOutputTemplateReplacesTheDefault()
+    {
+        var evt = SomeLogEvent(properties: new LogEventProperty("Name", new ScalarValue("world")));
+
+        Assert.Equal("INF Hello, world!\n", RenderText(evt, "{@l:u3} {@m}\n"));
+    }
+
+    static LogEvent SomeLogEvent(
+        DateTimeOffset? timestamp = null,
+        LogEventLevel level = LogEventLevel.Information,
+        Exception? exception = null,
+        params LogEventProperty[] properties)
+    {
+        return new LogEvent(
+            timestamp ?? FixedTimestamp,
+            level,
+            exception,
+            new MessageTemplateParser().Parse("Hello, {Name}!"),
+            properties);
+    }
+
+    static string RenderText(LogEvent evt, string? outputTemplate = null)
+    {
+        var output = new StringWriter();
+        OutputFormatter.Text(theme: null, outputTemplate).Format(evt, output);
+        return output.ToString();
+    }
+
+    static string RenderJson(TemplateTheme? theme)
     {
         var evt = OutputFormat.ToSerilogEvent(Some.MakeEvent(e => e.Properties = []));
 

--- a/test/SeqCli.Tests/Output/TextFormattersTests.cs
+++ b/test/SeqCli.Tests/Output/TextFormattersTests.cs
@@ -13,7 +13,7 @@ namespace SeqCli.Tests.Output;
 public class TextFormattersTests
 {
     const char Escape = '\x1b';
-    static readonly DateTimeOffset FixedTimestamp = new DateTimeOffset(2024, 1, 1, 10, 0, 1, 250, TimeSpan.Zero);
+    static readonly DateTimeOffset FixedTimestamp = new(2024, 1, 1, 10, 0, 1, 250, TimeSpan.Zero);
 
     [Fact]
     public void ThemedJsonOutputIsColorizedRegardlessOfRedirection()
@@ -35,7 +35,7 @@ public class TextFormattersTests
             properties: new LogEventProperty("Name", new ScalarValue("world")));
 
         Assert.Equal(
-            "[2024-01-01T10:00:01.2500000+00:00 WRN] Hello, world! {\"Name\":\"world\"}\n",
+            "[2024-01-01T10:00:01.2500000+00:00 WRN] Hello, world!\n",
             RenderText(evt));
     }
 
@@ -49,7 +49,7 @@ public class TextFormattersTests
             new LogEventProperty("Name", new ScalarValue("world")));
 
         Assert.Equal(
-            "[2024-01-01T10:00:01.2500000+00:00 ERR] Hello, world! {\"Name\":\"world\"}\nSystem.Exception: Boom!\n",
+            "[2024-01-01T10:00:01.2500000+00:00 ERR] Hello, world!\nSystem.Exception: Boom!\n",
             RenderText(evt));
     }
 
@@ -64,7 +64,7 @@ public class TextFormattersTests
         ]);
 
         Assert.Equal(
-            "[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1250 ms) {\"Name\":\"world\",\"@st\":\"2024-01-01T10:00:00.0000000Z\"}\n",
+            "[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1250 ms)\n",
             RenderText(evt));
     }
 
@@ -80,7 +80,7 @@ public class TextFormattersTests
         ]);
 
         Assert.Equal(
-            "[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1.5 ms) {\"Name\":\"world\",\"SpanStartTimestamp\":\"2024-01-01T10:00:01.2485000Z\"}\n",
+            "[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1.5 ms)\n",
             RenderText(evt));
     }
 

--- a/test/SeqCli.Tests/Output/TextFormattersTests.cs
+++ b/test/SeqCli.Tests/Output/TextFormattersTests.cs
@@ -35,7 +35,7 @@ public class TextFormattersTests
             properties: new LogEventProperty("Name", new ScalarValue("world")));
 
         Assert.Equal(
-            "[2024-01-01T10:00:01.2500000+00:00 WRN] Hello, world!\n",
+            $"[2024-01-01T10:00:01.2500000+00:00 WRN] Hello, world!{Environment.NewLine}",
             RenderText(evt));
     }
 
@@ -49,7 +49,7 @@ public class TextFormattersTests
             new LogEventProperty("Name", new ScalarValue("world")));
 
         Assert.Equal(
-            "[2024-01-01T10:00:01.2500000+00:00 ERR] Hello, world!\nSystem.Exception: Boom!\n",
+            $"[2024-01-01T10:00:01.2500000+00:00 ERR] Hello, world!{Environment.NewLine}System.Exception: Boom!{Environment.NewLine}",
             RenderText(evt));
     }
 
@@ -64,7 +64,7 @@ public class TextFormattersTests
         ]);
 
         Assert.Equal(
-            "[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1250 ms)\n",
+            $"[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1250 ms){Environment.NewLine}",
             RenderText(evt));
     }
 
@@ -80,7 +80,7 @@ public class TextFormattersTests
         ]);
 
         Assert.Equal(
-            "[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1.5 ms)\n",
+            $"[2024-01-01T10:00:01.2500000+00:00 INF] Hello, world! (1.5 ms){Environment.NewLine}",
             RenderText(evt));
     }
 
@@ -89,7 +89,7 @@ public class TextFormattersTests
     {
         var evt = SomeLogEvent(properties: new LogEventProperty("Name", new ScalarValue("world")));
 
-        Assert.Equal("INF Hello, world!\n", RenderText(evt, "{@l:u3} {@m}\n"));
+        Assert.Equal($"INF Hello, world!{Environment.NewLine}", RenderText(evt, $"{{@l:u3}} {{@m}}{Environment.NewLine}"));
     }
 
     static LogEvent SomeLogEvent(

--- a/test/SeqCli.Tests/Output/TextFormattersTests.cs
+++ b/test/SeqCli.Tests/Output/TextFormattersTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace SeqCli.Tests.Output;
 
-public class OutputFormatterTests
+public class TextFormattersTests
 {
     const char Escape = '\x1b';
     static readonly DateTimeOffset FixedTimestamp = new DateTimeOffset(2024, 1, 1, 10, 0, 1, 250, TimeSpan.Zero);
@@ -109,7 +109,7 @@ public class OutputFormatterTests
     static string RenderText(LogEvent evt, string? outputTemplate = null)
     {
         var output = new StringWriter();
-        OutputFormatter.Text(theme: null, outputTemplate).Format(evt, output);
+        TextFormatters.Plain(theme: null, outputTemplate).Format(evt, output);
         return output.ToString();
     }
 
@@ -118,7 +118,7 @@ public class OutputFormatterTests
         var evt = OutputFormat.ToSerilogEvent(Some.MakeEvent(e => e.Properties = []));
 
         var output = new StringWriter();
-        OutputFormatter.Json(theme).Format(evt, output);
+        TextFormatters.Json(theme).Format(evt, output);
         return output.ToString();
     }
 }


### PR DESCRIPTION
All themed output now uses Serilog.Expressions theming. Breaking change in the `seqcli print` command's template parameter; the syntax was previously undocumented but used Serilog syntax. It's now Serilog.Expressions syntax.

Also improved output for spans (show elapsed timing) and switched the theme appearance to approximate the one used by Seq's `flaretl` command:

<img width="1064" height="161" alt="image" src="https://github.com/user-attachments/assets/5dd60e0b-e0c7-48fc-baf0-56c8861e2d7a" />

Refactoring and additions largely by hand; some AI assistance for initial versions of PInvoke signatures/calls and some test cases.

~~Needs testing on Windows before it will be ready.~~

Also now includes some additional consistency-related fixes on Windows, and drops trailing property lists from plain-text output (which previously made `seqcli search` effectively unusable for quick log reading).