### PR TITLE
Newline syntax for `seqcli print` templates

### DIFF
--- a/src/SeqCli/Cli/Commands/PrintCommand.cs
+++ b/src/SeqCli/Cli/Commands/PrintCommand.cs
@@ -22,6 +22,7 @@ using Seq.Syntax.Expressions;
 using SeqCli.Cli.Features;
 using SeqCli.Config;
 using SeqCli.Ingestion;
+using SeqCli.Output;
 using SeqCli.Util;
 using Serilog;
 using Serilog.Core;
@@ -50,7 +51,7 @@ class PrintCommand : Command
 
         Options.Add("template=",
             "Specify an output template to control plain text formatting",
-            v => _template = InterpretTemplateEscapeChars(ArgumentString.Normalize(v)));
+            v => _template = ArgumentString.Normalize(v));
 
         _invalidDataHandlingFeature = Enable<InvalidDataHandlingFeature>();
 
@@ -75,7 +76,8 @@ class PrintCommand : Command
             filter = evt => ExpressionResult.IsTrue(compiled(evt));
         }
 
-        var output = _output.GetOutputFormat(config, _template);
+        var template = _template == null ? null : PrintTemplate.InterpretEscapeChars(_template);
+        var output = _output.GetOutputFormat(config, template);
 
         foreach (var input in _fileInputFeature.OpenInputs())
         {
@@ -105,29 +107,5 @@ class PrintCommand : Command
         }
 
         return 0;
-    }
-    
-    static string? InterpretTemplateEscapeChars(string? template)
-    {
-        if (template == null) return null;
-
-        var result = new StringBuilder();
-        for (var i = 0; i < template.Length; ++i)
-        {
-            var ch = template[i];
-            if (ch != '\\' || i == template.Length - 1)
-                result.Append(ch);
-
-            i += 1;
-            var next = template[i];
-            result.Append(next switch
-            {
-                'r' => '\r',
-                'n' => '\n',
-                _ => throw new ArgumentException($"Sequence `\\{next}` is invalid in templates; escape literal `\\` as `\\\\`.")
-            });
-        }
-
-        return result.ToString();
     }
 }

--- a/src/SeqCli/Cli/Commands/PrintCommand.cs
+++ b/src/SeqCli/Cli/Commands/PrintCommand.cs
@@ -14,8 +14,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Seq.Syntax.Expressions;
@@ -25,7 +23,6 @@ using SeqCli.Ingestion;
 using SeqCli.Output;
 using SeqCli.Util;
 using Serilog;
-using Serilog.Core;
 using Serilog.Events;
 
 namespace SeqCli.Cli.Commands;

--- a/src/SeqCli/Cli/Commands/PrintCommand.cs
+++ b/src/SeqCli/Cli/Commands/PrintCommand.cs
@@ -14,6 +14,8 @@
 
 using System;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Seq.Syntax.Expressions;
@@ -22,6 +24,7 @@ using SeqCli.Config;
 using SeqCli.Ingestion;
 using SeqCli.Util;
 using Serilog;
+using Serilog.Core;
 using Serilog.Events;
 
 namespace SeqCli.Cli.Commands;
@@ -47,7 +50,7 @@ class PrintCommand : Command
 
         Options.Add("template=",
             "Specify an output template to control plain text formatting",
-            v => _template = ArgumentString.Normalize(v));
+            v => _template = InterpretTemplateEscapeChars(ArgumentString.Normalize(v)));
 
         _invalidDataHandlingFeature = Enable<InvalidDataHandlingFeature>();
 
@@ -102,5 +105,29 @@ class PrintCommand : Command
         }
 
         return 0;
