### PR TITLE
Avoid a blocking `Task.WaitAny()`, which may contribute to intermittent CI test failures when thread count is low

### DIFF
--- a/src/SeqCli/PlainText/Framing/FrameReader.cs
+++ b/src/SeqCli/PlainText/Framing/FrameReader.cs
@@ -57,8 +57,8 @@ class FrameReader
         }
         else if (_unawaitedNextLine != null)
         {
-            var index = Task.WaitAny([_unawaitedNextLine], _trailingLineArrivalDeadline);
-            if (index == -1)
+            var completed = await Task.WhenAny(_unawaitedNextLine, Task.Delay(_trailingLineArrivalDeadline));
+            if (completed != _unawaitedNextLine)
                 return new Frame();
                 
             var line = await _unawaitedNextLine;
@@ -79,9 +79,9 @@ class FrameReader
         Task<string?>? readLine = null;
         while (true)
         {
-            readLine = readLine ?? Task.Run(_source.ReadLineAsync);                
-            var index = Task.WaitAny([readLine], _trailingLineArrivalDeadline);
-            if (index == -1)
+            readLine ??= Task.Run(_source.ReadLineAsync);                
+            var completed = await Task.WhenAny(readLine, Task.Delay(_trailingLineArrivalDeadline));
+            if (completed != readLine)
             {
                 if (hasValue)
                 {


### PR DESCRIPTION
We've been hitting intermittent timeouts in `SeqCli.Tests.PlainText.FrameReaderTests.CollectsTrailingLines`; this is a speculative fix attempt based on digging around with Claude. If no thread pool thread is available to pick up the pending task, .NET will take a little while to spin one up, exceeding the (otherwise reasonable) 100ms deadline imposed by the tests.