+    }
+    
+    static string? InterpretTemplateEscapeChars(string? template)
+    {
+        if (template == null) return null;
+
+        var result = new StringBuilder();
+        for (var i = 0; i < template.Length; ++i)
+        {
+            var ch = template[i];
+            if (ch != '\\' || i == template.Length - 1)
+                result.Append(ch);
+
+            i += 1;
+            var next = template[i];
+            result.Append(next switch
+            {
+                'r' => '\r',
+                'n' => '\n',
+                _ => throw new ArgumentException($"Sequence `\\{next}` is invalid in templates; escape literal `\\` as `\\\\`.")
+            });
+        }
+
+        return result.ToString();
     }
 }

--- a/src/SeqCli/Output/PrintTemplate.cs
+++ b/src/SeqCli/Output/PrintTemplate.cs
@@ -1,0 +1,59 @@
+// Copyright © Datalust Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Text;
+
+namespace SeqCli.Output;
+
+static class PrintTemplate
+{
+    /// <summary>
+    /// Windows disallows passing literal newlines in process arguments (and it's inconvenient to figure out
+    /// how to do it with varied shells, anyway). This function provides JSON-like (C#-like) backslash-escaped
+    /// substitutes for newlines and a few other nonprintable characters.
+    /// </summary>
+    public static string InterpretEscapeChars(string template)
+    {
+        var result = new StringBuilder();
+        for (var i = 0; i < template.Length; ++i)
+        {
+            var ch = template[i];
+            if (ch != '\\')
+            {
+                result.Append(ch);
+                continue;
+            }
+
+            if (i == template.Length - 1)
+                throw new ArgumentException(@"Trailing literal `\` is invalid in templates and must be escaped as `\\`.");
+
+            i += 1;
+            var next = template[i];
+            result.Append(next switch
+            {
+                '\\' => '\\',
+                't' => '\t',
+                'r' => '\r',
+                'n' => '\n',
+                'e' => '\e',
+                'b' => '\b',
+                'f' => '\f',
+                _ => throw new ArgumentException($@"Sequence `\{next}` is invalid in templates; escape literal `\` as `\\`.")
+            });
+        }
+
+        return result.ToString();
+    }
+}

--- a/test/SeqCli.Tests/Output/PrintTemplateTests.cs
+++ b/test/SeqCli.Tests/Output/PrintTemplateTests.cs
@@ -1,0 +1,30 @@
+using System;
+using SeqCli.Output;
+using Xunit;
+
+namespace SeqCli.Tests.Output;
+
+public class PrintTemplateTests
+{
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("abc", "abc")]
+    [InlineData(@"{@m}\\{@x}", @"{@m}\{@x}")]
+    [InlineData(@"{@m}\n{@x}", "{@m}\n{@x}")]
+    [InlineData(@"{@m}\r\n{@x}", "{@m}\r\n{@x}")]
+    [InlineData(@"\\\n", "\\\n")]
+    public void PrintTemplatesAreProcessedCorrectly(string template, string expected)
+    {
+        var actual = PrintTemplate.InterpretEscapeChars(template);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(@"\")]
+    [InlineData(@"test\")]
+    [InlineData(@"\q")]
+    public void InvalidTemplatesAreRejected(string template)
+    {
+        Assert.Throws<ArgumentException>(() => PrintTemplate.InterpretEscapeChars(template));
+    }
+}


### PR DESCRIPTION
`seqcli print` accepts a `--template` argument to control formatting. This was previously a Serilog ouput template, where `{NewLine}` is supported. Recently, this switched to the (vastly more capable and actively developed) [Serilog.Expressions](https://github.com/serilog/serilog-expressions) formatting, where newlines are expected to be literally included in templates and no special newline syntax exists.

This poses a problem on Windows, where process args are not permitted to contain newlines (it appears to work fine on Linux, which caught me out :-)).

This PR extends `--template` to allow some simple C#-style escape sequences for newlines:

```
seqcli search -c 5 | seqcli print --template="{@t} {SourceContext}\n{@m}"
```

Requires `\\` escaping of literal backslashes, though these should rarely show up in this context.

Fixes #483 